### PR TITLE
fix #275: handle rule-result without check

### DIFF
--- a/api/source/controllers/Review.js
+++ b/api/source/controllers/Review.js
@@ -29,7 +29,7 @@ module.exports.importReviewsByAsset = async function importReviewsByAsset (req, 
             result = await Parsers.reviewsFromCkl(data.toString(), {ignoreNr: true})
             break
           case 'xml':
-            result = Parsers.reviewsFromScc(data.toString(), {ignoreNr: true})
+            result = Parsers.reviewsFromScc(data.toString(), {ignoreNotChecked: true})
             break
         }
         reviewsRequested = []

--- a/api/source/utils/parsers.js
+++ b/api/source/utils/parsers.js
@@ -482,7 +482,7 @@ module.exports.reviewsFromScc = function (sccFileContent, options = {}) {
         reviews.push({
           ruleId: ruleResult.idref.replace('xccdf_mil.disa.stig_rule_', ''),
           result: result,
-          resultComment: `SCC Reviewed at ${ruleResult.time} using:\n${ruleResult.check['check-content-ref'].href.replace('#scap_mil.disa.stig_comp_', '')}`,
+          resultComment: `SCC Reviewed at ${ruleResult.time}`,
           autoResult: true,
           status: result != 'fail' ? 'accepted' : 'saved'
         })  

--- a/api/source/utils/parsers.js
+++ b/api/source/utils/parsers.js
@@ -508,10 +508,13 @@ module.exports.reviewsFromScc = function (sccFileContent, options = {}) {
         target[name] = fact['#text'] 
       }
     })
-    const {ip, host_name, ...metadata} = target
+    const {ip, host_name, fqdn, mac, ...metadata} = target
     return {
       name: host_name,
+      description: '',
       ip: ip,
+      mac: mac,
+      fqdn: fqdn,
       noncomputing: false,
       metadata: metadata
     }

--- a/clients/extjs/js/SM/Parsers.js
+++ b/clients/extjs/js/SM/Parsers.js
@@ -295,7 +295,7 @@ const reviewsFromScc = function (sccFileContent, options = {}) {
         reviews.push({
           ruleId: ruleResult.idref.replace('xccdf_mil.disa.stig_rule_', ''),
           result: result,
-          resultComment: `SCC Reviewed at ${ruleResult.time} using:\n${ruleResult.check['check-content-ref'].href.replace('#scap_mil.disa.stig_comp_', '')}`,
+          resultComment: `SCC Reviewed at ${ruleResult.time}`,
           autoResult: true,
           status: result != 'fail' ? 'accepted' : 'saved'
         })  

--- a/clients/extjs/js/SM/Parsers.js
+++ b/clients/extjs/js/SM/Parsers.js
@@ -321,10 +321,13 @@ const reviewsFromScc = function (sccFileContent, options = {}) {
         target[name] = fact['#text'] 
       }
     })
-    const {ip, host_name, ...metadata} = target
+    const {ip, host_name, fqdn, mac, ...metadata} = target
     return {
       name: host_name,
+      description: '',
       ip: ip,
+      mac: mac,
+      fqdn: fqdn,
       noncomputing: false,
       metadata: metadata
     }

--- a/clients/extjs/js/SM/ReviewsImport.js
+++ b/clients/extjs/js/SM/ReviewsImport.js
@@ -1226,7 +1226,8 @@ class TaskObject {
             const stigIsInstalled = ({ benchmarkId, revisionStr }) => {
                 const revisionStrs = this.mappedStigs.get(benchmarkId)
                 if (revisionStrs) {
-                    return revisionStrs.includes(revisionStr)
+                    if (revisionStr) return revisionStrs.includes(revisionStr)
+                    return true
                 }
                 else {
                     return false


### PR DESCRIPTION
Fixes #275 

In an SCC XCCDF TestResult file, `<rule-result>` can sometimes lack a child `<check>`. Modified the parser so the generated `review.resultComment` property does not rely on `<check>`. 