### PR TITLE
UI: History->log, now displays current state of Reviews as latest entry

### DIFF
--- a/clients/extjs/js/collectionReview.js
+++ b/clients/extjs/js/collectionReview.js
@@ -1862,7 +1862,7 @@ async function addCollectionReview ( params ) {
 							layout: 'fit',
 							items: metadataGrid
 						},{
-							title: 'History',
+							title: 'Log',
 							layout: 'fit',
 							id: 'history-tab' + idAppend,
 							items: historyData.grid

--- a/clients/extjs/js/collectionReview.js
+++ b/clients/extjs/js/collectionReview.js
@@ -1312,6 +1312,9 @@ async function addCollectionReview ( params ) {
 		function handleGroupSelectionForCollection(record, idAppend, leaf, benchmarkId, revisionStr) {
 			getContent(benchmarkId, revisionStr, record.data.ruleId, record.data.groupId)
 			getReviews(leaf.collectionId, record)
+			//when new group is selected, deselect rows from reviews grid (to make resources panel clear)
+			reviewsGrid.getSelectionModel().clearSelections();
+
 
 			// // Content panel
 			// let contentPanel = Ext.getCmp('content-panel' + idAppend);
@@ -1579,7 +1582,21 @@ async function addCollectionReview ( params ) {
 				})
 				if (result.response.status === 200) {
 					let apiReview = JSON.parse(result.response.responseText)
-					//TODO: Set the history
+					//TODO: Set the history (does not set history on handleGroupSelectionForCollection)
+					//append the current state of the review to history
+					let currentReview = {
+						action: apiReview.action,
+						actionComment: apiReview.actionComment,
+						autoResult: apiReview.autoResult,
+						rejectText: apiReview.rejectText,
+						result: apiReview.result,
+						resultComment: apiReview.resultComment,
+						status: apiReview.status,
+						ts: apiReview.ts,
+						userId: apiReview.userId,
+						username: apiReview.username
+					  }
+					apiReview.history.push(currentReview)
 					Ext.getCmp('historyGrid' + idAppend).getStore().loadData(apiReview.history)
 	
 					// Reject text

--- a/clients/extjs/js/review.js
+++ b/clients/extjs/js/review.js
@@ -1409,7 +1409,7 @@ async function addReview( params ) {
         padding: 10,
         autoScroll: true
       },{
-        title: 'History',
+        title: 'Log',
         layout: 'fit',
         id: 'history-tab' + idAppend,
         items: historyData.grid

--- a/clients/extjs/js/review.js
+++ b/clients/extjs/js/review.js
@@ -2151,6 +2151,20 @@ async function addReview( params ) {
       Ext.getCmp('editor' + idAppend).setValue(`${extDate.format('Y-m-d H:i')} by ${reviewFromApi.username}`)
 
       // Update history
+      // append current state of review to history grid
+      let currentReview = {
+        action: reviewFromApi.action,
+        actionComment: reviewFromApi.actionComment,
+        autoResult: reviewFromApi.autoResult,
+        rejectText: reviewFromApi.rejectText,
+        result: reviewFromApi.result,
+        resultComment: reviewFromApi.resultComment,
+        status: reviewFromApi.status,
+        ts: reviewFromApi.ts,
+        userId: reviewFromApi.userId,
+        username: reviewFromApi.username
+      }
+      reviewFromApi.history.push(currentReview)
       historyData.store.loadData(reviewFromApi.history)
 
       //Reset lastSavedData to current values, so we do not trigger the save again:

--- a/clients/extjs/js/stigmanUtils.js
+++ b/clients/extjs/js/stigmanUtils.js
@@ -789,7 +789,7 @@ function Sm_HistoryData (idAppend) {
 		stripeRows:true,
 		view: new Ext.grid.GridView({
 			forceFit:true,
-			emptyText: 'No history to display.',
+			emptyText: 'No log to display.',
 			deferEmptyText:false
 		}),
 		columns: [

--- a/clients/extjs/js/stigmanUtils.js
+++ b/clients/extjs/js/stigmanUtils.js
@@ -1138,6 +1138,20 @@ async function handleGroupSelectionForAsset (groupGridRecord, collectionId, asse
 			Ext.getCmp('historyGrid' + idAppend).getStore().removeAll()
 		}
 		else if (reviewWithHistory.history) {
+			// append current state of review to history grid
+			let currentReview = {
+				action: reviewWithHistory.action,
+				actionComment: reviewWithHistory.actionComment,
+				autoResult: reviewWithHistory.autoResult,
+				rejectText: reviewWithHistory.rejectText,
+				result: reviewWithHistory.result,
+				resultComment: reviewWithHistory.resultComment,
+				status: reviewWithHistory.status,
+				ts: reviewWithHistory.ts,
+				userId: reviewWithHistory.userId,
+				username: reviewWithHistory.username
+			  }
+			reviewWithHistory.history.push(currentReview)
 			Ext.getCmp('historyGrid' + idAppend).getStore().loadData(reviewWithHistory.history)
 		}
 		// Feedback


### PR DESCRIPTION
Displays of history now include the current state of the Review as the latest entry.
Renamed history tabs to "log"

fixes: #255 

