### PR TITLE
SCAP BenchmarkId Map

### DIFF
--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -5,7 +5,7 @@ const config = require('../utils/config')
 const parsers = require('../utils/parsers.js')
 const STIG = require(`../service/${config.database.type}/STIGService`)
 
-module.exports.importManualBenchmark = async function importManualBenchmark (req, res, next) {
+module.exports.importBenchmark = async function importManualBenchmark (req, res, next) {
   try {
     let extension = req.file.originalname.substring(req.file.originalname.lastIndexOf(".")+1)
     if (extension.toLowerCase() != 'xml') {
@@ -194,4 +194,25 @@ module.exports.getStigById = async function getStigById (req, res, next) {
   catch(err) {
     writer.writeJson(res, err)
   }
+}
+
+module.exports.getScapMap = async function getStigById (req, res, next) {
+  writer.writeJson(res, [
+    {
+      scapBenchmarkId: 'CAN_Ubuntu_18-04_STIG',
+      benchmarkId: 'U_CAN_Ubuntu_18-04_STIG'
+    },
+    {
+      scapBenchmarkId: 'Mozilla_Firefox_RHEL',
+      benchmarkId: 'Mozilla_Firefox'
+    },
+    {
+      scapBenchmarkId: 'Mozilla_Firefox_Windows',
+      benchmarkId: 'Mozilla_Firefox'
+    },
+    {
+      scapBenchmarkId: 'Solaris_10_X86_STIG',
+      benchmarkId: 'Solaris_10_X86'
+    }
+  ])
 }

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1381,8 +1381,8 @@ paths:
     post:
       tags:
         - STIG
-      summary: Import a new STIG
-      operationId: importManualBenchmark
+      summary: Import a STIG or SCAP Benchmark
+      operationId: importBenchmark
       requestBody:
         required: true
         content:
@@ -1416,8 +1416,6 @@ paths:
       security:
         - oauth:
             - 'stig-manager:stig'
-      x-rbac:
-        - admin
   '/stigs/ccis/{cci}':
     get:
       tags:
@@ -1472,6 +1470,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuleProjected'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:stig:read'
+  '/stigs/scap-maps':
+    get:
+      tags:
+        - STIG
+      summary: Return a list of SCAP benchmarkIds mapped to Manual benchmarkIds
+      operationId: getScapMap
+      responses:
+        '200':
+          description: SCAP Map response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SCAPMap'
         default:
           description: unexpected error
           content:
@@ -3116,6 +3138,13 @@ components:
         - high
         - medium
         - low
+    SCAPMap:
+      type: object
+      properties:
+        scapBenchmarkId:
+          type: string
+        benchmarkId:
+          type: string
     STIG:
       type: object
       properties:

--- a/clients/extjs/js/SM/Parsers.js
+++ b/clients/extjs/js/SM/Parsers.js
@@ -242,6 +242,9 @@ const reviewsFromScc = function (sccFileContent, options = {}) {
 
     // Process parsed data
     let benchmarkId = parsed.Benchmark.id.replace('xccdf_mil.disa.stig_benchmark_', '')
+    if (options.scapBenchmarkMap && options.scapBenchmarkMap.has(benchmarkId)) {
+      benchmarkId = options.scapBenchmarkMap.get(benchmarkId)
+    }
     let target = processTargetFacts(parsed.Benchmark.TestResult['target-facts'].fact)
     if (!target.name) {
       throw (new Error('No host_name fact'))

--- a/clients/extjs/js/SM/ReviewsImport.js
+++ b/clients/extjs/js/SM/ReviewsImport.js
@@ -1546,6 +1546,9 @@ async function showImportResultFiles(collectionId, el) {
                     method: 'GET'
                 })
 
+                // Get SCAP benchmarkId map
+                let scapBenchmarkMap = await getScapBenchmarkMap()
+
                 let filesHandled = 0
                 const parseResults = {
                     success: [],
@@ -1572,7 +1575,7 @@ async function showImportResultFiles(collectionId, el) {
                     }
                     if (extension === 'xml') {
                         try {
-                            const r = reviewsFromScc(data, { ignoreNotChecked: false })
+                            const r = reviewsFromScc(data, { ignoreNotChecked: false, scapBenchmarkMap })
                             r.file = file
                             parseResults.success.push(r)
                         }
@@ -2121,4 +2124,13 @@ async function showImportResultFile(params) {
         }
 
     }
+}
+
+async function getScapBenchmarkMap() {
+    let result = await Ext.Ajax.requestPromise({
+        url: `${STIGMAN.Env.apiBase}/stigs/scap-maps`,
+        method: 'GET'
+    })
+    apiScapMaps = JSON.parse(result.response.responseText)
+    return new Map(apiScapMaps.map(apiScapMap => [apiScapMap.scapBenchmarkId, apiScapMap.benchmarkId]))
 }


### PR DESCRIPTION
Resolves #248 

The example given in the issue (RHEL_8_STIG => RHEL_8) no longer applies since V1R2 of the STIG changed the Manual benchmarkId. `GET stigs/scap-maps` returns a static array:

```
[
    {
      scapBenchmarkId: 'CAN_Ubuntu_18-04_STIG',
      benchmarkId: 'U_CAN_Ubuntu_18-04_STIG'
    },
    {
      scapBenchmarkId: 'Mozilla_Firefox_RHEL',
      benchmarkId: 'Mozilla_Firefox'
    },
    {
      scapBenchmarkId: 'Mozilla_Firefox_Windows',
      benchmarkId: 'Mozilla_Firefox'
    },
    {
      scapBenchmarkId: 'Solaris_10_X86_STIG',
      benchmarkId: 'Solaris_10_X86'
    }
  ]
```