### PR TITLE
Adds metadata handling for Assets and Collections

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -599,7 +599,7 @@ module.exports.updateAsset = async function updateAsset (req, res, next) {
 
 
 async function getAssetIdAndCheckPermission(request) {
-  const elevate = request.query.elevate
+  const elevate = false
   let assetId = request.params.assetId
 
   // fetch the Asset for access control checks and the response

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -318,3 +318,109 @@ module.exports.updateCollection = async function updateCollection (req, res, nex
     next(err)
   }
 }
+
+
+
+async function getCollectionIdAndCheckPermission(request) {
+  let collectionId = request.params.collectionId
+  const elevate = request.query.elevate
+  const collectionGrant = request.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
+
+  if (!( elevate || (collectionGrant && collectionGrant.accessLevel >= 3) )) {
+    throw( {status: 403, message: "User has insufficient privilege to complete this request."} )
+  }
+
+  return collectionId
+}
+
+module.exports.getCollectionMetadata = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let result = await Collection.getCollectionMetadata(collectionId, req.userObject)
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.patchCollectionMetadata = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let metadata = req.body
+    await Collection.patchCollectionMetadata(collectionId, metadata)
+    let result = await Collection.getCollectionMetadata(collectionId)
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.putCollectionMetadata = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let body = req.body
+    await Collection.putCollectionMetadata( collectionId, body)
+    let result = await Collection.getCollectionMetadata(collectionId)
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.getCollectionMetadataKeys = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let result = await Collection.getCollectionMetadataKeys(collectionId, req.userObject)
+    if (!result)  
+      throw ( {status: 404, message: "metadata keys not found"} )
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.getCollectionMetadataValue = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let key = req.params.key
+    let result = await Collection.getCollectionMetadataValue(collectionId, key, req.userObject)
+    if (!result) {
+      throw ( {status: 404, message: "metadata key not found"} )
+    }
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.putCollectionMetadataValue = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let key = req.params.key
+    let value = req.body
+    let result = await Collection.putCollectionMetadataValue(collectionId, key, value)
+    res.status(204).send()
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+
+module.exports.deleteCollectionMetadataKey = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req)
+    let key = req.params.key
+    let result = await Collection.deleteCollectionMetadataKey(collectionId, key, req.userObject)
+    res.status(204).send()
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+

--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -982,3 +982,101 @@ exports.updateCollection = async function( collectionId, body, projection, userO
   }
 }
 
