### PR TITLE
Remove typeCast handling for JSON (#62)

### DIFF
--- a/api/source/service/mysql/utils.js
+++ b/api/source/service/mysql/utils.js
@@ -27,9 +27,6 @@ function getPoolConfig() {
     user: config.database.username,
     database: config.database.schema,
     typeCast: function (field, next) {
-      if (field.type == 'JSON') {
-        return (JSON.parse(field.string())); 
-      }
       if ((field.type === "BIT") && (field.length === 1)) {
         let bytes = field.buffer() || [0];
         return( bytes[ 0 ] === 1 );


### PR DESCRIPTION
Our mysql2 `options.typeCast` method didn't explicitly specify utf-8 encoding for JSON.parse(). But mysql2's built-in JSON typecaster already handles this properly, so our method is redundant and, rather than fix it, I have removed it.. 