### PR TITLE
ovalCount based on ruleId instead of benchmarkId

### DIFF
--- a/api/source/service/mysql/migrations/0006.js
+++ b/api/source/service/mysql/migrations/0006.js
@@ -1,0 +1,29 @@
+const Importer = require('./lib/mysql-import.js')
+const config = require('../../../utils/config')
+const path = require('path')
+const fs = require('fs')
+
+module.exports = {
+    up: async (pool) => {
+        let migrationName = path.basename(__filename, '.js')
+        console.log(`[DB] Running migration ${migrationName} UP`)
+        const importer = new Importer(pool)
+        let dir = path.join(__dirname, 'sql', migrationName, 'up')
+        let files = await fs.promises.readdir(dir)
+        for (file of files) {
+            console.log(`[DB] Running MySQL script ${file}...`)
+            await importer.import(path.join(dir, file))
+        }
+    },
+    down: async(pool)=> {
+        let migrationName = path.basename(__filename, '.js')
+        console.log(`[DB] Running migration ${migrationName} DOWN`)
+        const importer = new Importer(pool)
+        let dir = path.join(__dirname, 'sql', migrationName, 'down')
+        let files = await fs.promises.readdir(dir)
+        for (file of files) {
+            console.log(`[DB] Running MySQL script ${file}...`)
+            await importer.import(path.join(dir, file))
+        }
+    }
+}

--- a/api/source/service/mysql/migrations/sql/0006/up/10-v-current-rev.sql
+++ b/api/source/service/mysql/migrations/sql/0006/up/10-v-current-rev.sql
@@ -1,0 +1,90 @@
+ALTER VIEW `v_current_rev` AS
+select 
+	`rr`.`revId` AS `revId`,
+	`rr`.`benchmarkId` AS `benchmarkId`,
+	`rr`.`version` AS `version`,
+	`rr`.`release` AS `release`,
+	`rr`.`benchmarkDate` AS `benchmarkDate`,
+	`rr`.`benchmarkDateSql` AS `benchmarkDateSql`,
+	`rr`.`status` AS `status`,
+	`rr`.`statusDate` AS `statusDate`,
+	`rr`.`description` AS `description`,
+	`rr`.`active` AS `active`,
+	`rr`.`groupCount` AS `groupCount`,
+	`rr`.`ruleCount` AS `ruleCount`,
+	`rr`.`checkCount` AS `checkCount`,
+	`rr`.`fixCount` AS `fixCount`,
+	`rr`.`ovalCount` AS `ovalCount`
+ from (
+ select 
+	 `r`.`revId` AS `revId`,
+	 `r`.`benchmarkId` AS `benchmarkId`,
+	 `r`.`version` AS `version`,
+	 `r`.`release` AS `release`,
+	 `r`.`benchmarkDate` AS `benchmarkDate`,
+	 `r`.`benchmarkDateSql` AS `benchmarkDateSql`,
+	 `r`.`status` AS `status`,
+	 `r`.`statusDate` AS `statusDate`,
+	 `r`.`description` AS `description`,
+	 `r`.`active` AS `active`,
+	 `r`.`groupCount` AS `groupCount`,
+	 `r`.`ruleCount` AS `ruleCount`,
+	 `r`.`checkCount` AS `checkCount`,
+	 `r`.`fixCount` AS `fixCount`,
+	 (select count(distinct `ro`.`ruleId`) from `rule_oval_map` `ro` where `ro`.`ruleId` IN (
+     SELECT `rgr`.`ruleId` from `rev_group_map` `rg` inner join `rev_group_rule_map` `rgr` on `rg`.`rgId` = `rgr`.`rgId` WHERE `rg`.`revId` = `r`.`revId`)) AS `ovalCount`,
+	row_number() OVER (
+		PARTITION BY `r`.`benchmarkId` 
+        ORDER BY 
+			FIELD(status, 'draft', 'accepted') desc,
+			(`r`.`version` + 0) desc,
+			(`r`.`release` + 0) desc )  AS `rn` 
+    from 
+		`revision` `r`) `rr` where (`rr`.`rn` = 1);
+
+DELETE from current_rev;
+INSERT INTO current_rev (
+      revId,
+      benchmarkId,
+      `version`, 
+      `release`, 
+      benchmarkDate,
+      benchmarkDateSql,
+      status,
+      statusDate,
+      description,
+      active,
+      groupCount,
+      ruleCount,
+      checkCount,
+      fixCount,
+      ovalCount)
+      SELECT 
+        revId,
+        benchmarkId,
+        `version`,
+        `release`,
+        benchmarkDate,
+        benchmarkDateSql,
+        status,
+        statusDate,
+        description,
+        active,
+        groupCount,
+        ruleCount,
+        checkCount,
+        fixCount,
+        ovalCount
+      FROM
+        v_current_rev;
+DELETE FROM current_group_rule;
+INSERT INTO current_group_rule (groupId, ruleId, benchmarkId)
+      SELECT rg.groupId,
+        rgr.ruleId,
+        cr.benchmarkId
+      from
+        current_rev cr
+        left join rev_group_map rg on rg.revId=cr.revId
+        left join rev_group_rule_map rgr on rgr.rgId=rg.rgId
+      order by
+        rg.groupId,rgr.ruleId,cr.benchmarkId;

