### PR TITLE
feat: Accept all XCCDF result values (#67)

### DIFF
--- a/api/source/service/mysql/utils.js
+++ b/api/source/service/mysql/utils.js
@@ -409,42 +409,21 @@ module.exports.updateStatsAssetStig = async function(connection, { collectionId,
 module.exports.CONTEXT_ALL = 'all'
 module.exports.CONTEXT_DEPT = 'department'
 module.exports.CONTEXT_USER = 'user'
-module.exports.REVIEW_RESULT_ID = { 
-  1: {api: 'notchecked', ckl: 'Not_Reviewed', abbr: 'NC'},
-  2: {api: 'notapplicable', ckl: 'Not_Applicable', abbr: 'NA'},
-  3: {api: 'pass', ckl: 'NotAFinding', abbr: 'NF'},
-  4: {api: 'fail', ckl: 'Open', abbr: 'O'}
-}
 module.exports.REVIEW_RESULT_API = { 
+  'notchecked': 1,
   'notapplicable': 2,
   'pass': 3,
-  'fail': 4
-}
-module.exports.REVIEW_RESULT_CKL = { 
-  'Not_Applicable': {id: 2},
-  'NotAFinding': {id: 3},
-  'Open': {id: 4}
-}
-module.exports.REVIEW_RESULT_ABBR = { 
-  'NA': {id: 2},
-  'NF': {id: 3},
-  'O': {id: 4}
-}
-module.exports.REVIEW_ACTION_ID = { 
-  1: 'remediate',
-  2: 'mitigate',
-  3: 'exception'
+  'fail': 4,
+  'unknown': 5,
+  'error': 6,
+  'notselected': 7,
+  'informational': 8,
+  'fixed': 9
 }
 module.exports.REVIEW_ACTION_API = { 
   'remediate': 1,
   'mitigate': 2,
   'exception': 3
-}
-module.exports.REVIEW_STATUS_ID = { 
-  0: 'saved',
-  1: 'submitted',
-  2: 'rejected',
-  3: 'approved'
 }
 module.exports.REVIEW_STATUS_API = { 
   'saved': 0,
@@ -457,14 +436,3 @@ module.exports.WRITE_ACTION = {
   REPLACE: 1,
   UPDATE: 2
 }
-module.exports.USER_ROLE_ID = {
-  2: {role: "IAWF", display: "IA Workforce"},
-  3: {role: "IAO", display: "IA Officer"},
-  4: {role: "Staff", display: "IA Staff"}
-}
-module.exports.USER_ROLE = {
-  IAWF: {id: 2, display: "IA Workforce"},
-  IAO: {id: 3, display: "IA Officer"},
-  Staff: {id: 4, display: "IA Staff"}
-}
-

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -2480,6 +2480,12 @@ components:
         - fail
         - pass
         - notapplicable
+        - notchecked
+        - unknown
+        - error
+        - notselected
+        - informational
+        - fixed
         - null
     ChecklistStatus:
       type: string
@@ -2969,6 +2975,12 @@ components:
         - fail
         - pass
         - notapplicable
+        - notchecked
+        - unknown
+        - error
+        - notselected
+        - informational
+        - fixed
     ReviewStatus:
       type: string
       enum:

--- a/clients/extjs/css/stigman.css
+++ b/clients/extjs/css/stigman.css
@@ -204,12 +204,11 @@ body {
 	text-align: center;
 }
 .sm-result-na {
-	color: grey;
+	color: #b1b1b1;
 	text-align: center;
 }
 .sm-result-nr {
-    color: hsla(0, 10%, 96%, 1);
-    background-color: #d74400;
+    color: #404040;
     text-align: center;
 }
 

--- a/clients/extjs/js/SM/Global.js
+++ b/clients/extjs/js/SM/Global.js
@@ -36,4 +36,51 @@ SM.actionTipText = `<b>Recommended Action</b><br>For failed results (i.e., Open)
 SM.actionCommentTipText = `<b>Recommended Action Comment</b><br>For failed results (i.e., Open), the action plan recommended by the evaluator.<br><br><b>Export Mappings</b><br><b>CKL:</b> &lt;CHECKLIST&gt;&lt;STIGS&gt;&lt;iSTIG&gt;&lt;VULN&gt;&lt;COMMENTS&gt;<br>
 <b>XCCDF:</b> &lt;TestResult&gt;&lt;rule-result&gt;&lt;metadata action-comment&gt;`
 
+SM.RenderResult = {
+    fail: {
+        css: 'sm-result-fail',
+        textDisa: 'O',
+        textNist: 'F'
+    },
+    pass: {
+        css: 'sm-result-pass',
+        textDisa: 'NF',
+        textNist: 'P'
+    },
+    notapplicable: {
+        css: 'sm-result-na',
+        textDisa: 'NA',
+        textNist: 'N'
+    },
+    notchecked: {
+        css: 'sm-result-nr',
+        textDisa: 'NR',
+        textNist: 'K'
+    },
+    unknown: {
+        css: 'sm-result-nr',
+        textDisa: 'U',
+        textNist: 'U'
+    },
+    error: {
+        css: 'sm-result-nr',
+        textDisa: 'E',
+        textNist: 'E'
+    },
+    notselected: {
+        css: 'sm-result-nr',
+        textDisa: 'S',
+        textNist: 'S'
+    },
+    informational: {
+        css: 'sm-result-nr',
+        textDisa: 'I',
+        textNist: 'I'
+    },
+    fixed: {
+        css: 'sm-result-pass',
+        textDisa: 'F',
+        textNist: 'F'
+    }
+}
 

--- a/clients/extjs/js/SM/Parsers.js
+++ b/clients/extjs/js/SM/Parsers.js
@@ -25,15 +25,19 @@
 //         }
 //       ],
 //       stats: {
-//         pass: 0,
-//         fail: 0,
-//         notapplicable: 0,
-//         notchecked: 0
+//          pass: 0,
+//          fail: 0,
+//          notapplicable: 0,
+//          notchecked: 0,
+//          notselected: 0,
+//          informational: 0,
+//          error: 0,
+//          fixed: 0,
+//          unknown: 0
 //       }
 //     }
 //   ]
 // }
-
 const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
   function tagValueProcessor(html) {
     var txt = document.createElement("textarea");
@@ -139,32 +143,29 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
       //     STIG_DATA [26]
       // }
   
-      const results = {
+      const resultMap = {
         NotAFinding: 'pass',
         Open: 'fail',
         Not_Applicable: 'notapplicable',
         Not_Reviewed: 'notchecked'
       }
+      const resultStats = {
+        pass: 0,
+        fail: 0,
+        notapplicable: 0,
+        notchecked: 0,
+        notselected: 0,
+        informational: 0,
+        error: 0,
+        fixed: 0,
+        unknown: 0
+      }  
       let vulnArray = []
-      let nf = na = nr = o = 0
       vulnElements?.forEach(vuln => {
-        const result = results[vuln.STATUS]
+        let result = resultMap[vuln.STATUS]
         if (result) {
-          switch (result) {
-            case 'pass':
-                nf++
-                break
-            case 'fail':
-                o++
-                break
-            case 'notapplicable':
-                na++
-                break
-            case 'notchecked':
-                nr++
-                break
-          }
-
+          if (result === 'notchecked' && vuln.FINDING_DETAILS) result = 'informational'
+          resultStats[result]++
           let ruleId
           vuln.STIG_DATA.some(stigDatum => {
             if (stigDatum.VULN_ATTRIBUTE == "Rule_ID") {
@@ -206,12 +207,7 @@ const reviewsFromCkl = function reviewsFromCkl (cklData, options = {}) {
   
       return {
         reviews: vulnArray,
-        stats: {
-          notchecked: nr,
-          notapplicable: na,
-          pass: nf,
-          fail: o
-        }
+        stats: resultStats
       }
     }  
   }
@@ -266,49 +262,34 @@ const reviewsFromScc = function (sccFileContent, options = {}) {
   finally {}
 
   function processRuleResults(ruleResults) {
-    const results = {
-      pass: 'pass',
-      fail: 'fail',
-      notapplicable: 'notapplicable',
-      notchecked: 'notchecked'
+    const resultStats = {
+      pass: 0,
+      fail: 0,
+      notapplicable: 0,
+      notchecked: 0,
+      notselected: 0,
+      informational: 0,
+      error: 0,
+      fixed: 0,
+      unknown: 0
     }
     let reviews = []
-    let nf = na = nr = o = 0   
     ruleResults.forEach(ruleResult => {
-      result = results[ruleResult.result]
-      if (result) {
-        switch (result) {
-          case 'pass':
-              nf++
-              break
-          case 'fail':
-              o++
-              break
-          case 'notapplicable':
-              na++
-              break
-          case 'notchecked':
-              nr++
-              break
-        }
-        if ( result === 'notchecked' && options.ignoreNotChecked ) return
+      resultStats[ruleResult.result]++
+      if (ruleResult.result) {
+        if ( ruleResult.result === 'notchecked' && options.ignoreNotChecked ) return
         reviews.push({
           ruleId: ruleResult.idref.replace('xccdf_mil.disa.stig_rule_', ''),
-          result: result,
+          result: ruleResult.result,
           resultComment: `SCC Reviewed at ${ruleResult.time}`,
           autoResult: true,
-          status: result != 'fail' ? 'accepted' : 'saved'
+          status: ruleResult.result != 'fail' ? 'accepted' : 'saved'
         })  
       }
     })
     return {
       reviews: reviews,
-      stats: {
-        notchecked: nr,
-        notapplicable: na,
-        pass: nf,
-        fail: o
-      }  
+      stats: resultStats
     }
   }
 

--- a/clients/extjs/js/SM/ReviewsImport.js
+++ b/clients/extjs/js/SM/ReviewsImport.js
@@ -49,6 +49,10 @@ SM.ReviewsImport.Grid = Ext.extend(Ext.grid.GridPanel, {
                 mapping: 'checklist.newAssignment'
             },
             {
+                name: 'informational',
+                mapping: 'checklist.stats.informational'
+            },
+            {
                 name: 'notchecked',
                 mapping: 'checklist.stats.notchecked'
             },
@@ -146,6 +150,14 @@ SM.ReviewsImport.Grid = Ext.extend(Ext.grid.GridPanel, {
                         return v
                     }
                 }
+            },
+            {
+                header: '<div class="sm-grid-result-sprite sm-result-na">I</div></div>',
+                width: 50,
+                align: 'center',
+                dataIndex: 'informational',
+                sortable: true,
+                renderer: (v) => me.importReviews ? v : '--'
             },
             {
                 header: '<div class="sm-grid-result-sprite sm-result-na">NR</div></div>',

--- a/clients/extjs/js/review.js
+++ b/clients/extjs/js/review.js
@@ -384,7 +384,7 @@ async function addReview( params ) {
     var checksO = 0;
     var checksNF = 0;
     var checksNA = 0;
-    var checksNR = 0;
+    var checksOther = 0;
     store.data.each(function (item, index, totalItems) {
       switch (item.data.result) {
         case 'fail':
@@ -396,12 +396,12 @@ async function addReview( params ) {
         case 'notapplicable':
           checksNA++;
           break;
-        case '':
-          checksNR++;
+        default:
+          checksOther++;
           break;
       }
     });
-    return totalChecks + ' checks (' + checksO + ' Open, ' + checksNF + ' NF, ' + checksNA + ' NA, ' + checksNR + ' NR)';
+    return totalChecks + ' checks (' + checksO + ' Open, ' + checksNF + ' NF, ' + checksNA + ' NA, ' + checksOther + ' NR/Other )';
   };
 
   /******************************************************/
@@ -972,19 +972,7 @@ async function addReview( params ) {
 				fixed: true,
         dataIndex: 'result',
         sortable: true,
-        renderer: function (val) {
-					switch (val) {
-						case 'fail':
-							return '<div style="color:red;font-weight:bolder;text-align:center">O</div>';
-							break;
-						case 'pass':
-							return '<div style="color:green;font-weight:bolder;text-align:center">NF</div>';
-							break;
-						case 'notapplicable':
-							return '<div style="color:grey;font-weight:bolder;text-align:center">NA</div>';
-							break;
-					}
-				}
+        renderer: renderResult
       },
       // {
       //   header: 'Comment',
@@ -1536,7 +1524,6 @@ async function addReview( params ) {
         fieldLabel: 'Result<i class= "fa fa-question-circle sm-question-circle"></i>',
         labelSeparator: '',
         emptyText: 'Your result...',
-        valueNotFoundText: 'Your result...',
         disabled: true,
         name: 'result',
         hiddenName: 'result',

--- a/clients/extjs/js/stigmanUtils.js
+++ b/clients/extjs/js/stigmanUtils.js
@@ -818,19 +818,7 @@ function Sm_HistoryData (idAppend) {
 				width: 50,
 				fixed: true,
 				dataIndex: 'result',
-				renderer: function (val) {
-					switch (val) {
-						case 'fail':
-							return '<div style="color:red;font-weight:bolder;text-align:center">O</div>';
-							break;
-						case 'pass':
-							return '<div style="color:green;font-weight:bolder;text-align:center">NF</div>';
-							break;
-						case 'notapplicable':
-							return '<div style="color:grey;font-weight:bolder;text-align:center">NA</div>';
-							break;
-					}
-				},
+				renderer: renderResult,
 				sortable: true
 			},
 			{ 	
@@ -1189,22 +1177,12 @@ function checked(val) {
 // 	}
 // }
 
+
+
 function renderResult(val, metaData, record, rowIndex, colIndex, store) {
-	switch (val) {
-		case 'pass':
-			return '<div class="sm-grid-result-sprite sm-result-pass">NF</div>'
-		case 'fail':
-			return '<div class="sm-grid-result-sprite sm-result-fail">O</div>'
-		case 'notapplicable':
-			return '<div class="sm-grid-result-sprite sm-result-na">NA</div>'
-		case 'notchecked':
-			return '<div class="sm-grid-result-sprite sm-result-nr">NR</div>'
-		default:
-			return ''
-	}
+	if (!val) return ''
+	return `<div class="sm-grid-result-sprite ${SM.RenderResult[val]?.css}" ext:qtip="${val}">${SM.RenderResult[val]?.textDisa}</div>`
 }
-
-
 
 function renderStatuses(val, metaData, record, rowIndex, colIndex, store) {
 	var statusIcons = '';


### PR DESCRIPTION
Fixes #67 

I've expanded the API to accept all nine (9) XCCDF result values, not just the three (3) compliance categories:
```
- fail
- pass
- notapplicable
- notchecked
- unknown
- error
- notselected
- informational
- fixed
```
I've also updated the CKL parsers in the API and Web Client to map `<STATUS>Not_Reviewed</STATUS>` where `<FINDING_DETAILS>` is not empty as result `informational`. All other `Not_Reviewed` reviews will continue to be ignored. 

The CKL exporter was already configured to map an `informational` result to `Not_Reviewed`.

The API will now accept `notchecked` as a valid result but for now our clients will not submit Reviews with that.
