### PR TITLE
Adds new review-history endpoints

### DIFF
--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -4,6 +4,7 @@ var writer = require('../utils/writer')
 var config = require('../utils/config')
 var Collection = require(`../service/${config.database.type}/CollectionService`)
 var Serialize = require(`../utils/serializers`)
+var Security = require('../utils/accessLevels')
 
 module.exports.createCollection = async function createCollection (req, res, next) {
   try {
@@ -320,16 +321,13 @@ module.exports.updateCollection = async function updateCollection (req, res, nex
 }
 
 
-
-async function getCollectionIdAndCheckPermission(request) {
+async function getCollectionIdAndCheckPermission(request, minimumAccessLevel = Security.ACCESS_LEVEL.Manage, allowElevate = false) {
   let collectionId = request.params.collectionId
   const elevate = request.query.elevate
   const collectionGrant = request.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
-
-  if (!( elevate || (collectionGrant && collectionGrant.accessLevel >= 3) )) {
+  if (!( (allowElevate && elevate) || (collectionGrant && collectionGrant.accessLevel >= minimumAccessLevel) )) {
     throw( {status: 403, message: "User has insufficient privilege to complete this request."} )
   }
-
   return collectionId
 }
 
@@ -424,3 +422,50 @@ module.exports.deleteCollectionMetadataKey = async function (req, res, next) {
   }  
 }
 
+
+
+module.exports.deleteReviewHistoryByCollection = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Manage)
+    const retentionDate = req.query.retentionDate
+    const assetId = req.query.assetId
+    let result = await Collection.deleteReviewHistoryByCollection(collectionId, retentionDate, assetId)
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.getReviewHistoryByCollection = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    const startDate = req.query.startDate
+    const endDate = req.query.endDate
+    const assetId = req.query.assetId
+    const ruleId = req.query.ruleId
+    const status = req.query.status
+      let result = await Collection.getReviewHistoryByCollection(collectionId, startDate, endDate, assetId, ruleId, status, req.userObject)
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}
+
+module.exports.getReviewHistoryStatsByCollection = async function (req, res, next) {
+  try {
+    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    const startDate = req.query.startDate
+    const endDate = req.query.endDate
+    const assetId = req.query.assetId
+    const ruleId = req.query.ruleId
+    const status = req.query.status
+    const projection = req.query.projection
+      let result = await Collection.getReviewHistoryStatsByCollection(collectionId, startDate, endDate, assetId, ruleId, status, projection, req.userObject)
+    res.json(result)
+  }
+  catch (err) {
+    next(err)
+  }  
+}

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -429,6 +429,7 @@ module.exports.deleteReviewHistoryByCollection = async function (req, res, next)
     let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Manage)
     const retentionDate = req.query.retentionDate
     const assetId = req.query.assetId
+    
     let result = await Collection.deleteReviewHistoryByCollection(collectionId, retentionDate, assetId)
     res.json(result)
   }
