### PR TITLE
bug: Fire event to trigger panel refresh after import finishes

### DIFF
--- a/clients/extjs/js/SM/ReviewsImport.js
+++ b/clients/extjs/js/SM/ReviewsImport.js
@@ -1388,6 +1388,8 @@ async function showImportResultFiles(collectionId, el) {
                     updateProgress(processedCount / entries.length, assetObj.name)
                 }
                 updateProgress(0, 'Finished')
+                SM.Dispatcher.fireEvent('stigassetschanged')
+
 
             }
             catch (e) {


### PR DESCRIPTION
Addresses issue #214 
Fired event 'stigassetschanged' after bulk import finishes to trigger assets and stigs panels to reload.