### PR TITLE
Support older MySQL syntax and check minimum version

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1202,6 +1202,13 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "crypt": {
@@ -2639,6 +2646,11 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -3572,6 +3584,11 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },
@@ -3627,6 +3644,13 @@
         "semver": "^5.6.0",
         "slash": "^2.0.0",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "path": {
@@ -4004,9 +4028,27 @@
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -4014,6 +4056,13 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
         "semver": "^5.0.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "send": {
@@ -4762,6 +4811,11 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
     },

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -33,6 +33,7 @@
     "oracledb": "^4.2.0",
     "patch-package": "^6.2.2",
     "request": "^2.88.2",
+    "semver": "^7.3.4",
     "swagger-ui-express": "4.1.3",
     "umzug": "^2.3.0",
     "xlsx-template": "^1.3.0"

--- a/api/source/service/mysql/utils.js
+++ b/api/source/service/mysql/utils.js
@@ -343,21 +343,21 @@ module.exports.updateStatsAssetStig = async function(connection, { collectionId,
       highCount,
       mediumCount,
       lowCount)
-    VALUES ? AS stats
+    VALUES ? 
       on duplicate key update
-        minTs = stats.minTs,
-        maxTs = stats.maxTs,
-        savedManual = stats.savedManual,
-        savedAuto = stats.savedAuto,
-        submittedManual = stats.submittedManual,
-        submittedAuto = stats.submittedAuto,
-        rejectedManual = stats.rejectedManual,
-        rejectedAuto = stats.rejectedAuto,
-        acceptedManual = stats.acceptedManual,
-        acceptedAuto = stats.acceptedAuto,
-        highCount = stats.highCount,
-        mediumCount = stats.mediumCount,
-        lowCount = stats.lowCount
+        minTs = VALUES(minTs),
+        maxTs = VALUES(maxTs),
+        savedManual = VALUES(savedManual),
+        savedAuto = VALUES(savedAuto),
+        submittedManual = VALUES(submittedManual),
+        submittedAuto = VALUES(submittedAuto),
+        rejectedManual = VALUES(rejectedManual),
+        rejectedAuto = VALUES(rejectedAuto),
+        acceptedManual = VALUES(acceptedManual),
+        acceptedAuto = VALUES(acceptedAuto),
+        highCount = VALUES(highCount),
+        mediumCount = VALUES(mediumCount),
+        lowCount = VALUES(lowCount)
     `
     let results;
     [results] = await connection.query(sqlSelect, binds)

--- a/api/source/service/mysql/utils.js
+++ b/api/source/service/mysql/utils.js
@@ -4,14 +4,16 @@ const retry = require('async-retry')
 const Umzug = require('umzug')
 const path = require('path')
 const fs = require("fs")
+const semverLt = require('semver/functions/lt')
 
+const minMySqlVersion = '8.0.14'
 let _this = this
 
 module.exports.version = '0.6'
 module.exports.testConnection = async function () {
   try {
-    let [result] = await _this.pool.query('SHOW DATABASES')
-    return JSON.stringify(result, null, 2)
+    let [result] = await _this.pool.query('SELECT VERSION() as version')
+    return result[0].version
   }
   catch (err) {
     // console.log(err.message)
@@ -83,7 +85,7 @@ module.exports.initializeDatabase = async function () {
 
     // Preflight the pool every 5 seconds
     console.log('[DB] Attempting preflight connection.')
-    let result = await retry(_this.testConnection, {
+    const detectedMySqlVersion = await retry(_this.testConnection, {
       retries: 24,
       factor: 1,
       minTimeout: 5 * 1000,
@@ -93,6 +95,14 @@ module.exports.initializeDatabase = async function () {
       }
     })
     console.log('[DB] Preflight connection succeeded.')
+    if ( semverLt(detectedMySqlVersion, minMySqlVersion) ) {
+      console.log(`[DB] MySQL release ${detectedMySqlVersion} is too old. Update to release ${minMySqlVersion} or later.`)
+      console.log("Terminating")
+      process.exit(1)
+    } else {
+      console.log(`[DB] MySQL release ${detectedMySqlVersion} is supported.`)
+    }
+
 
     // console.log(result)
 


### PR DESCRIPTION
Some pilot deployments are stuck using MySQL 8.0.15. Rewrote one query to avoid using syntax introduced in 8.0.19. This query will need work again once the VALUES() function is removed by the MySQL team.