### PR TITLE
docs: follow code.mil guidance on license.md file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,7 +7,9 @@
 
 ## MIT License
 
-Copyright (c) 2020 U.S. Federal Government (in countries where recognized)
+Copyright (c) 2021 U.S. Federal Government (in countries where recognized)
+Copyright (c) 2021 Science Applications International Corporation
+Copyright (c) 2021 Rite-Solutions, Inc. 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Added SAIC and Rite company names to license.md file, to follow code.mil guidance. 

fixes #300 