--- a/api/source/service/mysql/utils.js
+++ b/api/source/service/mysql/utils.js
@@ -263,7 +263,6 @@ module.exports.scrubReviewsByUser = async function(reviews, elevate, userObject)
 }
 module.exports.updateStatsAssetStig = async function(connection, options) {
   try {
-    console.log(`Connection ${connection.connection.connectionId} STATS ENTER`)
     if (!connection) { throw ('Connection required')}
     // Handle optional predicates, 
     let predicates = []

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -2948,13 +2948,17 @@ components:
       properties:
         benchmarkId:
           type: string
+        title:
+          type: string
+        status:
+          type: string
         lastRevisionStr:
           type: string
         lastRevisionDate:
           type: string
-        title:
-          type: string
         ruleCount:
+          type: integer
+        autoCount:
           type: integer
     StigAsset:
       type: object

--- a/clients/extjs/js/stigAdmin.js
+++ b/clients/extjs/js/stigAdmin.js
@@ -8,18 +8,30 @@ function addStigAdmin() {
 	var stigFields = Ext.data.Record.create([
 		{	name:'benchmarkId',
 			type: 'string'
-		},{
+		},
+		{
 			name: 'title',
 			type: 'string'
-		},{
+		},
+		{
+			name: 'status',
+			type: 'string'
+		},
+		{
 			name: 'lastRevisionStr',
 			type: 'string'
-		},{
+		},
+		{
 			name: 'lastRevisionDate',
 			type: 'date',
 			dateFormat: 'Y-m-d'
-		},{
+		},
+		{
 			name: 'ruleCount',
+			type: 'integer'
+		},
+		{
+			name: 'autoCount',
 			type: 'integer'
 		}
 	]);
@@ -69,6 +81,12 @@ function addStigAdmin() {
 				dataIndex: 'title',
 				sortable: true
 			},{ 	
+				header: "Status",
+				width: 150,
+                align: "center",
+				dataIndex: 'status',
+				sortable: true
+			},{ 	
 				header: "Current revision",
 				width: 150,
                 align: "center",
@@ -83,11 +101,18 @@ function addStigAdmin() {
 				format: 'Y-m-d',
 				sortable: true
 			},{ 	
-				header: "Rule count",
+				header: "Rules",
 				width: 150,
                 align: "center",
 				dataIndex: 'ruleCount',
 				sortable: true
+			},{ 	
+				header: "SCAP Rules",
+				width: 150,
+                align: "center",
+				dataIndex: 'autoCount',
+				sortable: true,
+				renderer: (v) => v ? v : '--'
 			}
 		],
 		autoExpandColumn: 'stigGrid-title-column',


### PR DESCRIPTION
DISA releases SCAP content (a.k.a. "Benchmarks") where the benchmarkIds do not necessarily correspond to a manual STIG. The calculation of ovalCount did not account for this and has been revised.