### PR TITLE
fix: allowReserved for office query param

### DIFF
--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1063,6 +1063,7 @@ paths:
           in: query
           schema:
             type: string
+          allowReserved: true
         - name: status
           description: Value for column Status
           in: query

--- a/clients/extjs/js/SM/FindingsPanel.js
+++ b/clients/extjs/js/SM/FindingsPanel.js
@@ -590,7 +590,6 @@ SM.RequestAndServePoam = async function ( collectionId, params ) {
 	let mb
 	try {
 		mb = Ext.MessageBox.wait('Generating POA&M')
-		params.office = encodeURIComponent(params.office)
 		const search = new URLSearchParams(params).toString()
 		let url = `${STIGMAN.Env.apiBase}/collections/${collectionId}/poam?${search}`
 	


### PR DESCRIPTION
Revert changes from #466 and implement using `allowReserved` OAS property