### PR TITLE
feat: Ext.LoadMask looks for store.smMaskDelay

### DIFF
--- a/clients/extjs/js/SM/CollectionAsset.js
+++ b/clients/extjs/js/SM/CollectionAsset.js
@@ -82,6 +82,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
         })
         let assetStore = new Ext.data.JsonStore({
             grid: this,
+            smMaskDelay: 250,
             proxy: this.proxy,
             baseParams: {
                 collectionId: this.collectionId,
@@ -293,7 +294,10 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                         tooltip: 'Reload this grid',
                         width: 20,
                         handler: function(btn){
+                            const savedSmMaskDelay = btn.grid.store.smMaskDelay
+                            btn.grid.store.smMaskDelay = 0
                             btn.grid.store.reload();
+                            btn.grid.store.smMaskDelay = savedSmMaskDelay
                         }
                     },{
                         xtype: 'tbseparator'

--- a/clients/extjs/js/SM/CollectionStig.js
+++ b/clients/extjs/js/SM/CollectionStig.js
@@ -57,6 +57,7 @@ SM.CollectionStigsGrid = Ext.extend(Ext.grid.GridPanel, {
         })
         let stigStore = new Ext.data.JsonStore({
             grid: this,
+            smMaskDelay: 250,
             proxy: this.proxy,
             root: '',
             fields: fieldsConstructor,
@@ -243,7 +244,10 @@ SM.CollectionStigsGrid = Ext.extend(Ext.grid.GridPanel, {
                         tooltip: 'Reload this grid',
                         width: 20,
                         handler: function(btn){
+                            const savedSmMaskDelay = btn.grid.store.smMaskDelay
+                            btn.grid.store.smMaskDelay = 0
                             btn.grid.store.reload();
+                            btn.grid.store.smMaskDelay = savedSmMaskDelay
                         }
                     },{
                         xtype: 'tbseparator'

--- a/clients/extjs/js/overrides.js
+++ b/clients/extjs/js/overrides.js
@@ -1,3 +1,20 @@
+Ext.LoadMask.prototype.onBeforeLoad = function() {
+    if(!this.disabled){
+        if (!this.store.smMaskDelay) {
+            this.smTask = new Ext.util.DelayedTask(function () {
+                this.el.mask(this.msg, this.msgCls)
+            }, this)
+            this.smTask.delay(this.store.smMaskDelay)
+        }
+    }
+}
+Ext.LoadMask.prototype.onLoad = function() {
+    if (this.smTask) {
+        this.smTask.cancel()
+    }
+    this.el.unmask(this.removeMask);
+}
+
 // patch DragDropMgr to prevent a "hung" drop with cursor stuck
 // Source: carl.a.smigielski@saic.com
 Ext.dd.DragDropMgr.getZIndex = function(element) {


### PR DESCRIPTION
Allow stores to be configured with smMaskDelay that suppresses showing a load mask until the configured number of milliseconds has elapsed.