### PR TITLE
OAS, API, test, and UI for statusStats with rejectedCount, minTs, maxTs

### DIFF
--- a/api/source/service/mysql/AssetService.js
+++ b/api/source/service/mysql/AssetService.js
@@ -36,15 +36,18 @@ exports.queryAssets = async function (inProjection = [], inPredicates = {}, elev
     ]
 
     // PROJECTIONS
-    if (inProjection.includes('adminStats')) {
+    if (inProjection.includes('statusStats')) {
       columns.push(`json_object(
         'stigCount', COUNT(sa.benchmarkId),
         'stigAssignedCount', COUNT(distinct usa.saId),
         'ruleCount', SUM(cr.ruleCount),
         'acceptedCount', SUM(sa.acceptedManual) + SUM(sa.acceptedAuto),
+        'rejectedCount', SUM(sa.rejectedManual) + SUM(sa.rejectedAuto),
         'submittedCount', SUM(submittedManual) + SUM(submittedAuto),
-        'savedCount', SUM(savedManual) + SUM(savedAuto)
-        ) as "adminStats"`)
+        'savedCount', SUM(savedManual) + SUM(savedAuto),
+        'minTs', DATE_FORMAT(LEAST(MIN(minTs), MIN(maxTs)),'%Y-%m-%dT%H:%i:%sZ'),
+        'maxTs', DATE_FORMAT(GREATEST(MAX(minTs), MAX(maxTs)),'%Y-%m-%dT%H:%i:%sZ')
+        ) as "statusStats"`)
     }
     if (inProjection.includes('stigGrants')) {
       columns.push(`(select

--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -888,8 +888,11 @@ exports.getStigsByCollection = async function( collectionId, elevate, userObject
       'cr.ruleCount',
       'COUNT(a.assetId) as assetCount',
       'CAST(SUM(sa.acceptedManual) + SUM(sa.acceptedAuto) AS SIGNED) as acceptedCount',
+      'CAST(SUM(sa.rejectedManual) + SUM(sa.rejectedAuto) AS SIGNED) as rejectedCount',
       'CAST(SUM(sa.submittedManual) + SUM(sa.submittedAuto) AS SIGNED) as submittedCount',
-      'CAST(SUM(sa.savedManual) + SUM(sa.savedAuto) AS SIGNED) as savedCount'
+      'CAST(SUM(sa.savedManual) + SUM(sa.savedAuto) AS SIGNED) as savedCount',
+      `LEAST(MIN(minTs), MIN(maxTs)) as minTs`,
+      `GREATEST(MAX(minTs), MAX(maxTs)) as maxTs`
     ]
 
     let joins = [

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -2804,7 +2804,7 @@ components:
         - $ref: '#/components/schemas/Asset'
         - type: object
           properties:
-            adminStats:
+            statusStats:
               type: object
               properties:
                 stigCount:
@@ -2815,8 +2815,16 @@ components:
                   type: integer
                 acceptedCount:
                   type: integer
+                rejectedCount:
+                  type: integer
                 submittedCount:
                   type: integer
+                savedCount:
+                  type: integer
+                minTs:
+                  type: string
+                maxTs:
+                  type: string
             stigs:
               type: array
               description: The benchmarkIds mapped to this Asset
@@ -3303,6 +3311,11 @@ components:
           type: integer
         savedCount:
           type: integer
+        minTs:
+          type: string
+        maxTs:
+          type: string
+
     CollectionUpdate:
       additionalProperties: false
       type: object
@@ -4033,7 +4046,7 @@ components:
         items:
           type: string
           enum:
-            - adminStats
+            - statusStats
             - stigs
             - stigGrants
     BenchmarkIdPath:

--- a/clients/extjs/js/SM/CollectionAsset.js
+++ b/clients/extjs/js/SM/CollectionAsset.js
@@ -35,32 +35,42 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
             {
                 name: 'ruleCount',
                 type: 'integer',
-                mapping: 'adminStats.ruleCount'
+                mapping: 'statusStats.ruleCount'
             },
             {
                 name: 'stigCount',
                 type: 'integer',
-                mapping: 'adminStats.stigCount'
+                mapping: 'statusStats.stigCount'
             },
             {
                 name: 'savedPct',
                 type: 'integer',
-                convert: (v, r) => r.adminStats.ruleCount ? Math.round(((r.adminStats.savedCount + r.adminStats.submittedCount + r.adminStats.acceptedCount)/r.adminStats.ruleCount) * 100) : 0
+                convert: (v, r) => r.statusStats.ruleCount ? Math.round(((r.statusStats.savedCount + r.statusStats.submittedCount + r.statusStats.acceptedCount)/r.statusStats.ruleCount) * 100) : 0
             },
             {
                 name: 'submittedPct',
                 type: 'integer',
-                convert: (v, r) => r.adminStats.ruleCount ? Math.round(((r.adminStats.submittedCount + r.adminStats.acceptedCount)/r.adminStats.ruleCount) * 100) : 0
+                convert: (v, r) => r.statusStats.ruleCount ? Math.round(((r.statusStats.submittedCount + r.statusStats.acceptedCount)/r.statusStats.ruleCount) * 100) : 0
             },
             {
                 name: 'acceptedPct',
                 type: 'integer',
-                convert: (v, r) => r.adminStats.ruleCount ? Math.round((r.adminStats.acceptedCount/r.adminStats.ruleCount) * 100) : 0
+                convert: (v, r) => r.statusStats.ruleCount ? Math.round((r.statusStats.acceptedCount/r.statusStats.ruleCount) * 100) : 0
             },
             {
                 name: 'stigUnassignedCount',
                 type: 'integer',
-                convert: (v, r) => r.adminStats.stigCount - r.adminStats.stigAssignedCount
+                convert: (v, r) => r.statusStats.stigCount - r.statusStats.stigAssignedCount
+            },
+            {
+                name: 'minTs',
+                type: 'date',
+                mapping: 'statusStats.minTs'
+            },
+            {
+                name: 'maxTs',
+                type: 'date',
+                mapping: 'statusStats.maxTs'
             },
             {name: 'metadata'}
         ])
@@ -90,7 +100,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
             proxy: this.proxy,
             baseParams: {
                 collectionId: this.collectionId,
-                projection: ['adminStats']
+                projection: ['statusStats']
             },
             root: '',
             fields: fieldsConstructor,
@@ -300,7 +310,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                                           url: `${STIGMAN.Env.apiBase}/assets/${thisRecord.data.assetId}`,
                                           method: 'PATCH',
                                           params: {
-                                              projection: ['stigs', 'adminStats']
+                                              projection: ['stigs', 'statusStats']
                                           },
                                           jsonData: {
                                               collectionId: item.collectionId
@@ -904,7 +914,7 @@ async function showAssetProps( assetId, initialCollectionId ) {
                             url: url,
                             method: method,
                             params: {
-                                projection: ['stigs', 'adminStats']
+                                projection: ['stigs', 'statusStats']
                             },
                             headers: { 'Content-Type': 'application/json;charset=utf-8' },
                             jsonData: values

--- a/clients/extjs/js/SM/Exports.js
+++ b/clients/extjs/js/SM/Exports.js
@@ -55,12 +55,12 @@ SM.ExportsAssetTree = Ext.extend(Ext.tree.TreePanel, {
           method: 'GET',
           params: {
             collectionId: collectionId,
-            projection: 'adminStats'
+            projection: 'statusStats'
           }
         })
         let apiAssets = JSON.parse(result.response.responseText)
         let content = apiAssets.map(asset => {
-          const badgePercent = Math.round((asset.adminStats.acceptedCount / asset.adminStats.ruleCount) * 100)
+          const badgePercent = Math.round((asset.statusStats.acceptedCount / asset.statusStats.ruleCount) * 100)
           const badgeClass = badgePercent === 100 ? 'sm-export-sprite-low' : badgePercent >= 50 ? 'sm-export-sprite-medium' : 'sm-export-sprite-high'
           return {
             id: `${collectionId}-${asset.assetId}-assignment-assets-asset-node`,

--- a/clients/extjs/js/SM/ReviewsImport.js
+++ b/clients/extjs/js/SM/ReviewsImport.js
@@ -1710,7 +1710,7 @@ async function showImportResultFiles(collectionId, options) {
                                 url: `${STIGMAN.Env.apiBase}/assets/${assetId}`,
                                 method: 'GET',
                                 params: {
-                                    projection: ['stigs', 'adminStats']
+                                    projection: ['stigs', 'statusStats']
                                 },
                                 headers: { 'Content-Type': 'application/json;charset=utf-8' }
                             })
@@ -1772,7 +1772,7 @@ async function showImportResultFiles(collectionId, options) {
                         url: url,
                         method: method,
                         params: {
-                            projection: ['stigs', 'adminStats']
+                            projection: ['stigs', 'statusStats']
                         },
                         headers: { 'Content-Type': 'application/json;charset=utf-8' },
                         jsonData: jsonData

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -581,8 +581,11 @@
 															"    \"lastRevisionStr\",\r",
 															"    \"assetCount\",\r",
 															"    \"acceptedCount\",\r",
+															"    \"rejectedCount\",\r",
 															"    \"submittedCount\",\r",
-															"    \"savedCount\"\r",
+															"    \"savedCount\",\r",
+															"    \"minTs\",\r",
+															"    \"maxTs\"\r",
 															"]\r",
 															"\r",
 															"let validStigs = JSON.parse(pm.environment.get(\"stigs.valid\"));\r",
@@ -3300,18 +3303,21 @@
 													"    \"lastRevisionStr\"\r",
 													"]\r",
 													"\r",
-													"let adminStatsKeys = [\r",
+													"let statusStatsKeys = [\r",
 													"    \"acceptedCount\",\r",
+													"    \"rejectedCount\",\r",
 													"    \"submittedCount\",\r",
 													"    \"savedCount\",\r",
 													"    \"ruleCount\",\r",
 													"    \"stigCount\",\r",
-													"    \"stigAssignedCount\"\r",
+													"    \"stigAssignedCount\",\r",
+													"    \"minTs\",\r",
+													"    \"maxTs\"\r",
 													"]\r",
 													"\r",
 													"\r",
-													"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"    assetKeys.push(\"adminStats\")\r",
+													"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"    assetKeys.push(\"statusStats\")\r",
 													"}\r",
 													"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 													"    assetKeys.push(\"stigGrants\")\r",
@@ -3360,8 +3366,8 @@
 													"        }\r",
 													"    }\r",
 													"    \r",
-													"    if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"            pm.expect(jsonData.adminStats).to.have.all.keys(adminStatsKeys);\r",
+													"    if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"            pm.expect(jsonData.statusStats).to.have.all.keys(statusStatsKeys);\r",
 													"    }\r",
 													"\r",
 													"    // };\r",
@@ -3381,7 +3387,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -3397,7 +3403,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -3501,18 +3507,21 @@
 													"    \"lastRevisionStr\"\r",
 													"]\r",
 													"\r",
-													"let adminStatsKeys = [\r",
+													"let statusStatsKeys = [\r",
 													"    \"acceptedCount\",\r",
+													"    \"rejectedCount\",\r",
 													"    \"submittedCount\",\r",
 													"    \"savedCount\",\r",
 													"    \"ruleCount\",\r",
 													"    \"stigCount\",\r",
-													"    \"stigAssignedCount\"\r",
+													"    \"stigAssignedCount\",\r",
+													"    \"minTs\",\r",
+													"    \"maxTs\"\r",
 													"]\r",
 													"\r",
 													"\r",
-													"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"    assetKeys.push(\"adminStats\")\r",
+													"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"    assetKeys.push(\"statusStats\")\r",
 													"}\r",
 													"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 													"    assetKeys.push(\"stigGrants\")\r",
@@ -3561,8 +3570,8 @@
 													"        }\r",
 													"    }\r",
 													"    \r",
-													"    if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"            pm.expect(jsonData.adminStats).to.have.all.keys(adminStatsKeys);\r",
+													"    if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"            pm.expect(jsonData.statusStats).to.have.all.keys(statusStatsKeys);\r",
 													"    }\r",
 													"\r",
 													"    // };\r",
@@ -3582,7 +3591,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -3598,7 +3607,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -3702,18 +3711,21 @@
 													"    \"lastRevisionStr\"\r",
 													"]\r",
 													"\r",
-													"let adminStatsKeys = [\r",
+													"let statusStatsKeys = [\r",
 													"    \"acceptedCount\",\r",
+													"    \"rejectedCount\",\r",
 													"    \"submittedCount\",\r",
 													"    \"savedCount\",\r",
 													"    \"ruleCount\",\r",
 													"    \"stigCount\",\r",
-													"    \"stigAssignedCount\"\r",
+													"    \"stigAssignedCount\",\r",
+													"    \"minTs\",\r",
+													"    \"maxTs\"\r",
 													"]\r",
 													"\r",
 													"\r",
-													"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"    assetKeys.push(\"adminStats\")\r",
+													"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"    assetKeys.push(\"statusStats\")\r",
 													"}\r",
 													"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 													"    assetKeys.push(\"stigGrants\")\r",
@@ -3759,8 +3771,8 @@
 													"        }\r",
 													"    }\r",
 													"    \r",
-													"    if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"            pm.expect(jsonData.adminStats).to.have.all.keys(adminStatsKeys);\r",
+													"    if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"            pm.expect(jsonData.statusStats).to.have.all.keys(statusStatsKeys);\r",
 													"    }\r",
 													"\r",
 													"    // };\r",
@@ -3780,7 +3792,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -3796,7 +3808,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -3901,18 +3913,21 @@
 													"    \"lastRevisionStr\"\r",
 													"]\r",
 													"\r",
-													"let adminStatsKeys = [\r",
+													"let statusStatsKeys = [\r",
 													"    \"acceptedCount\",\r",
+													"    \"rejectedCount\",\r",
 													"    \"submittedCount\",\r",
 													"    \"savedCount\",\r",
 													"    \"ruleCount\",\r",
 													"    \"stigCount\",\r",
-													"    \"stigAssignedCount\"\r",
+													"    \"stigAssignedCount\",\r",
+													"    \"minTs\",\r",
+													"    \"maxTs\"\r",
 													"]\r",
 													"\r",
 													"\r",
-													"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"    assetKeys.push(\"adminStats\")\r",
+													"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"    assetKeys.push(\"statusStats\")\r",
 													"}\r",
 													"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 													"    assetKeys.push(\"stigGrants\")\r",
@@ -3958,8 +3973,8 @@
 													"        }\r",
 													"    }\r",
 													"    \r",
-													"    if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-													"            pm.expect(jsonData.adminStats).to.have.all.keys(adminStatsKeys);\r",
+													"    if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+													"            pm.expect(jsonData.statusStats).to.have.all.keys(statusStatsKeys);\r",
 													"    }\r",
 													"\r",
 													"    // };\r",
@@ -3979,7 +3994,7 @@
 										"method": "GET",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -3995,7 +4010,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -4744,13 +4759,16 @@
 											"    \"users\"\r",
 											"]\r",
 											"\r",
-											"let adminStatsKeys = [\r",
+											"let statusStatsKeys = [\r",
 											"    \"acceptedCount\",\r",
+											"    \"rejectedCount\",\r",
 											"    \"submittedCount\",\r",
 											"    \"savedCount\",\r",
 											"    \"ruleCount\",\r",
 											"    \"stigCount\",\r",
-											"    \"stigAssignedCount\"\r",
+											"    \"stigAssignedCount\",\r",
+											"    \"minTs\",\r",
+											"    \"maxTs\"\r",
 											"]\r",
 											"let userBasicKeys = [\r",
 											"    // \"user\",\r",
@@ -4762,8 +4780,8 @@
 											"if (pm.request.url.getQueryString().match(/projection=stigs/)) {\r",
 											"    assetKeys.push(\"stigs\")\r",
 											"}\r",
-											"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-											"    assetKeys.push(\"adminStats\")\r",
+											"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+											"    assetKeys.push(\"statusStats\")\r",
 											"}\r",
 											"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 											"    assetKeys.push(\"stigGrants\")\r",
@@ -4782,8 +4800,8 @@
 											"        pm.expect(asset.collection).to.have.all.keys(collectionKeys);\r",
 											"\r",
 											"\r",
-											"        if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-											"            pm.expect(asset.adminStats).to.have.all.keys(adminStatsKeys);\r",
+											"        if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+											"            pm.expect(asset.statusStats).to.have.all.keys(statusStatsKeys);\r",
 											"        }\r",
 											"\r",
 											"        if (pm.request.url.getQueryString().match(/projection=stigs/)) {\r",
@@ -4861,7 +4879,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}&benchmarkId={{testBenchmark}}&elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+									"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}&benchmarkId={{testBenchmark}}&elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -4886,7 +4904,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -4972,13 +4990,16 @@
 											"    \"users\"\r",
 											"]\r",
 											"\r",
-											"let adminStatsKeys = [\r",
+											"let statusStatsKeys = [\r",
 											"    \"acceptedCount\",\r",
+											"    \"rejectedCount\",\r",
 											"    \"submittedCount\",\r",
 											"    \"savedCount\",\r",
 											"    \"ruleCount\",\r",
 											"    \"stigCount\",\r",
-											"    \"stigAssignedCount\"\r",
+											"    \"stigAssignedCount\",\r",
+											"    \"minTs\",\r",
+											"    \"maxTs\"\r",
 											"]\r",
 											"let userBasicKeys = [\r",
 											"    // \"user\",\r",
@@ -4990,8 +5011,8 @@
 											"if (pm.request.url.getQueryString().match(/projection=stigs/)) {\r",
 											"    assetKeys.push(\"stigs\")\r",
 											"}\r",
-											"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-											"    assetKeys.push(\"adminStats\")\r",
+											"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+											"    assetKeys.push(\"statusStats\")\r",
 											"}\r",
 											"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 											"    assetKeys.push(\"stigGrants\")\r",
@@ -5010,8 +5031,8 @@
 											"        pm.expect(asset.collection).to.have.all.keys(collectionKeys);\r",
 											"\r",
 											"\r",
-											"        if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-											"            pm.expect(asset.adminStats).to.have.all.keys(adminStatsKeys);\r",
+											"        if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+											"            pm.expect(asset.statusStats).to.have.all.keys(statusStatsKeys);\r",
 											"        }\r",
 											"\r",
 											"        if (pm.request.url.getQueryString().match(/projection=stigs/)) {\r",
@@ -5091,7 +5112,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}&benchmarkId={{testBenchmark}}&elevate={{elevated}}&projection=adminStats&projection=stigs",
+									"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}&benchmarkId={{testBenchmark}}&elevate={{elevated}}&projection=statusStats&projection=stigs",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -5116,7 +5137,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -5203,13 +5224,16 @@
 											"    \"users\"\r",
 											"]\r",
 											"\r",
-											"let adminStatsKeys = [\r",
+											"let statusStatsKeys = [\r",
 											"    \"acceptedCount\",\r",
+											"    \"rejectedCount\",\r",
 											"    \"submittedCount\",\r",
 											"    \"savedCount\",\r",
 											"    \"ruleCount\",\r",
 											"    \"stigCount\",\r",
-											"    \"stigAssignedCount\"\r",
+											"    \"stigAssignedCount\",\r",
+											"    \"minTs\",\r",
+											"    \"maxTs\"\r",
 											"]\r",
 											"let userBasicKeys = [\r",
 											"    // \"user\",\r",
@@ -5221,8 +5245,8 @@
 											"if (pm.request.url.getQueryString().match(/projection=stigs/)) {\r",
 											"    assetKeys.push(\"stigs\")\r",
 											"}\r",
-											"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-											"    assetKeys.push(\"adminStats\")\r",
+											"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+											"    assetKeys.push(\"statusStats\")\r",
 											"}\r",
 											"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 											"    assetKeys.push(\"stigGrants\")\r",
@@ -5242,8 +5266,8 @@
 											"        pm.expect(asset.collection).to.have.all.keys(collectionKeys);\r",
 											"\r",
 											"\r",
-											"        if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-											"            pm.expect(asset.adminStats).to.have.all.keys(adminStatsKeys);\r",
+											"        if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+											"            pm.expect(asset.statusStats).to.have.all.keys(statusStatsKeys);\r",
 											"        }\r",
 											"\r",
 											"        if (pm.request.url.getQueryString().match(/projection=stigs/)) {\r",
@@ -5335,7 +5359,7 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}&elevate={{elevated}}&projection=adminStats&projection=stigs",
+									"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}&elevate={{elevated}}&projection=statusStats&projection=stigs",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -5361,7 +5385,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -10145,7 +10169,7 @@
 													"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"{{metadataKey}}\":\"{{metadataValue}}\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}\n"
 												},
 												"url": {
-													"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+													"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 													"host": [
 														"{{baseUrl}}"
 													],
@@ -10160,7 +10184,7 @@
 														},
 														{
 															"key": "projection",
-															"value": "adminStats"
+															"value": "statusStats"
 														},
 														{
 															"key": "projection",
@@ -10655,7 +10679,7 @@
 											"raw": "{\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"pocName\": \"poc2Put\",\n        \"pocEmail\": \"pocEmailPut@email.com\",\n        \"pocPhone\": \"12342\",\n        \"reqRar\": \"true\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 										},
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -10671,7 +10695,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -10754,7 +10778,7 @@
 											"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"pocName\": \"poc2Put\",\n        \"pocEmail\": \"pocEmailPut@email.com\",\n        \"pocPhone\": \"12342\",\n        \"reqRar\": \"true\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 										},
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -10770,7 +10794,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -10844,7 +10868,7 @@
 										"method": "DELETE",
 										"header": [],
 										"url": {
-											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+											"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 											"host": [
 												"{{baseUrl}}"
 											],
@@ -10860,7 +10884,7 @@
 												},
 												{
 													"key": "projection",
-													"value": "adminStats",
+													"value": "statusStats",
 													"description": "Additional properties to include in the response.\n"
 												},
 												{
@@ -10945,7 +10969,7 @@
 									"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {\n        \"pocName\": \"poc2Put\",\n        \"pocEmail\": \"pocEmailPut@email.com\",\n        \"pocPhone\": \"12342\",\n        \"reqRar\": \"true\"\n    },\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\"\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/assets?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+									"raw": "{{baseUrl}}/assets?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -10960,7 +10984,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -12942,7 +12966,7 @@
 									"raw": "{\n    \"collectionId\": \"{{scrapLvl1}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -12958,7 +12982,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -13061,7 +13085,7 @@
 									"raw": "{\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -13077,7 +13101,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -13254,7 +13278,7 @@
 									"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapLvl1}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -13270,7 +13294,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -13370,7 +13394,7 @@
 									"raw": "{\n    \"name\": \"TEST_{{$randomNoun}}-{{$randomJobType}}\",\n    \"collectionId\": \"{{scrapCollection}}\",\n    \"description\": \"test desc\",\n    \"ip\": \"1.1.1.1\",\n    \"noncomputing\": true,\n    \"metadata\": {},\n    \"stigs\": [\n        \"VPN_SRG\",\n        \"Windows_10_STIG\",\n        \"RHEL_7_STIG\"\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=adminStats&projection=stigs&projection=stigGrants",
+									"raw": "{{baseUrl}}/assets/:assetId?elevate={{elevated}}&projection=statusStats&projection=stigs&projection=stigGrants",
 									"host": [
 										"{{baseUrl}}"
 									],
@@ -13386,7 +13410,7 @@
 										},
 										{
 											"key": "projection",
-											"value": "adminStats",
+											"value": "statusStats",
 											"description": "Additional properties to include in the response.\n"
 										},
 										{
@@ -15338,8 +15362,11 @@
 									"    \"lastRevisionStr\",\r",
 									"    \"assetCount\",\r",
 									"    \"acceptedCount\",\r",
+									"    \"rejectedCount\",\r",
 									"    \"submittedCount\",\r",
-									"    \"savedCount\"\r",
+									"    \"savedCount\",\r",
+									"    \"minTs\",\r",
+									"    \"maxTs\"\r",
 									"]\r",
 									"\r",
 									"let validStigs = JSON.parse(pm.environment.get(\"stigs.valid\"));\r",
@@ -15473,18 +15500,21 @@
 									"    \"lastRevisionStr\"\r",
 									"]\r",
 									"\r",
-									"let adminStatsKeys = [\r",
+									"let statusStatsKeys = [\r",
 									"    \"ruleCount\",\r",
 									"    \"stigCount\",\r",
 									"    \"stigAssignedCount\",\r",
 									"    \"savedCount\",\r",
 									"    \"acceptedCount\",\r",
-									"    \"submittedCount\"\r",
-									"]\r",
+									"    \"rejectedCount\",\r",
+									"    \"submittedCount\",\r",
+									"    \"minTs\",\r",
+									"    \"maxTs\"\r",
+							"]\r",
 									"\r",
 									"\r",
-									"if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-									"    assetKeys.push(\"adminStats\")\r",
+									"if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+									"    assetKeys.push(\"statusStats\")\r",
 									"}\r",
 									"if (pm.request.url.getQueryString().match(/projection=stigGrants/)) {\r",
 									"    assetKeys.push(\"stigGrants\")\r",
@@ -15526,15 +15556,15 @@
 									"        }\r",
 									"    }\r",
 									"    \r",
-									"    if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
-									"            pm.expect(jsonData.adminStats).to.have.all.keys(adminStatsKeys);\r",
+									"    if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
+									"            pm.expect(jsonData.statusStats).to.have.all.keys(statusStatsKeys);\r",
 									"\r",
 									"    }\r",
 									"\r",
-									"    if (pm.request.url.getQueryString().match(/projection=adminStats/)) {\r",
+									"    if (pm.request.url.getQueryString().match(/projection=statusStats/)) {\r",
 									"            //check for proper adminStat counts for lvl1 user\r",
-									"            pm.expect(jsonData.adminStats.ruleCount).to.equal(81);\r",
-									"            pm.expect(jsonData.adminStats.submittedCount).to.equal(5);\r",
+									"            pm.expect(jsonData.statusStats.ruleCount).to.equal(81);\r",
+									"            pm.expect(jsonData.statusStats.submittedCount).to.equal(5);\r",
 									"    }\r",
 									"    // };\r",
 									"\r",
@@ -15553,7 +15583,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/assets/:assetId?projection=adminStats&projection=stigs",
+							"raw": "{{baseUrl}}/assets/:assetId?projection=statusStats&projection=stigs",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -15570,7 +15600,7 @@
 								},
 								{
 									"key": "projection",
-									"value": "adminStats",
+									"value": "statusStats",
 									"description": "Additional properties to include in the response.\n"
 								},
 								{
@@ -15627,7 +15657,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/assets/:assetId?projection=adminStats&projection=stigs",
+							"raw": "{{baseUrl}}/assets/:assetId?projection=statusStats&projection=stigs",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -15644,7 +15674,7 @@
 								},
 								{
 									"key": "projection",
-									"value": "adminStats",
+									"value": "statusStats",
 									"description": "Additional properties to include in the response.\n"
 								},
 								{


### PR DESCRIPTION
Resolves #438

`adminStats` projection of `GET /assets` and `GET /assets/{assetId}` changed to `statusStats` and includes `rejectedCount`, `minTs` and `maxTs`

Added `rejectedCount`, `minTs` and `maxTs` to object returned by `GET /collections/{collectionId}/stigs`

