### PR TITLE
fix: collection review filter (#64)

### DIFF
--- a/clients/extjs/js/collectionReview.js
+++ b/clients/extjs/js/collectionReview.js
@@ -367,7 +367,7 @@ async function addCollectionReview ( leaf, selectedRule, selectedAsset ) {
 			filterState: 'All',
 			title: 'Checklist',
 			split:true,
-			titleColumnDataIndex: 'groupTitle', // STIG Manager defined property
+			titleColumnDataIndex: 'ruleTitle', // STIG Manager defined property
 			//collapsible: true,
 			store: groupStore,
 			stripeRows:true,


### PR DESCRIPTION
Set initial value for `groupGrid.titleColumnDataIndex` to 'ruleTitle'
