### PR TITLE
fix: Removed STIG filename filters 

### DIFF
--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -8,7 +8,7 @@ const STIG = require(`../service/${config.database.type}/STIGService`)
 module.exports.importManualBenchmark = async function importManualBenchmark (req, res, next) {
   try {
     let extension = req.file.originalname.substring(req.file.originalname.lastIndexOf(".")+1)
-    if (extension != 'xml') {
+    if (extension.toLowerCase() != 'xml') {
       throw (writer.respondWithCode ( 400, {message: `File extension .${extension} not supported`} ))
     }
     let xmlData = req.file.buffer
@@ -23,7 +23,7 @@ module.exports.importManualBenchmark = async function importManualBenchmark (req
     writer.writeJson(res, response)
   }
   catch(err) {
-    writer.writeJson(res, err)
+    writer.writeJson(res, {message: err.message})
   }
 }
 

--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -12,7 +12,13 @@ module.exports.importManualBenchmark = async function importManualBenchmark (req
       throw (writer.respondWithCode ( 400, {message: `File extension .${extension} not supported`} ))
     }
     let xmlData = req.file.buffer
-    let benchmark = parsers.benchmarkFromXccdf(xmlData)
+    let benchmark
+    try {
+      benchmark = await parsers.benchmarkFromXccdf(xmlData)
+    }
+    catch(err){
+      throw (writer.respondWithCode( 400, {message: err.message} ))
+    }
     let response
     if (benchmark.scap) {
       response = await STIG.insertScapBenchmark(benchmark, xmlData)
@@ -23,7 +29,7 @@ module.exports.importManualBenchmark = async function importManualBenchmark (req
     writer.writeJson(res, response)
   }
   catch(err) {
-    writer.writeJson(res, {message: err.message})
+    writer.writeJson(res, err)
   }
 }
 

--- a/api/source/utils/fetchStigs.js
+++ b/api/source/utils/fetchStigs.js
@@ -12,7 +12,7 @@ const scapURL = 'https://public.cyber.mil/stigs/scap/'
 const stigMatchString = '<a href="(https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/.*)" target=.*'
 const scapMatchString = '<a href="(https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/.*enchmark.zip)" target=.*'
 
-// let localCompilationFile = '/STIGs/U_SRG-STIG_Library_2021_01v2.zip'
+// let localCompilationFile = 'E:/STIGs/U_SRG-STIG_Library_2021_01v2.zip'
 
 
 exports.fetchCompilation = async function fetchCompilation() {
@@ -72,7 +72,7 @@ exports.fetchScap = async function fetchScap() {
 //     await processZip(data)
 //   }
 //   catch (e) {
-//     throw (e)
+//     console.log(e)
 //   }
 // }
 
@@ -82,7 +82,7 @@ async function processZip (f) {
 
     let contents = await parentZip.loadAsync(f)
     let fns = Object.keys(contents.files)
-    let xmlMembers = fns.filter( fn => fn.endsWith('xccdf.xml') || fn.endsWith('Benchmark.xml') )
+    let xmlMembers = fns.filter( fn => fn.toLowerCase().endsWith('.xml'))
     let zipMembers = fns.filter( fn => fn.endsWith('.zip') )
     for (let x=0,l=xmlMembers.length; x<l; x++) {
       let xml = xmlMembers[x]
@@ -111,7 +111,7 @@ async function processZip (f) {
     }
   }
   catch (e) {
-    throw (e)
+    console.log(`Caught error: ${e}`)
   }
   
 }

--- a/api/source/utils/fetchStigs.js
+++ b/api/source/utils/fetchStigs.js
@@ -12,7 +12,7 @@ const scapURL = 'https://public.cyber.mil/stigs/scap/'
 const stigMatchString = '<a href="(https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/.*)" target=.*'
 const scapMatchString = '<a href="(https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/.*enchmark.zip)" target=.*'
 
-// let localCompilationFile = 'E:/STIGs/U_SRG-STIG_Library_2021_01v2.zip'
+// let localCompilationFile = 'E:/STIGs/test.zip'
 
 
 exports.fetchCompilation = async function fetchCompilation() {
@@ -88,7 +88,14 @@ async function processZip (f) {
       let xml = xmlMembers[x]
       console.log(`PARSING   : ${xml}`)
       let xmlData = await parentZip.files[xml].async("nodebuffer")
-      let benchmark = parsers.benchmarkFromXccdf(xmlData)
+      let benchmark
+      try {
+        benchmark = await parsers.benchmarkFromXccdf(xmlData)
+      }
+      catch(err){
+        console.log(`Error while parsing file ${xml}: ${err}`)
+        continue
+      }
       let response
       if (benchmark.scap) {
         response = await STIG.insertScapBenchmark(benchmark, xmlData)
@@ -111,7 +118,7 @@ async function processZip (f) {
     }
   }
   catch (e) {
-    console.log(`Caught error: ${e}`)
+    throw (e)
   }
   
 }

--- a/clients/extjs/js/stigmanUtils.js
+++ b/clients/extjs/js/stigmanUtils.js
@@ -1646,7 +1646,7 @@ function uploadStigs(n) {
 					let input = document.getElementById("form-file-file")
 					let file = input.files[0]
 					let extension = file.name.substring(file.name.lastIndexOf(".")+1)
-					if (extension === 'xml') {
+					if (extension.toLowerCase() === 'xml') {
 						let formEl = fp.getForm().getEl().dom
 						let formData = new FormData(formEl)
 						formData.set('replace', 'true')
@@ -1691,7 +1691,7 @@ function uploadStigs(n) {
 		   
 						let contents = await parentZip.loadAsync(f)
 						let fns = Object.keys(contents.files)
-						let xmlMembers = fns.filter( fn => fn.toLowerCase().endsWith('xccdf.xml') || fn.toLowerCase().endsWith('benchmark.xml') )
+						let xmlMembers = fns.filter( fn => fn.toLowerCase().endsWith('.xml'))
 						let zipMembers = fns.filter( fn => fn.toLowerCase().endsWith('.zip') )
 						for (let x=0,l=xmlMembers.length; x<l; x++) {
 							let xml = xmlMembers[x]


### PR DESCRIPTION
Removed attempts to filter STIG processing based on filename (Aside from requiring a xml/XML extension), since they do not seem to follow any reliable convention. Restricted error responses to just parser error message (removed stack trace portion so it does not show up in user's import log).

fixes: #235 