### PR TITLE
fix: inline row editors

### DIFF
--- a/clients/extjs/css/stigman.css
+++ b/clients/extjs/css/stigman.css
@@ -197,7 +197,7 @@ body {
     border-radius: 3px;
 }
 .ext-el-mask {
-    background-color: #333333;
+    background-color: #666;
 }
 .sm-round-panel .x-window-header {
 	color: #111;

--- a/clients/extjs/js/RowEditor.js
+++ b/clients/extjs/js/RowEditor.js
@@ -160,6 +160,7 @@ Ext.ux.grid.RowEditor = Ext.extend(Ext.Panel, {
             rowIndex = this.grid.getStore().indexOf(rowIndex);
         }
         if(this.fireEvent('beforeedit', this, rowIndex) !== false){
+            this.grid.getEl().mask()
             this.editing = true;
             var g = this.grid, view = g.getView(),
                 row = view.getRow(rowIndex),
@@ -200,6 +201,7 @@ Ext.ux.grid.RowEditor = Ext.extend(Ext.Panel, {
 
     stopEditing : function(saveChanges){
         this.editing = false;
+        this.grid.getEl().unmask()
         if(!this.isVisible()){
             return;
         }

--- a/clients/extjs/js/overrides.js
+++ b/clients/extjs/js/overrides.js
@@ -1,3 +1,11 @@
+// Lower default z-index value from 11000 to 8000
+// Source: carl.a.smigielski@saic.com
+Ext.override(Ext.Layer, {
+    getZIndex: function(){
+        return this.zindex || parseInt((this.getShim() || this).getStyle('z-index'), 10) || 8000;
+    }
+});
+
 // Prevent changing readOnly checkboxes
 // Source: https://forum.sencha.com/forum/showthread.php?90531-Readonly-Checkbox-Override
 Ext.override(Ext.form.Checkbox, {


### PR DESCRIPTION
- z-index default set to 8000
- mask parent grid when editor is active
- lighten mask color to 666