@@ -439,13 +440,14 @@ module.exports.deleteReviewHistoryByCollection = async function (req, res, next)
 
 module.exports.getReviewHistoryByCollection = async function (req, res, next) {
   try {
-    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Full)
     const startDate = req.query.startDate
     const endDate = req.query.endDate
     const assetId = req.query.assetId
     const ruleId = req.query.ruleId
     const status = req.query.status
-      let result = await Collection.getReviewHistoryByCollection(collectionId, startDate, endDate, assetId, ruleId, status, req.userObject)
+
+    let result = await Collection.getReviewHistoryByCollection(collectionId, startDate, endDate, assetId, ruleId, status)
     res.json(result)
   }
   catch (err) {
@@ -455,14 +457,15 @@ module.exports.getReviewHistoryByCollection = async function (req, res, next) {
 
 module.exports.getReviewHistoryStatsByCollection = async function (req, res, next) {
   try {
-    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    let collectionId = await getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Full)
     const startDate = req.query.startDate
     const endDate = req.query.endDate
     const assetId = req.query.assetId
     const ruleId = req.query.ruleId
     const status = req.query.status
     const projection = req.query.projection
-      let result = await Collection.getReviewHistoryStatsByCollection(collectionId, startDate, endDate, assetId, ruleId, status, projection, req.userObject)
+
+    let result = await Collection.getReviewHistoryStatsByCollection(collectionId, startDate, endDate, assetId, ruleId, status, projection)
     res.json(result)
   }
   catch (err) {

--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -1,6 +1,7 @@
 'use strict';
 const dbUtils = require('./utils')
 const config = require('../../utils/config.js')
+const Security = require('../utils/accessLevels')
 
 const _this = this
 
@@ -1079,4 +1080,250 @@ exports.deleteCollectionMetadataKey = async function ( collectionId, key ) {
   binds.push(`$."${key}"`, collectionId)
   let [rows] = await dbUtils.pool.query(sql, binds)
   return rows.length > 0 ? rows[0].value : ""
+}
+
+
+/*
+Available only to level 3 or 4 users ("Manage" or "Owner")
+Returns number of history entries deleted.
+RetentionDate - Delete all review history entries prior to the specified date.
+Asset Id - if provided, only delete entries for that asset.
+*/
+exports.deleteReviewHistoryByCollection = async function (collectionId, retentionDate, assetId) {
+  let sql = `
+    DELETE rh 
+    FROM review_history rh 
+      INNER JOIN review r on rh.reviewId = r.reviewId
+      INNER JOIN asset a on r.assetId = a.assetId
+    WHERE a.collectionId = :collectionId
+      AND rh.ts < :retentionDate`
+
+  if(assetId) {
+    sql += ' AND a.assetId = :assetId'
+  }
+
+  let binds = {
+    collectionId: collectionId,
+    retentionDate: retentionDate,
+    assetId: assetId
+  }  
+
+  let [rows] = await dbUtils.pool.query(sql, binds)
+  let result = {
+    HistoryEntriesDeleted: rows.affectedRows
+  }
+  return (result)
+}
+
+/*
+GET /collections/{collectionId}/review-history
+Available to all users with a grant to the collection. For level 1 users, only entries that fall under their Asset-STIG grants should be returned.
+Returns block of review history entries that fit criteria. Takes optional:
+Start Date
+End Date
+(If no dates provided, return all history. If only one date, return block from that date to current, or that date to oldest, as appropriate)
+Asset ID - only return history for this asset id
+Rule ID - only return history for this rule id
+status- only return history with this status
+If rule and asset id provided, return that intersection.
+*/
+exports.getReviewHistoryByCollection = async function (collectionId, startDate, endDate, assetId, ruleId, status, userObject) {
+  const level1User = userObject.collectionGrants.find( g => g.collection.collectionId === collectionId && g.collection.lvl1User)
+
+  let binds = {
+    collectionId: collectionId
+  }
+  
+  let sql = `
+    SELECT a.assetId, 
+      (select coalesce(
+        (select json_arrayagg(
+          json_object
+            (
+            'ruleId', rv.ruleId,
+            'ts', rh.ts, 
+            'resultId', rh.resultId,
+            'resultComment', rh.resultComment,
+            'actionId', rh.actionId,
+            'actionComment', rh.actionComment,
+            'autoResult', rh.autoResult = 1,
+            'statusId', rh.statusId,
+            'userId', rh.userId,
+            'username', ud.username,
+            'rejectText', rh.rejectText,
+            'rejectUserId', rh.rejectUserId
+            )
+          )
+          FROM review_history rh
+            INNER JOIN review rv on rh.reviewId = rv.reviewId
+            INNER JOIN user_data ud on rh.userId = ud.userId
+          WHERE rv.assetId = a.assetId`
+
+  if (startDate) {
+    binds.startDate = startDate
+    sql += " AND rh.ts >= :startDate"
+  }
+
+  if (endDate) {
+    binds.endDate = endDate
+    sql += " AND rh.ts <= :endDate"
+  }
+
+  if(ruleId) {
+    binds.ruleId = ruleId
+    sql += " AND rv.ruleId = :ruleId"
+  }
+
+  if(status) {
+    binds.statusId = dbUtils.REVIEW_STATUS_API[status]
+    sql += ' AND rh.statusId = :statusId'
+  }
+  
+  sql += `
+          ), json_array()
+        )
+      ) as history
+    FROM asset a
+    WHERE a.collectionId = :collectionId
+  `
+
+  if(assetId) {
+    binds.assetId = assetId
+    sql += " AND a.assetId = :assetId"
+  }
+
+  if(level1User) {
+    binds.level1User = userObject.userId
+    sql += ` 
+      AND a.assetId IN (
+        SELECT sam.assetId
+        FROM stig_asset_map sam
+          INNER JOIN user_stig_asset_map usam ON sam.saId = usam.saId
+        WHERE usam.userId = :level1User
+      )
+    `
+  }
+
+
+  try {
+    let [rows] = await dbUtils.pool.query(sql, binds)
+    for(const row of rows) {
+      for(const history of row.history) {
+
+        //Translate the numeric values from the database back to text since we don't have lookup tables for these.
+        history.result = Security.getKeyByValue(dbUtils.REVIEW_RESULT_API, history.resultId)
+        history.action = Security.getKeyByValue(dbUtils.REVIEW_ACTION_API, history.actionId)
+        history.status = Security.getKeyByValue(dbUtils.REVIEW_STATUS_API, history.statusId)
+  
+        // Remove the properties which have been translated to text.
+        delete history.resultId
+        delete history.actionId
+        delete history.statusId
+      }
+    }
+
+    return (rows)
+  }
+  catch(err) {
+    throw ( {status: 500, message: err.message, stack: err.stack} ) 
+  }
+}
+
+/*
+GET /collections/{collectionId}/review-history/stats
+Available to all users with a grant to the collection. For level 1 users, only entries that fall under their Asset-STIG grants should be returned.
+Return some simple stats about the number/properties of history entries.
+Uses same params as GET review-history, expecting stats to be scoped to whatever would be returned by that query.
+Projection: asset - Break out statistics by Asset in the specified collection
+*/
+exports.getReviewHistoryStatsByCollection = async function (collectionId, startDate, endDate, assetId, ruleId, status, projection, userObject) {
+  const level1User = userObject.collectionGrants.find( g => g.collection.collectionId === collectionId && g.collection.lvl1User)
+
+  let binds = {
+    collectionId: collectionId
+  }
+
+  let sql = 'SELECT COUNT(*) as collectionHistoryEntryCount, MIN(rh.ts) as oldestHistoryEntryDate'
+
+  if (projection && projection.includes('asset')) {
+    sql += `, coalesce(
+      (SELECT json_arrayagg(
+        json_object(
+          'assetId', assetId,
+          'historyEntryCount', historyEntryCount,
+          'oldestHistoryEntry', oldestHistoryEntry
+          )
+        )
+        FROM 
+        (
+          SELECT a.assetId, COUNT(*) as historyEntryCount, MIN(rh.ts) as oldestHistoryEntry
+          FROM review_history rh
+            INNER JOIN review rv on rh.reviewId = rv.reviewId
+            INNER JOIN asset a on rv.assetId = a.assetId
+          WHERE a.collectionId = :collectionId
+          additionalPredicates
+          GROUP BY a.assetId
+        ) v
+      ), json_array()
+      ) as assetHistoryEntryCounts`
+  }
+
+  sql += `
+    FROM review_history rh
+      INNER JOIN review rv on rh.reviewId = rv.reviewId
+      INNER JOIN asset a on rv.assetId = a.assetId
+    WHERE a.collectionId = :collectionId
+    additionalPredicates
+  `
+
+  let additionalPredicates = ""
+
+  if (startDate) {
+    binds.startDate = startDate
+    additionalPredicates += " AND rh.ts >= :startDate"
+  }
+
+  if (endDate) {
+    binds.endDate = endDate
+    additionalPredicates += " AND rh.ts <= :endDate"
+  }
+
+  if(ruleId) {
+    binds.ruleId = ruleId
+    additionalPredicates += " AND rv.ruleId = :ruleId"
+  }
+
+  if(status) {
+    binds.statusId = dbUtils.REVIEW_STATUS_API[status]
+    additionalPredicates += ' AND rh.statusId = :statusId'
+  }
+  
+  if(assetId) {
+    binds.assetId = assetId
+    additionalPredicates += " AND a.assetId = :assetId"
+  }
+
+  if(level1User) {
+    binds.level1User = userObject.userId
+    additionalPredicates += ` 
+      AND a.assetId IN (
+        SELECT sam.assetId
+        FROM stig_asset_map sam
+          INNER JOIN user_stig_asset_map usam ON sam.saId = usam.saId
+        WHERE usam.userId = :level1User
+      )
+    `
+  }
+
+  sql = sql.replace(/additionalPredicates/g, additionalPredicates)
+
+
+  try {
+    let [rows] = await dbUtils.pool.query(sql, binds)
+    return (rows[0])
+  }
+  catch(err) {
+    throw ( {status: 500, message: err.message, stack: err.stack} ) 
+  }
+
 }

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1646,6 +1646,93 @@ paths:
       security:
         - oauth:
             - 'stig-manager:collection'
+  '/collections/{collectionId}/review-history':
+    parameters:
+      - $ref: '#/components/parameters/CollectionIdPath'
+    get:
+      tags:
+        - Collection
+      summary: Return history records for the specified Collection that meet the specified criteria
+      operationId: getReviewHistoryByCollection
+      parameters: 
+        - $ref: '#/components/parameters/StartDateQuery' # Upper (most recent) bound of returned history entry timestamps
+        - $ref: '#/components/parameters/EndDateQuery'    # Lower (earliest) bound of returned history entry timestamps 
+        - $ref: '#/components/parameters/AssetIdQuery'  # return review history entries for just the specified assetId, if provided.
+        - $ref: '#/components/parameters/RuleIdQuery'  # return review history entries for just the specified RuleId, if provided.        
+        - $ref: '#/components/parameters/ReviewStatusQuery' # return review history entries with the specified status
+      responses:
+        '200':
+          description: ReviewHistory response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReviewHistoryAsset'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'
+    delete:
+      tags:
+        - Collection
+      summary: Remove history records that meet specified criteria
+      operationId: deleteReviewHistoryByCollection
+      parameters: 
+        - $ref: '#/components/parameters/RetentionDateQuery' # Review History Entries older than this date will be deleted.
+        - $ref: '#/components/parameters/AssetIdQuery'  # Apply operation to just the specified assetId, if provided.
+      responses:
+        '200':
+          description: Number of history records deleted.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReviewHistoryDeleted'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'            
+  '/collections/{collectionId}/review-history/stats':
+    parameters:
+      - $ref: '#/components/parameters/CollectionIdPath'
+    get:
+      tags:
+        - Collection
+      summary: Return history statistics for the specified Collection
+      operationId: getReviewHistoryStatsByCollection
+      parameters:
+        - $ref: '#/components/parameters/StartDateQuery' # Upper (most recent) bound of history entry timestamps
+        - $ref: '#/components/parameters/EndDateQuery'    # Lower (earliest) bound of history entry timestamps 
+        - $ref: '#/components/parameters/AssetIdQuery'  # return review history stats for just the specified assetId, if provided.
+        - $ref: '#/components/parameters/RuleIdQuery'  # return review history stats for just the specified RuleId, if provided.        
+        - $ref: '#/components/parameters/ReviewStatusQuery' # return review history stats with the specified status        
+        - $ref: '#/components/parameters/ReviewHistoryStatsProjectionQuery' 
+      responses:
+        '200':
+          description: ReviewHistoryStats response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReviewHistoryStats'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection:read'            
   '/collections/{collectionId}/status':
     parameters:
       - $ref: '#/components/parameters/CollectionIdPath'
@@ -3221,6 +3308,9 @@ components:
       enum:
         - continuous
         - emass
+    Date:
+      type: string
+      pattern: '^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1])$'        
     EmassAp:
       type: object
       properties:
@@ -3447,6 +3537,8 @@ components:
     ReviewHistory:
       type: object
       properties:
+        ruleId:
+          type: string        
         ts:
           type: string
         result:
@@ -3461,8 +3553,6 @@ components:
           nullable: true
         autoResult:
           type: boolean
-        metadata:
-          $ref: '#/components/schemas/Metadata'
         status:
           $ref: '#/components/schemas/ReviewStatus'
         userId:
@@ -3471,6 +3561,92 @@ components:
           type: string
         rejectText:
           type: string
+          nullable: true
+        rejectUserId:
+          type: string
+          nullable: true
+      required: 
+        - ts      
+        - result
+        - resultComment
+        - action
+        - actionComment 
+        - autoResult
+        - status
+        - userId         
+        - username
+        - rejectText
+    ReviewHistoryAsset:
+      type: object
+      properties:
+        assetId:
+          type: string
+        history:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReviewHistory'   
+      required: 
+        - assetId
+        - history
+    ReviewHistoryDeleted:     
+      type: object
+      properties:
+        HistoryEntriesDeleted: 
+          type: integer   
+    ReviewHistoryStat:
+      type: object
+      properties:
+        historyEntryCount: 
+          type: integer
+        oldestHistoryEntryDate: 
+          type: string
+    ReviewHistoryStats:
+      type: object
+      properties:
+        collectionHistoryEntryCount: 
+          type: integer
+        oldestHistoryEntryDate: 
+          type: string
+          nullable: true
+        assetHistoryEntryCounts:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReviewHistoryStatsAssetProjected'
+      required:
+        - collectionHistoryEntryCount
+        - oldestHistoryEntryDate
+    ReviewHistoryStatsAssetProjected:
+      type: object
+      properties:
+        assetId:
+          type: string
+        historyEntryCount:
+          type: integer
+        oldestHistoryEntry:
+          type: string
+          nullable: true
+        # ruleHistoryStats:
+        #   type: array
+        #   items:
+        #     $ref: '#/components/schemas/ReviewHistoryStatsAssetRuleProjected'
+      required: 
+        - assetId
+        - historyEntryCount
+        - oldestHistoryEntry
+    ReviewHistoryStatsAssetRuleProjected:
+      type: object
+      properties:
+        ruleId:
+          type: string
+        historyEntryCount:
+          type: integer
+        oldestHistoryEntry:
+          type: string
+          nullable: true
+      required: 
+        - ruleId
+        - historyEntryCount
+        - oldestHistoryEntry
     ReviewPut:
       type: object
       required:
@@ -3949,6 +4125,12 @@ components:
         enum:
           - continuous
           - emass
+    EndDateQuery:
+      name: endDate
+      in: query
+      description: History entries with a timestamp after the specified end date.
+      schema:
+        $ref: '#/components/schemas/Date'
     ElevateQuery:
       name: elevate
       in: query
@@ -4058,6 +4240,13 @@ components:
         enum:
           - ruleId
           - groupId
+    RetentionDateQuery:
+      name: retentionDate
+      in: query
+      description: Delete history entries with a timestamp earlier than the specified retention date.
+      required: true
+      schema:
+        $ref: '#/components/schemas/Date'
     ReviewActionQuery:
       name: action
       in: query
@@ -4079,6 +4268,19 @@ components:
             - rule
             - stigs
             - history
+    ReviewHistoryStatsProjectionQuery:
+      name: projection
+      in: query
+      description: |
+        Return review history statistics with the specified level of granularity.
+      style: form
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+            - asset
     ReviewsProjectionQuery:
       name: projection
       in: query
@@ -4164,6 +4366,12 @@ components:
             - ccis
             - checks
             - fixes
+    StartDateQuery:
+      name: startDate
+      in: query
+      description: History entries with a timestamp before the specified start date.
+      schema:
+        $ref: '#/components/schemas/Date'            
     StigAssetsProjectionQuery:
       name: projection
       in: query

--- a/api/source/utils/accessLevels.js
+++ b/api/source/utils/accessLevels.js
@@ -1,8 +1,3 @@
-
-// Needed to look up the property when retrieving the values from the database
-module.exports.getKeyByValue = (obj, value) => 
-        Object.keys(obj).find(key => obj[key] === value);
-
 module.exports.ACCESS_LEVEL = { 
     'Restricted': 1,
     'Full': 2,

--- a/api/source/utils/accessLevels.js
+++ b/api/source/utils/accessLevels.js
@@ -1,0 +1,11 @@
+
+// Needed to look up the property when retrieving the values from the database
+module.exports.getKeyByValue = (obj, value) => 
+        Object.keys(obj).find(key => obj[key] === value);
+
+module.exports.ACCESS_LEVEL = { 
+    'Restricted': 1,
+    'Full': 2,
+    'Manage': 3,
+    'Owner': 4
+}


### PR DESCRIPTION
resolves #331 
GET /collections/{collectionId}/review-history
Available to all users with a grant to the collection. For level 1 users, only entries that fall under their Asset-STIG grants should be returned.
Returns block of review history entries that fit criteria. Takes optional:
Start Date
End Date
(If no dates provided, return all history. If only one date, return block from that date to current, or that date to oldest, as appropriate)
Asset ID - only return history for this asset id
Rule ID - only return history for this rule id
status- only return history with this status
If rule and asset id provided, return that intersection.

DELETE /collections/{collectionId}/review-history
Available only to level 3 or 4 users ("Manage" or "Owner")
Returns number of history entries deleted.
RetentionDate - Delete all review history entries prior to the specified date.
Asset Id - if provided, only delete entries for that asset.

GET /collections/{collectionId}/review-history/stats
Available to all users with a grant to the collection. For level 1 users, only entries that fall under their Asset-STIG grants should be returned.
Return some simple stats about the number/properties of history entries.
Uses same params as GET review-history, expecting stats to be scoped to whatever would be returned by that query.
Projection: asset - Break out statistics by Asset in the specified collection