+
+exports.getCollectionMetadataKeys = async function ( collectionId ) {
+  const binds = []
+  let sql = `
+    select
+      JSON_KEYS(metadata) as keyArray
+    from 
+      collection
+    where 
+      collectionId = ?`
+  binds.push(collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return rows.length > 0 ? rows[0].keyArray : []
+}
+
+exports.getCollectionMetadata = async function ( collectionId ) {
+  const binds = []
+  let sql = `
+    select
+      metadata 
+    from 
+      collection
+    where 
+      collectionId = ?`
+  binds.push(collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return rows.length > 0 ? rows[0].metadata : {}
+}
+
+exports.patchCollectionMetadata = async function ( collectionId, metadata ) {
+  const binds = []
+  let sql = `
+    update
+      collection 
+    set 
+      metadata = JSON_MERGE_PATCH(metadata, ?)
+    where 
+      collectionId = ?`
+  binds.push(JSON.stringify(metadata), collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return true
+}
+
+exports.putCollectionMetadata = async function ( collectionId, metadata ) {
+  const binds = []
+  let sql = `
+    update
+      collection
+    set 
+      metadata = ?
+    where 
+      collectionId = ?`
+  binds.push(JSON.stringify(metadata), collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return true
+}
+
+exports.getCollectionMetadataValue = async function ( collectionId, key ) {
+  const binds = []
+  let sql = `
+    select
+      JSON_EXTRACT(metadata, ?) as value
+    from 
+      collection
+    where 
+      collectionId = ?`
+  binds.push(`$."${key}"`, collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return rows.length > 0 ? rows[0].value : ""
+}
+
+exports.putCollectionMetadataValue = async function ( collectionId, key, value ) {
+  const binds = []
+  let sql = `
+    update
+      collection
+    set 
+      metadata = JSON_SET(metadata, ?, ?)
+    where 
+      collectionId = ?`
+  binds.push(`$."${key}"`, value, collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return rows.length > 0 ? rows[0].value : ""
+}
+
+exports.deleteCollectionMetadataKey = async function ( collectionId, key ) {
+  const binds = []
+  let sql = `
+    update
+      collection
+    set 
+      metadata = JSON_REMOVE(metadata, ?)
+    where 
+      collectionId = ?`
+  binds.push(`$."${key}"`, collectionId)
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  return rows.length > 0 ? rows[0].value : ""
+}

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -295,6 +295,175 @@ paths:
       security:
         - oauth:
             - 'stig-manager:collection'
+  '/assets/{assetId}/metadata':
+    parameters:
+      - $ref: '#/components/parameters/AssetIdPath'
+    get:
+      tags:
+        - Asset
+      summary: Return the metadata for Asset
+      operationId: getAssetMetadata
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    patch:
+      tags:
+        - Asset
+      summary: Merge the provided object to a Assetmetadata
+      operationId: patchAssetMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metadata'
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+    put:
+      tags:
+        - Asset
+      summary: Set a Asset metadata to the provided object
+      operationId: putAssetMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metadata'
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+  '/assets/{assetId}/metadata/keys':
+    parameters:
+      - $ref: '#/components/parameters/AssetIdPath'
+    get:
+      tags:
+        - Asset
+      summary: Return the keys of the provided Asset's metadata
+      operationId: getAssetMetadataKeys
+      responses:
+        '200':
+          description: MetadataKeys response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetadataKey'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+  '/assets/{assetId}/metadata/keys/{key}':
+    parameters:
+      - $ref: '#/components/parameters/AssetIdPath'
+      - $ref: '#/components/parameters/MetadataKeyPath'
+    get:
+      tags:
+        - Asset
+      summary: Return the value of the provided Asset metadata key
+      operationId: getAssetMetadataValue
+      responses:
+        '200':
+          description: MetadataValue response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataValue'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    put:
+      tags:
+        - Asset
+      summary: Set the value of the provided Asset metadata key to the provided string
+      operationId: putAssetMetadataValue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataValue'
+      responses:
+        '204':
+          description: Empty to avoid large response after putting key with large value
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+    delete:
+      tags:
+        - Asset
+      summary: Remove the provided Asset metadata key
+      operationId: deleteAssetMetadataKey
+      responses:
+        '204':
+          description: Empty to avoid large response after deleteing key with large value
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
   '/assets/{assetId}/stigs':
     parameters:
       - $ref: '#/components/parameters/ElevateQuery'
@@ -1465,178 +1634,6 @@ paths:
         - Collection
       summary: Remove the provided Collection metadata key
       operationId: deleteCollectionMetadataKey
-      responses:
-        '204':
-          description: Empty to avoid large response after deleteing key with large value
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection'
-  '/assets/{assetId}/metadata':
-    parameters:
-      - $ref: '#/components/parameters/ElevateQuery'
-      - $ref: '#/components/parameters/AssetIdPath'
-    get:
-      tags:
-        - Asset
-      summary: Return the metadata for Asset
-      operationId: getAssetMetadata
-      responses:
-        '200':
-          description: Metadata response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Metadata'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection:read'
-    patch:
-      tags:
-        - Asset
-      summary: Merge the provided object to a Assetmetadata
-      operationId: patchAssetMetadata
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Metadata'
-      responses:
-        '200':
-          description: Metadata response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Metadata'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection'
-    put:
-      tags:
-        - Asset
-      summary: Set a Asset metadata to the provided object
-      operationId: putAssetMetadata
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Metadata'
-      responses:
-        '200':
-          description: Metadata response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Metadata'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection'
-  '/assets/{assetId}/metadata/keys':
-    parameters:
-      - $ref: '#/components/parameters/ElevateQuery'
-      - $ref: '#/components/parameters/AssetIdPath'
-    get:
-      tags:
-        - Asset
-      summary: Return the keys of the provided Asset's metadata
-      operationId: getAssetMetadataKeys
-      responses:
-        '200':
-          description: MetadataKeys response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/MetadataKey'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection:read'
-  '/assets/{assetId}/metadata/keys/{key}':
-    parameters:
-      - $ref: '#/components/parameters/ElevateQuery'
-      - $ref: '#/components/parameters/AssetIdPath'
-      - $ref: '#/components/parameters/MetadataKeyPath'
-    get:
-      tags:
-        - Asset
-      summary: Return the value of the provided Asset metadata key
-      operationId: getAssetMetadataValue
-      responses:
-        '200':
-          description: MetadataValue response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MetadataValue'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection:read'
-    put:
-      tags:
-        - Asset
-      summary: Set the value of the provided Asset metadata key to the provided string
-      operationId: putAssetMetadataValue
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MetadataValue'
-      responses:
-        '204':
-          description: Empty to avoid large response after putting key with large value
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:collection'
-    delete:
-      tags:
-        - Asset
-      summary: Remove the provided Asset metadata key
-      operationId: deleteAssetMetadataKey
       responses:
         '204':
           description: Empty to avoid large response after deleteing key with large value

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1305,6 +1305,350 @@ paths:
       security:
         - oauth:
             - 'stig-manager:collection'
+  '/collections/{collectionId}/metadata':
+    parameters:
+      - $ref: '#/components/parameters/CollectionIdPath'
+      - $ref: '#/components/parameters/ElevateQuery'
+    get:
+      tags:
+        - Collection
+      summary: Return the metadata for Collection
+      operationId: getCollectionMetadata
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    patch:
+      tags:
+        - Collection
+      summary: Merge the provided object to a Collection metadata
+      operationId: patchCollectionMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metadata'
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+    put:
+      tags:
+        - Collection
+      summary: Set a Collection metadata to the provided object
+      operationId: putCollectionMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metadata'
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+  '/collections/{collectionId}/metadata/keys':
+    parameters:
+      - $ref: '#/components/parameters/CollectionIdPath'
+      - $ref: '#/components/parameters/ElevateQuery'
+    get:
+      tags:
+        - Collection
+      summary: Return the keys of the provided Collection metadata
+      operationId: getCollectionMetadataKeys
+      responses:
+        '200':
+          description: MetadataKeys response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetadataKey'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+  '/collections/{collectionId}/metadata/keys/{key}':
+    parameters:
+      - $ref: '#/components/parameters/ElevateQuery'
+      - $ref: '#/components/parameters/CollectionIdPath'
+      - $ref: '#/components/parameters/MetadataKeyPath'
+    get:
+      tags:
+        - Collection
+      summary: Return the value of the provided Collection metadata key
+      operationId: getCollectionMetadataValue
+      responses:
+        '200':
+          description: MetadataValue response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataValue'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    put:
+      tags:
+        - Collection
+      summary: Set the value of the provided Collection metadata key to the provided string
+      operationId: putCollectionMetadataValue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataValue'
+      responses:
+        '204':
+          description: Empty to avoid large response after putting key with large value
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+    delete:
+      tags:
+        - Collection
+      summary: Remove the provided Collection metadata key
+      operationId: deleteCollectionMetadataKey
+      responses:
+        '204':
+          description: Empty to avoid large response after deleteing key with large value
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+  '/assets/{assetId}/metadata':
+    parameters:
+      - $ref: '#/components/parameters/ElevateQuery'
+      - $ref: '#/components/parameters/AssetIdPath'
+    get:
+      tags:
+        - Asset
+      summary: Return the metadata for Asset
+      operationId: getAssetMetadata
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    patch:
+      tags:
+        - Asset
+      summary: Merge the provided object to a Assetmetadata
+      operationId: patchAssetMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metadata'
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+    put:
+      tags:
+        - Asset
+      summary: Set a Asset metadata to the provided object
+      operationId: putAssetMetadata
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Metadata'
+      responses:
+        '200':
+          description: Metadata response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metadata'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+  '/assets/{assetId}/metadata/keys':
+    parameters:
+      - $ref: '#/components/parameters/ElevateQuery'
+      - $ref: '#/components/parameters/AssetIdPath'
+    get:
+      tags:
+        - Asset
+      summary: Return the keys of the provided Asset's metadata
+      operationId: getAssetMetadataKeys
+      responses:
+        '200':
+          description: MetadataKeys response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MetadataKey'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+  '/assets/{assetId}/metadata/keys/{key}':
+    parameters:
+      - $ref: '#/components/parameters/ElevateQuery'
+      - $ref: '#/components/parameters/AssetIdPath'
+      - $ref: '#/components/parameters/MetadataKeyPath'
+    get:
+      tags:
+        - Asset
+      summary: Return the value of the provided Asset metadata key
+      operationId: getAssetMetadataValue
+      responses:
+        '200':
+          description: MetadataValue response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataValue'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    put:
+      tags:
+        - Asset
+      summary: Set the value of the provided Asset metadata key to the provided string
+      operationId: putAssetMetadataValue
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataValue'
+      responses:
+        '204':
+          description: Empty to avoid large response after putting key with large value
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+    delete:
+      tags:
+        - Asset
+      summary: Remove the provided Asset metadata key
+      operationId: deleteAssetMetadataKey
+      responses:
+        '204':
+          description: Empty to avoid large response after deleteing key with large value
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
   '/collections/{collectionId}/status':
     parameters:
       - $ref: '#/components/parameters/CollectionIdPath'

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d5dc2bb6-2810-426d-80ae-0aa1e5c7b221",
+		"_postman_id": "f12fa892-017e-4f7b-8d61-9e96325843b3",
 		"name": "stig-manager",
 		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:\n Name: Carl Smigielski\n Email: carl.a.smigielski@saic.com",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -2729,10 +2729,7 @@
 														"exec": [
 															"let user = pm.environment.get(\"user\");\r",
 															"console.log(\"user: \" + user);\r",
-															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
-															"    user = \"elevated\";\r",
-															"    console.log(\"setting user to 'elevated'\");\r",
-															"}\r",
+															"\r",
 															"\r",
 															"//&& user != \"collectioncreator\"\r",
 															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
@@ -2775,7 +2772,7 @@
 												"method": "GET",
 												"header": [],
 												"url": {
-													"raw": "{{baseUrl}}/assets/:assetId/metadata?elevate={{elevated}}",
+													"raw": "{{baseUrl}}/assets/:assetId/metadata",
 													"host": [
 														"{{baseUrl}}"
 													],
@@ -2783,12 +2780,6 @@
 														"assets",
 														":assetId",
 														"metadata"
-													],
-													"query": [
-														{
-															"key": "elevate",
-															"value": "{{elevated}}"
-														}
 													],
 													"variable": [
 														{
@@ -2810,10 +2801,6 @@
 															"let user = pm.environment.get(\"user\");\r",
 															"console.log(\"user: \" + user);\r",
 															"\r",
-															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
-															"    user = \"elevated\";\r",
-															"    console.log(\"setting user to 'elevated'\");\r",
-															"}\r",
 															"\r",
 															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
 															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
@@ -2852,7 +2839,7 @@
 												"method": "GET",
 												"header": [],
 												"url": {
-													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys?elevate={{elevated}}",
+													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys",
 													"host": [
 														"{{baseUrl}}"
 													],
@@ -2861,12 +2848,6 @@
 														":assetId",
 														"metadata",
 														"keys"
-													],
-													"query": [
-														{
-															"key": "elevate",
-															"value": "{{elevated}}"
-														}
 													],
 													"variable": [
 														{
@@ -2888,10 +2869,6 @@
 															"let user = pm.environment.get(\"user\");\r",
 															"console.log(\"user: \" + user);\r",
 															"\r",
-															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
-															"    user = \"elevated\";\r",
-															"    console.log(\"setting user to 'elevated'\");\r",
-															"}\r",
 															"/*\r",
 															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
 															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
@@ -2929,7 +2906,7 @@
 												"method": "GET",
 												"header": [],
 												"url": {
-													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys/:key?elevate={{elevated}}",
+													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys/:key",
 													"host": [
 														"{{baseUrl}}"
 													],
@@ -2939,12 +2916,6 @@
 														"metadata",
 														"keys",
 														":key"
-													],
-													"query": [
-														{
-															"key": "elevate",
-															"value": "{{elevated}}"
-														}
 													],
 													"variable": [
 														{

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f12fa892-017e-4f7b-8d61-9e96325843b3",
+		"_postman_id": "77c7f0dd-c886-442f-8acf-7509db822c09",
 		"name": "stig-manager",
 		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:\n Name: Carl Smigielski\n Email: carl.a.smigielski@saic.com",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "acb62bf9-c924-40dc-bbe8-bfaca13b9f55",
+		"_postman_id": "d5dc2bb6-2810-426d-80ae-0aa1e5c7b221",
 		"name": "stig-manager",
 		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:\n Name: Carl Smigielski\n Email: carl.a.smigielski@saic.com",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1707,6 +1707,254 @@
 									"item": []
 								},
 								{
+									"name": "metadata",
+									"item": [
+										{
+											"name": "Return the Metadata for a Collection",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"//&& user != \"collectioncreator\"\r",
+															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated), collectioncreator, or >= level 3\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for \" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"});\r",
+															"\r",
+															"\r",
+															"\r",
+															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"    let testMetadataKey = pm.environment.get(\"pocEmail\");\r",
+															"    let testMetadataValue = pm.environment.get(\"pocEmail@email.com\");\r",
+															"    pm.expect(jsonData[testMetadataKey]).to.eql(testMetadataValue);\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata?elevate={{elevated}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Return the Metadata KEYS for a Collection",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200\", function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"pm.test(\"Response JSON is an array\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('array');\r",
+															"});\r",
+															"\r",
+															"\r",
+															"\r",
+															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"    pm.expect(jsonData).to.include(\"pocEmail\");\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata/keys?elevate={{elevated}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata",
+														"keys"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Return the Metadata VALUE for a Collection metadata KEY",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for \" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"pm.test(\"Response JSON is an array\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('string');\r",
+															"});\r",
+															"\r",
+															"\r",
+															"\r",
+															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"    pm.expect(jsonData).to.eql(\"poc2Patched\");\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata/keys/:key?elevate={{elevated}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata",
+														"keys",
+														":key"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														},
+														{
+															"key": "key",
+															"value": "{{metadataKey}}"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
+								{
 									"name": "Return a Collection",
 									"event": [
 										{
@@ -2469,6 +2717,251 @@
 						{
 							"name": "{asset Id}",
 							"item": [
+								{
+									"name": "metadata",
+									"item": [
+										{
+											"name": "Return the Metadata for an Asset",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"//&& user != \"collectioncreator\"\r",
+															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated), collectioncreator, or >= level 3\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for \" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"});\r",
+															"\r",
+															"\r",
+															"\r",
+															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"    let testMetadataKey = pm.environment.get(\"pocEmail\");\r",
+															"    let testMetadataValue = pm.environment.get(\"pocEmail@email.com\");\r",
+															"    pm.expect(jsonData[testMetadataKey]).to.eql(testMetadataValue);\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata?elevate={{elevated}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{testAsset}}"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Return the Metadata KEYS for an Asset",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200\", function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"pm.test(\"Response JSON is an array\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('array');\r",
+															"});\r",
+															"\r",
+															"\r",
+															"/*\r",
+															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"    pm.expect(jsonData).to.include(\"pocEmail\");\r",
+															"});\r",
+															"*/"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys?elevate={{elevated}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata",
+														"keys"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{testAsset}}"
+														}
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "Return the Metadata VALUE for an Asset metadata KEY",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"/*\r",
+															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for \" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"pm.test(\"Response JSON is an array\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('string');\r",
+															"});\r",
+															"\r",
+															"\r",
+															"\r",
+															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"    pm.expect(jsonData).to.eql(\"poc2Patched\");\r",
+															"});\r",
+															"*/"
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "GET",
+												"header": [],
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys/:key?elevate={{elevated}}",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata",
+														"keys",
+														":key"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{testAsset}}"
+														},
+														{
+															"key": "key",
+															"value": "{{metadataKey}}"
+														}
+													]
+												}
+											},
+											"response": []
+										}
+									]
+								},
 								{
 									"name": "stigs",
 									"item": [
@@ -7903,6 +8396,534 @@
 									]
 								},
 								{
+									"name": "metadata",
+									"item": [
+										{
+											"name": "Set all properties of a Collection- with metadata",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"    // pm.expect(jsonData).to.have.lengthOf.at.least(1);\r",
+															"    // pm.expect(jsonData).to.have.lengthOf(1);\r",
+															"\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n  \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n  \"workflow\": \"continuous\",\n    \"metadata\": {\n        \"{{metadataKey}}\":\"{{metadataValue}}\"\n    },\n    \"grants\": [\n        {\n          \"userId\": \"1\",\n          \"accessLevel\": 4\n        },\n        {\n                \"userId\": \"21\",\n            \"accessLevel\": 2\n        },\n        {\n                \"userId\": \"44\",\n            \"accessLevel\": 3\n        },\n        {\n                \"userId\": \"45\",\n            \"accessLevel\": 4\n        }\n    ]\n}"
+												},
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId?elevate={{elevated}}&projection=assets&projection=grants&projection=owners&projection=statistics&projection=stigs",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														},
+														{
+															"key": "projection",
+															"value": "assets",
+															"description": "Additional properties to include in the response.\n"
+														},
+														{
+															"key": "projection",
+															"value": "grants",
+															"description": "Additional properties to include in the response.\n"
+														},
+														{
+															"key": "projection",
+															"value": "owners"
+														},
+														{
+															"key": "projection",
+															"value": "statistics"
+														},
+														{
+															"key": "projection",
+															"value": "stigs"
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Set all metadata of a Collection",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"    // pm.expect(jsonData).to.have.lengthOf.at.least(1);\r",
+															"    // pm.expect(jsonData).to.have.lengthOf(1);\r",
+															"\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"{{testMetadataKey}}\":\"{{testMetadataValue}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Set one metadata key/value of a Collection",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 204 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(204);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 204) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "\"{{metadataValue}}\""
+												},
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata/keys/:key",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata",
+														"keys",
+														":key"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														},
+														{
+															"key": "key",
+															"value": "{{testMetadataKey}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Delete one metadata key/value of a Collection",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 204 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(204);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 204) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"\r",
+															"\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "\"{{metadataValue}}\""
+												},
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata/keys/:key",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata",
+														"keys",
+														":key"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														},
+														{
+															"key": "key",
+															"value": "{{testMetadataKey}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Merge metadata property/value into a Collection",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"    // pm.expect(jsonData).to.have.lengthOf.at.least(1);\r",
+															"    // pm.expect(jsonData).to.have.lengthOf(1);\r",
+															"\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"{{testMetadataKey}}\":\"{{metadataValue}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseUrl}}/collections/:collectionId/metadata",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"collections",
+														":collectionId",
+														"metadata"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "collectionId",
+															"value": "{{testCollection}}",
+															"description": "(Required) A path parameter that indentifies a Collection"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										}
+									]
+								},
+								{
 									"name": "Merge provided properties with a Collection",
 									"event": [
 										{
@@ -8643,6 +9664,519 @@
 									]
 								},
 								{
+									"name": "metadata",
+									"item": [
+										{
+											"name": "Set all properties of an Asset- with metadata",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"    // pm.expect(jsonData).to.have.lengthOf.at.least(1);\r",
+															"    // pm.expect(jsonData).to.have.lengthOf(1);\r",
+															"\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"{{metadataKey}}\":\"{{metadataValue}}\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}\n"
+												},
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId"
+													],
+													"query": [
+														{
+															"key": "elevate",
+															"value": "{{elevated}}"
+														},
+														{
+															"key": "projection",
+															"value": "adminStats"
+														},
+														{
+															"key": "projection",
+															"value": "stigs"
+														},
+														{
+															"key": "projection",
+															"value": "stigGrants"
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{scrapAsset}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Set all metadata of an Asset",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"    // pm.expect(jsonData).to.have.lengthOf.at.least(1);\r",
+															"    // pm.expect(jsonData).to.have.lengthOf(1);\r",
+															"\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"{{testMetadataKey}}\":\"{{testMetadataValue}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{scrapAsset}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Set one metadata key/value of an Asset",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator, lvl1, or lvl2\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 204 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(204);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 204) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PUT",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "\"{{metadataValue}}\""
+												},
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys/:key",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata",
+														"keys",
+														":key"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{scrapAsset}}"
+														},
+														{
+															"key": "key",
+															"value": "{{testMetadataKey}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Delete one metadata key/value of an Asset",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator, or lvl1, or lvl2\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 204 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(204);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 204) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"\r",
+															"\r",
+															"\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "DELETE",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "\"{{metadataValue}}\""
+												},
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata/keys/:key",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata",
+														"keys",
+														":key"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{scrapAsset}}"
+														},
+														{
+															"key": "key",
+															"value": "{{testMetadataKey}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										},
+										{
+											"name": "Merge metadata property/value into an Asset",
+											"event": [
+												{
+													"listen": "test",
+													"script": {
+														"exec": [
+															"let user = pm.environment.get(\"user\");\r",
+															"console.log(\"user: \" + user);\r",
+															"\r",
+															"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+															"    user = \"elevated\";\r",
+															"    console.log(\"setting user to 'elevated'\");\r",
+															"}\r",
+															"\r",
+															"if ( user == \"collectioncreator\" || user == \"lvl1\" || user ==\"lvl2\" ) { //placeholder for \"users\" that should fail\r",
+															"    pm.test(\"Status should be 403 for collectioncreator\", function () {\r",
+															"        pm.response.to.have.status(403);\r",
+															"    });\r",
+															"    return;\r",
+															"}\r",
+															"else {\r",
+															"    pm.test(\"Status code is 200 for all users but collectioncreator, lvl1, or lvl2. user=\" + user, function () {\r",
+															"        pm.response.to.have.status(200);\r",
+															"    });\r",
+															"}\r",
+															"\r",
+															"if (pm.response.code !== 200) {\r",
+															"    return;\r",
+															"}\r",
+															"\r",
+															"let jsonData = pm.response.json();\r",
+															"\r",
+															"\r",
+															"pm.test(\"Response JSON is an object\", function () {\r",
+															"    pm.expect(jsonData).to.be.an('object');\r",
+															"    // pm.expect(jsonData).to.have.lengthOf.at.least(1);\r",
+															"    // pm.expect(jsonData).to.have.lengthOf(1);\r",
+															"\r",
+															"});\r",
+															""
+														],
+														"type": "text/javascript"
+													}
+												}
+											],
+											"request": {
+												"method": "PATCH",
+												"header": [
+													{
+														"key": "Content-Type",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n    \"{{testMetadataKey}}\":\"{{metadataValue}}\"\n}"
+												},
+												"url": {
+													"raw": "{{baseUrl}}/assets/:assetId/metadata",
+													"host": [
+														"{{baseUrl}}"
+													],
+													"path": [
+														"assets",
+														":assetId",
+														"metadata"
+													],
+													"query": [
+														{
+															"key": "projection",
+															"value": "rule",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "history",
+															"description": "Additional properties to include in the response.\n",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "stigs",
+															"disabled": true
+														},
+														{
+															"key": "projection",
+															"value": "metadata",
+															"disabled": true
+														}
+													],
+													"variable": [
+														{
+															"key": "assetId",
+															"value": "{{scrapAsset}}"
+														}
+													]
+												},
+												"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+											},
+											"response": []
+										}
+									]
+								},
+								{
 									"name": "Merge provided properties with an Asset",
 									"event": [
 										{
@@ -8698,7 +10232,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
+											"raw": "{\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"pocName\": \"poc2Put\",\n        \"pocEmail\": \"pocEmailPut@email.com\",\n        \"pocPhone\": \"12342\",\n        \"reqRar\": \"true\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
@@ -8797,7 +10331,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
+											"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"pocName\": \"poc2Put\",\n        \"pocEmail\": \"pocEmailPut@email.com\",\n        \"pocPhone\": \"12342\",\n        \"reqRar\": \"true\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 										},
 										"url": {
 											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
@@ -8988,7 +10522,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\"\n    ]\n}"
+									"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"pocName\": \"poc2Put\",\n        \"pocEmail\": \"pocEmailPut@email.com\",\n        \"pocPhone\": \"12342\",\n        \"reqRar\": \"true\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\"\n    ]\n}"
 								},
 								"url": {
 									"raw": "{{baseUrl}}/assets?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
@@ -11974,7 +13508,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{baseUrl}}/stigs/ccis/:cci?projection=stigs&projection=references&projection=emassAp",
+									"raw": "{{baseUrl}}/stigs/ccis/:cci",
 									"host": [
 										"{{baseUrl}}"
 									],


### PR DESCRIPTION
resolves #316
note: the GETs asset tests have the checks for content comment out - since the assets metadata is {}. not sure how to get the column prepopulated. can discuss further.