### PR TITLE
feat: Welcome message enhancements

### DIFF
--- a/api/source/index.js
+++ b/api/source/index.js
@@ -155,7 +155,9 @@ const STIGMAN = {
     apiBase: "${config.client.apiBase}",
     welcome: {
       image: "${config.client.welcome.image}",
-      message: "${config.client.welcome.message}"
+      title: "${config.client.welcome.title}",
+      message: "${config.client.welcome.message}",
+      link: "${config.client.welcome.link}"
     },
     commit: {
         branch: "${config.commit.branch}",

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -63,7 +63,9 @@ let config = {
         },
         welcome: {
             image: process.env.STIGMAN_CLIENT_WELCOME_IMAGE || "",
-            message: process.env.STIGMAN_CLIENT_WELCOME_MESSAGE || ""
+            message: process.env.STIGMAN_CLIENT_WELCOME_MESSAGE || "",
+            title: process.env.STIGMAN_CLIENT_WELCOME_TITLE || "",
+            link: process.env.STIGMAN_CLIENT_WELCOME_LINK || ""
         }
     },
     docs: {

--- a/clients/extjs/js/SM/MainPanel.js
+++ b/clients/extjs/js/SM/MainPanel.js
@@ -98,8 +98,8 @@ SM.WelcomeWidget = Ext.extend(Ext.Panel, {
           `</div>`, 
           `<div class='sm-home-widget-text'>`,
             `<div class='sm-home-widget-subtitle'>${STIGMAN.Env.welcome.title ? Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.title) : STIGMAN.Env.welcome.message || STIGMAN.Env.welcome.link ? 'Support' : ''}</div>`,
-            `${Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.message)}`,
-            `${STIGMAN.Env.welcome.link ? '<br><br><a href="' + STIGMAN.Env.welcome.link + '">' + STIGMAN.Env.welcome.link  + '</a>': ''}`,
+            `${Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.message)}${STIGMAN.Env.welcome.message && STIGMAN.Env.welcome.link ? '<br><br>' : ''}`,
+            `${STIGMAN.Env.welcome.link ? '<a href="' + STIGMAN.Env.welcome.link + '">' + STIGMAN.Env.welcome.link  + '</a>': ''}`,
           `</div>`
 
         )

--- a/clients/extjs/js/SM/MainPanel.js
+++ b/clients/extjs/js/SM/MainPanel.js
@@ -97,7 +97,9 @@ SM.WelcomeWidget = Ext.extend(Ext.Panel, {
             `<b>STIG Manager</b> is an API and Web client for managing the assessment of Information Systems for compliance with <a href="https://public.cyber.mil/stigs/">security checklists</a> published by the United States Defense Information Systems Agency (DISA). The software is <a target="_blank" href="https://github.com/NUWCDIVNPT/stig-manager">an open source project</a> maintained by the Naval Sea Systems Command (NAVSEA) of the United States Navy.`,
           `</div>`, 
           `<div class='sm-home-widget-text'>`,
-            `${STIGMAN.Env.welcome.message}`,
+            `<div class='sm-home-widget-subtitle'>${STIGMAN.Env.welcome.title ? Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.title) : "Support"}</div>`,
+            `${Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.message)}`,
+            `${STIGMAN.Env.welcome.link ? '<br><br><a href="' + STIGMAN.Env.welcome.link + '">' + STIGMAN.Env.welcome.link  + '</a>': ''}`,
           `</div>`
 
         )

--- a/clients/extjs/js/SM/MainPanel.js
+++ b/clients/extjs/js/SM/MainPanel.js
@@ -97,7 +97,7 @@ SM.WelcomeWidget = Ext.extend(Ext.Panel, {
             `<b>STIG Manager</b> is an API and Web client for managing the assessment of Information Systems for compliance with <a href="https://public.cyber.mil/stigs/">security checklists</a> published by the United States Defense Information Systems Agency (DISA). The software is <a target="_blank" href="https://github.com/NUWCDIVNPT/stig-manager">an open source project</a> maintained by the Naval Sea Systems Command (NAVSEA) of the United States Navy.`,
           `</div>`, 
           `<div class='sm-home-widget-text'>`,
-            `<div class='sm-home-widget-subtitle'>${STIGMAN.Env.welcome.title ? Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.title) : "Support"}</div>`,
+            `<div class='sm-home-widget-subtitle'>${STIGMAN.Env.welcome.title ? Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.title) : STIGMAN.Env.welcome.message || STIGMAN.Env.welcome.link ? 'Support' : ''}</div>`,
             `${Ext.util.Format.htmlEncode(STIGMAN.Env.welcome.message)}`,
             `${STIGMAN.Env.welcome.link ? '<br><br><a href="' + STIGMAN.Env.welcome.link + '">' + STIGMAN.Env.welcome.link  + '</a>': ''}`,
           `</div>`


### PR DESCRIPTION
Removes support for rendering HTML in `STIGMAN_CLIENT_WELCOME_MESSAGE`.

Adds envvars:
`STIGMAN_CLIENT_WELCOME_TITLE` **Default: "Support"** The title for the custom Welcome message.
`STIGMAN_CLIENT_WELCOME_LINK` **No default** The value of the optional anchor tag following the custom Welcome message.