### PR TITLE
fix: encode office query param

### DIFF
--- a/clients/extjs/js/SM/FindingsPanel.js
+++ b/clients/extjs/js/SM/FindingsPanel.js
@@ -589,6 +589,7 @@ SM.RequestAndServePoam = async function ( collectionId, params ) {
 	let mb
 	try {
 		mb = Ext.MessageBox.wait('Generating POA&M')
+		params.office = encodeURIComponent(params.office)
 		const search = new URLSearchParams(params).toString()
 		let url = `${STIGMAN.Env.apiBase}/collections/${collectionId}/poam?${search}`
 	


### PR DESCRIPTION
Fixes #437