### PR TITLE
bug: Changed asset name, ip, and mac length to 255 in db and spec, added nullable property to collection description

### DIFF
--- a/api/source/service/mysql/migrations/0008.js
+++ b/api/source/service/mysql/migrations/0008.js
@@ -1,0 +1,56 @@
+const path = require('path')
+
+const upMigration = [
+  'ALTER TABLE asset MODIFY COLUMN name VARCHAR(255) NOT NULL',
+  'ALTER TABLE asset MODIFY COLUMN ip VARCHAR(255) NULL DEFAULT NULL',
+  'ALTER TABLE asset MODIFY COLUMN mac VARCHAR(255) NULL DEFAULT NULL'
+]
+
+const downMigration = [
+  'ALTER TABLE asset MODIFY COLUMN name VARCHAR(45) NOT NULL',
+  'ALTER TABLE asset MODIFY COLUMN ip VARCHAR(45) NULL DEFAULT NULL',
+  'ALTER TABLE asset MODIFY COLUMN mac VARCHAR(17) NULL DEFAULT NULL'
+]
+
+module.exports = {
+  up: async (pool) => {
+    let connection
+    try {
+      let migrationName = path.basename(__filename, '.js')
+      console.log(`[DB] Running migration ${migrationName} UP`)
+      connection = await pool.getConnection()
+      for (const statement of upMigration) {
+        console.log(`[DB] Execute: ${statement}`)
+        connection.query(statement)
+      }
+    }
+    catch (e) {
+      console.log(`[DB] Migration failed: ${e.message}`)
+      throw (e)
+    }
+    finally {
+      await connection.release()
+    }
+  },
+  down: async (pool) => {
+    let connection
+    try {
+      let migrationName = path.basename(__filename, '.js')
+      console.log(`[DB] Running migration ${migrationName} DOWN`)
+      connection = await pool.getConnection()
+      for (const statement of downMigration) {
+        console.log(`[DB] Execute: ${statement}`)
+        connection.query(statement)
+      }
+      await connection.release()
+    }
+    catch (e) {
+      console.log(`[DB] Migration failed: ${e.message}`)
+      throw (e)
+    }
+    finally {
+      await connection.release()
+    }
+  }
+}
+

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -2074,20 +2074,25 @@ components:
         name:
           type: string
           nullable: false
+          maxLength: 255
         fqdn:
           type: string
           nullable: true
+          maxLength: 255
         collection:
           $ref: '#/components/schemas/CollectionBasic'
         description:
           type: string
           nullable: true
+          maxLength: 255
         ip:
           type: string
           nullable: true
+          maxLength: 255
         mac:
           type: string
           nullable: true
+          maxLength: 255
         noncomputing:
           type: boolean
         metadata:
@@ -2113,21 +2118,26 @@ components:
         name:
           type: string
           nullable: false
+          maxLength: 255
         fqdn:
           type: string
           nullable: true
+          maxLength: 255
         collectionId:
           description: The collectionId mapped to this Asset
           type: string
         description:
           type: string
           nullable: true
+          maxLength: 255
         ip:
           type: string
           nullable: true
+          maxLength: 255
         mac:
           type: string
           nullable: true
+          maxLength: 255
         noncomputing:
           type: boolean
         metadata:
@@ -2176,21 +2186,26 @@ components:
         name:
           type: string
           nullable: false
+          maxLength: 255
         fqdn:
           type: string
           nullable: true
+          maxLength: 255
         collectionId:
           description: The collectionId mapped to this Asset
           type: string
         description:
           type: string
           nullable: true
+          maxLength: 255
         ip:
           type: string
           nullable: true
+          maxLength: 255
         mac:
           type: string
           nullable: true
+          maxLength: 255
         noncomputing:
           type: boolean
         metadata:
@@ -2494,6 +2509,7 @@ components:
           type: string
         description:
           type: string
+          nullable: true
         workflow:
           $ref: '#/components/schemas/CollectionWorkflow'
         metadata:
@@ -2522,6 +2538,7 @@ components:
           type: string
         description:
           type: string
+          nullable: true
         workflow:
           $ref: '#/components/schemas/CollectionWorkflow'
         metadata:
@@ -2653,6 +2670,7 @@ components:
           type: string
         description:
           type: string
+          nullable: true
         workflow:
           $ref: '#/components/schemas/CollectionWorkflow'
         metadata:

--- a/clients/extjs/js/SM/CollectionAsset.js
+++ b/clients/extjs/js/SM/CollectionAsset.js
@@ -716,7 +716,6 @@ SM.AssetProperties = Ext.extend(Ext.form.FormPanel, {
                                             anchor: '100%',
                                             emptyText: 'Enter IP',
                                             allowBlank: true,
-                                            vtype: 'IPAddress',
                                             name: 'ip'
                                         }
                                     ]


### PR DESCRIPTION
Changed asset name, ip, and mac varchar length to 255 in DB, added corresponding maxlength properties to API Spec. 
Removed ip validation from UI for modifying Assets, as this would prevent saving with multiple ips. 
Added nullable: true to collection description properties in api spec.

fixes #239 
fixes #246 
fixes #46 