### PR TITLE
Init from web container 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
 
 - Copyright 2020 U.S. Federal Government (in countries where recognized) **need contact email for NUWCDIVNPT.mil
 - Copyright 2020 Carl Smigielski, carl.a.smigielski@saic.com
+- Copyright 2020 Christopher Daley, cdaley@rite-solutions.com
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
 
 ## Note for U.S. Federal Employees

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The orchestration starts two containers:
 - Apache 2.4 serving the API and web client UI on TCP port 50443
 - An Oracle 12.2.0.1 database with no network ports exposed
 
-The orchestration bind mounts the `./stigman-init` directory in both containers. The STIG Manager Classic initialization prcess described here expects the Docker container names will be `docker_db_1` and `docker_web_1`, which are the default values when running the orchestration from the `docker` directory. 
+The orchestration bind mounts the `./stigman-init` directory in both containers. The STIG Manager Classic initialization process described here expects the Docker container names will be `docker_db_1` and `docker_web_1`, which are the default values when running the orchestration from the `docker` directory. 
 
 ### 1. Checkout and pull the Oracle Database image from DockerHub
 STIG Manager Classic only supports an Oracle Database backend. The orchestration makes use of the official Oracle Database 12.2.0.1 image available from Docker Hub. Because Oracle Database is not open source, you will need to login to Docker Hub and agree to Oracle's license terms before checking out the image. [Go here and click "Proceed to Checkout" to agree to Oracle's terms.](https://hub.docker.com/_/oracle-database-enterprise-edition)
@@ -91,5 +91,13 @@ We are revising our User Guide to remove sensitive screen shots and features. Pl
 
 ## Troubleshooting
 
-In some Windows environments, Hyper-V may have reserved port 50443. If you have trouble bringing up the Docker orchestration because of a conflict on that port, change the docker-compose.yml file from - "50443:443" to, for example, - "55443:443" and try again.
+In some Windows environments, Hyper-V may have reserved port 50443. If you have a conflict on that port, edit  `docker-compose.yml` and change the line:
+
+ `- "50443:443"`
+ 
+ to an appropriate value for your environment, for example 
+ 
+ `- "55443:443"`
+ 
+ and try again.
 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ Switching between users will help you understand how STIG Manager Classic suppor
 
 ## STIG Manager Classic User Guide
 We are revising our User Guide to remove sensitive screen shots and features. Please visit again very soon for updates.
+
+
+## Troubleshooting
+
+In some Windows environments, Hyper-V may have reserved port 50443. If you have trouble bringing up the Docker orchestration because of a conflict on that port, change the docker-compose.yml file from - "50443:443" to, for example, - "55443:443" and try again.
+

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ To run the orchestration, you must:
 - Have an account on Docker Hub
 - Pull the Oracle Database 12.2.0.1 image using your Docker Hub account
 
-*The initialization process has dependencies requiring you to run the orchestration on a Linux host. We will remove this dependency shortly and will support Docker Desktop for Windows and Mac.*
-
 ## Limitations of the Classic orchestration
 - The Apache server is configured to perform Basic Authentication
 - You cannot reliably logout of Basic Authentication without closing the browser. The logout function in STIG Manager does not work with all browsers when using Basic Authentication. The new API and client use OpenID Connect tokens and the logout feature works as designed.
@@ -28,7 +26,7 @@ The orchestration starts two containers:
 - Apache 2.4 serving the API and web client UI on TCP port 50443
 - An Oracle 12.2.0.1 database with no network ports exposed
 
-The orchestration bind mounts the `./stigman-init` directory in both containers. The STIG Manager Classic initialization script in this directory expects the Docker container names will be `docker_db_1` and `docker_web_1`, which are the default values when running the orchestration from the `docker` directory. 
+The orchestration bind mounts the `./stigman-init` directory in both containers. The STIG Manager Classic initialization prcess described here expects the Docker container names will be `docker_db_1` and `docker_web_1`, which are the default values when running the orchestration from the `docker` directory. 
 
 ### 1. Checkout and pull the Oracle Database image from DockerHub
 STIG Manager Classic only supports an Oracle Database backend. The orchestration makes use of the official Oracle Database 12.2.0.1 image available from Docker Hub. Because Oracle Database is not open source, you will need to login to Docker Hub and agree to Oracle's license terms before checking out the image. [Go here and click "Proceed to Checkout" to agree to Oracle's terms.](https://hub.docker.com/_/oracle-database-enterprise-edition)
@@ -58,12 +56,11 @@ Verify the Oracle container is ready for STIG Manager Classic to initialize, whi
 Once you see this line, you can exit the log output by typing `Ctrl-C`.
 
 ### 5. Initialize STIG Manager Classic with demonstration data
-*The initialization process has dependencies requiring you to run the orchestration on a Linux host. We will remove this dependency shortly.*
 
-You will now run a script that will initialize and populate the STIG Manager Classic database with demonstration data and STIGs. **By default, data is not persisted when the Oracle container is destroyed.** If you wish to persist data, you must edit `docker-compose.yml` to mount a volume to `/ORCL` in the Oracle container.
+You will now run a few commands that will prepare the containers and run a script on the web container to populate the STIG Manager Classic database with demonstration data and STIGs. **By default, data is not persisted when the Oracle container is destroyed.** If you wish to persist data, you must edit `docker-compose.yml` to mount a volume to `/ORCL` in the Oracle container.
 
-    cd stigman-init
-    ./stigman-init.sh
+    docker cp docker_db_1:/u01/app/oracle/product/12.2.0/dbhome_1/rdbms/admin/utl32k.sql stigman-init/db/utl32k.sql  
+    docker exec -it docker_web_1 bash ./stigman-init/stigman-init.sh
 
 The initialization script will ask to perform the following functions:
 - Create the STIG Manager Classic schemas
@@ -72,7 +69,7 @@ The initialization script will ask to perform the following functions:
 - Download the current SCAP content from https://public.cyber.mil/stigs/scap/
 - Import the STIG Compilation Library and SCAP content
 
-If you want to provide your own collection of STIGS, they are available for [individual download](https://public.cyber.mil/stigs/downloads). The Zipped files should be placed in the `docker/stigman-init/stigs` directory before you run the script. Check out the `stigman-init` script for how to run the STIGs import manually in the future. Please note that importing the STIG Compilation Library can take quite a while (~30 mins).
+If you want to provide your own collection of STIGS, they are available for [individual download](https://public.cyber.mil/stigs/downloads). The Zipped files should be placed in the `docker/stigman-init/stigs` directory before you run the script. Check out the `stigman-init` script for how to run the STIGs import manually in the future. Please note that importing the STIG Compilation Library can take quite a while, but will depend on your environment(10~30 mins).
 
 ### 6. Browse to `https://localhost:50443` and login
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     image: store/oracle/database-enterprise:12.2.0.1-slim
     volumes:
       - ./stigman-init:/stigman-init
+      ports:
+        - "1521:1521"      
   web:
     image: stigman-classic:basic
     build:
@@ -19,6 +21,6 @@ services:
       - SM_ORACLE_HOST=db
     init: true
     ports:
-      - "50443:443"
+      - "55443:443"
     depends_on:
       - db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,6 @@ services:
     image: store/oracle/database-enterprise:12.2.0.1-slim
     volumes:
       - ./stigman-init:/stigman-init
-    ports:
-      - "1521:1521"      
   web:
     image: stigman-classic:basic
     build:
@@ -21,6 +19,6 @@ services:
       - SM_ORACLE_HOST=db
     init: true
     ports:
-      - "55443:443"
+      - "50443:443"
     depends_on:
       - db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     image: store/oracle/database-enterprise:12.2.0.1-slim
     volumes:
       - ./stigman-init:/stigman-init
-      ports:
-        - "1521:1521"      
+    ports:
+      - "1521:1521"      
   web:
     image: stigman-classic:basic
     build:

--- a/docker/stigman-init/db/demo-data.sql
+++ b/docker/stigman-init/db/demo-data.sql
@@ -6,8 +6,11 @@ SET ECHO ON
 
 DEFINE sys_pw=Oradoc_db1
 DEFINE container_name=orclpdb1
+DEFINE our_service=@db/orclcdb.localdomain
 
-connect sys/&&sys_pw as sysdba;
+SET DEFINE ON;
+
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 set sqlbl on;

--- a/docker/stigman-init/db/enable_extended_dataTypes.sql
+++ b/docker/stigman-init/db/enable_extended_dataTypes.sql
@@ -1,8 +1,9 @@
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_container_service as sysdba;
+-- connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 shutdown immediate;
 startup upgrade;
 alter system set max_string_size=extended;
-start $ORACLE_HOME/rdbms/admin/utl32k.sql;
+start /stigman-init/db/utl32k.sql;
 shutdown immediate;
 startup;

--- a/docker/stigman-init/db/grant_roles.sql
+++ b/docker/stigman-init/db/grant_roles.sql
@@ -1,5 +1,5 @@
 set define on;
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 grant &&stigs_role to stigman;

--- a/docker/stigman-init/db/iacontrols_create.sql
+++ b/docker/stigman-init/db/iacontrols_create.sql
@@ -5,7 +5,7 @@ CLEAR SCREEN
 set serveroutput on
 
 set define on;
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 -- PROMPT Creating Role &&iacontrols_role ...

--- a/docker/stigman-init/db/inits.sql
+++ b/docker/stigman-init/db/inits.sql
@@ -9,8 +9,10 @@ DEFINE stig_import_jobs_password=stig_import_jobs
 DEFINE stig_import_jobs_role=role_stig_import_jobs
 DEFINE stigs_password=stigs
 DEFINE stigs_role=role_stigs
+DEFINE our_service=@db/orclcdb.localdomain
+DEFINE our_container_service=@db/orclpdb1.localdomain
 
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 @@enable_extended_dataTypes.sql

--- a/docker/stigman-init/db/stig-import-jobs_create.sql
+++ b/docker/stigman-init/db/stig-import-jobs_create.sql
@@ -6,7 +6,7 @@ CLEAR SCREEN
 set serveroutput on
 
 set define on;
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 PROMPT Creating Role &&stig_import_jobs_role ...

--- a/docker/stigman-init/db/stigman-starPack.sql
+++ b/docker/stigman-init/db/stigman-starPack.sql
@@ -3,10 +3,10 @@
 --------------------------------------------------------
 SET ECHO ON
 
-DEFINE sys_pw=Oradoc_db1
-DEFINE container_name=orclpdb1
+-- DEFINE sys_pw=Oradoc_db1
+-- DEFINE container_name=orclpdb1
 
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 -- prompt connecting to stigman

--- a/docker/stigman-init/db/stigman_create.sql
+++ b/docker/stigman-init/db/stigman_create.sql
@@ -6,7 +6,7 @@ CLEAR SCREEN
 set serveroutput on
 
 set define on;
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 -- PROMPT Creating Role &&stigman_role ...

--- a/docker/stigman-init/db/stigs_create.sql
+++ b/docker/stigman-init/db/stigs_create.sql
@@ -7,7 +7,7 @@ set serveroutput on
 
 
 set define on;
-connect sys/&&sys_pw as sysdba;
+connect sys/&&sys_pw&&our_service as sysdba;
 alter session set container=&&container_name;
 
 -- PROMPT Creating Role &&stigs_role ...

--- a/docker/stigman-init/stigman-init.sh
+++ b/docker/stigman-init/stigman-init.sh
@@ -63,7 +63,7 @@ if ask "Download the current SCAP Benchmarks to ./stigs?" Y; then
     echo -e "\nFinished attempt to download current SCAP content.\n"
 fi
 
-if ask "Import the contents of ./stigs [might take several minutes]?" Y; then
+if ask "Import the contents of ./stigman-init/stigs [might take several minutes]?" Y; then
     ./stigman-init/stigs/importStigs.pl --scap /stigman-init/stigs
     echo -e "\nFinished attempt to import STIGs.\n"
 fi

--- a/docker/stigman-init/stigman-init.sh
+++ b/docker/stigman-init/stigman-init.sh
@@ -37,7 +37,6 @@ ask() {
 }
 
 if ask "Create STIG Manager schemas?" Y; then
-    #sqlplus sys/Oradoc_db1@$SM_ORACLE_HOST/orclcdb.localdomain as sysdba  @/stigman-init/db/inits.sql
     sqlplus sys/Oradoc_db1@db/orclcdb.localdomain as sysdba @/stigman-init/db/inits.sql
     echo -e "\nFinsihed attempt to create schemas.\n"
 fi

--- a/docker/stigman-init/stigman-init.sh
+++ b/docker/stigman-init/stigman-init.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 
 ask() {
     # https://djm.me/ask
@@ -38,12 +37,13 @@ ask() {
 }
 
 if ask "Create STIG Manager schemas?" Y; then
-    docker exec -it docker_db_1 bash -l -c "sqlplus sys/Oradoc_db1 as sysdba @/stigman-init/db/inits.sql; exit"
+    #sqlplus sys/Oradoc_db1@$SM_ORACLE_HOST/orclcdb.localdomain as sysdba  @/stigman-init/db/inits.sql
+    sqlplus sys/Oradoc_db1@db/orclcdb.localdomain as sysdba @/stigman-init/db/inits.sql
     echo -e "\nFinsihed attempt to create schemas.\n"
 fi
 
 if ask "Import demonstration data?" Y; then
-    docker exec -it docker_db_1 bash -l -c "sqlplus sys/Oradoc_db1 as sysdba @/stigman-init/db/demo-data.sql; exit"
+    sqlplus sys/Oradoc_db1@db/orclcdb.localdomain as sysdba @/stigman-init/db/demo-data.sql
     echo -e "\nFinished attempt to import demonstration data.\n"
 fi
 
@@ -51,7 +51,7 @@ if ask "Download the current STIG Library Compilation [~215MB] to ./stigs?" Y; t
     echo "Retreiving list of Compilation files from public.cyber.mil..."
     files=$(curl -s "https://public.cyber.mil/stigs/compilations/" | \
     sed -n 's/.*<a href=\"\(https:\/\/dl.dod.cyber.mil\/wp-content\/uploads\/stigs\/zip\/.*\)\" target=.*$/\1/p')
-    while IFS= read -r line ; do wget -nc -P ./stigs $line; done <<< "$files"
+    while IFS= read -r line ; do wget -nc -P /stigman-init/stigs $line; done <<< "$files"
     echo -e "\nFinished attempt to download STIG Library Compilation.\n"
 fi
 
@@ -59,12 +59,12 @@ if ask "Download the current SCAP Benchmarks to ./stigs?" Y; then
     echo "Retreiving list of SCAP files from public.cyber.mil..."
     files=$(curl -s "https://public.cyber.mil/stigs/scap/" | \
     sed -n 's/.*<a href=\"\(https:\/\/dl.dod.cyber.mil\/wp-content\/uploads\/stigs\/zip\/.*\)\" target=.*$/\1/p')
-    while IFS= read -r line ; do wget -nc -P ./stigs $line; done <<< "$files"
+    while IFS= read -r line ; do wget -nc -P /stigman-init/stigs $line; done <<< "$files"
     echo -e "\nFinished attempt to download current SCAP content.\n"
 fi
 
 if ask "Import the contents of ./stigs [might take several minutes]?" Y; then
-    docker exec -it docker_web_1 bash -l -c "./stigman-init/stigs/importStigs.pl --scap /stigman-init/stigs; exit;"
+    ./stigman-init/stigs/importStigs.pl --scap /stigman-init/stigs
     echo -e "\nFinished attempt to import STIGs.\n"
 fi
 


### PR DESCRIPTION
Added changes to script and README to address issue #1 
Init script is now run from the web container using a docker exec command. 
Changed instructions in README, and added a Troubleshooting section about a problem I encountered where Hyper-V had grabbed the port specified in the docker-compose file.