### PR TITLE
feat: experimental CORS proxy for OIDC

### DIFF
--- a/api/source/index.js
+++ b/api/source/index.js
@@ -39,8 +39,9 @@ const upload = multer({
   }
  })
 app.use(upload.single('importFile'))
+app.use(express.urlencoded( {extended: true}))
 app.use(express.json({
-  strict: false, // allow root to be any JSON value, per https://datatracker.ietf.org/doc/html/rfc7159#section-2
+    strict: false, // allow root to be any JSON value, per https://datatracker.ietf.org/doc/html/rfc7159#section-2
   limit: parseInt(config.http.maxJsonBody)
 })) //Handle JSON request body
 app.use(cors())

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1936,6 +1936,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiConfiguration'
+  "/op/cors-proxy/oidc/.well-known/openid-configuration":
+    get:
+      tags:
+        - Operation
+      summary: Proxy a request to the OIDC provider's openid-configuration endpoint
+      operationId: getOidcConfiguration
+      security: []
+      responses:
+        '200':
+          description: Configuration response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OidcConfiguration'
+  "/op/cors-proxy/oidc/token":
+    post:
+      tags:
+        - Operation
+      summary: Proxy a request to the OIDC provider's token_endpoint
+      operationId: postOidcToken
+      security: []
+      requestBody:
+        description: Optional description in *Markdown*
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+                type: object
+      responses:
+        '200':
+          description: Token response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OidcToken'
   /op/definition:
     get:
       tags:
@@ -1947,12 +1982,11 @@ paths:
         - $ref: '#/components/parameters/JsonPathQuery'
       responses:
         '200':
-          description: Configuration response
+          description: Definition response
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiDefinition'
-      
   /stigs:
     get:
       tags:
@@ -3475,6 +3509,17 @@ components:
       type: string
     MetadataValue:
       type: string
+    OidcConfiguration:
+      type: object
+      properties:
+        authorization_endpoint:
+          type: string
+        end_session_endpoint:
+          type: string
+        token_endpoint:
+          type: string
+    OidcToken:
+      type: object
     Review:
       type: object
       properties:

--- a/api/source/utils/auth.js
+++ b/api/source/utils/auth.js
@@ -135,6 +135,8 @@ function initializeAuth() {
                         if (!openidConfig.jwks_uri) {
                             throw( new Error('[AUTH] No jwks_uri property found') )
                         }
+                        // store tokenEndpoint for use by the CORS proxy
+                        config.oauth.tokenEndpoint = openidConfig.token_endpoint
                         jwksUri = openidConfig.jwks_uri
                         client = jwksClient({
                             jwksUri: jwksUri

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -111,7 +111,8 @@ let config = {
             name: process.env.STIGMAN_JWT_NAME_CLAIM || process.env.STIGMAN_JWT_USERNAME_CLAIM || "name",
             privileges: formatChain(process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || process.env.STIGMAN_JWT_ROLES_CLAIM || "realm_access.roles"),
             email: process.env.STIGMAN_JWT_EMAIL_CLAIM || "email"
-        }
+        },
+        proxyHost: process.env.STIGMAN_OIDC_PROXY_HOST
     }
 }
 


### PR DESCRIPTION
The CORS proxy feature is experimental for use by deployments unable to control their OIDC Provider's CORS policy. The web client (UI) is configured to use the CORS proxy by setting:
```
STIGMAN_CLIENT_OIDC_PROVIDER = "api/op/cors-proxy/oidc"
```
The CORS proxy forwards incoming requests to the OIDC Provider configured by `STIGMAN_OIDC_PROVIDER`

Adds endpoints:
```
/op/cors-proxy/oidc/.well-known/openid-configuration
/op/cors-proxy/oidc/token
```
Adds optional envvar:
STIGMAN_OIDC_PROXY_HOST: **No default** The `Host:` header value to be used by the CORS proxy for outbound requests. Some OIDC providers return configuration metadata with endpoint URLs having this value as their base.

