### PR TITLE
chore: bump release to 1.0.41

### DIFF
--- a/.github/workflows/pub-docker-ib.yml
+++ b/.github/workflows/pub-docker-ib.yml
@@ -52,14 +52,14 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: |
-            BASE_IMAGE=registry1.dso.mil/ironbank/opensource/nodejs/nodejs14:latest
+            BASE_IMAGE=registry1.dso.mil/ironbank/opensource/nodejs/nodejs16:latest
             COMMIT_BRANCH=${{ steps.prep.outputs.branch }}
             COMMIT_SHA=${{ github.sha }}
             COMMIT_TAG=${{ steps.prep.outputs.tag }}
             COMMIT_DESCRIBE=${{ steps.prep.outputs.describe }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
-            stig-manager.last-migration.mysql=1.0.0-beta.35
+            stig-manager.last-migration.mysql=1.0.0-beta.39
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}
             org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}

--- a/.github/workflows/pub-docker.yml
+++ b/.github/workflows/pub-docker.yml
@@ -52,7 +52,7 @@ jobs:
             COMMIT_DESCRIBE=${{ steps.prep.outputs.describe }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
-            stig-manager.last-migration.mysql=1.0.0-beta.35
+            stig-manager.last-migration.mysql=1.0.0-beta.39
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}
             org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}
@@ -121,14 +121,14 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: |
-            BASE_IMAGE=registry1.dso.mil/ironbank/opensource/nodejs/nodejs14:latest
+            BASE_IMAGE=registry1.dso.mil/ironbank/opensource/nodejs/nodejs16:latest
             COMMIT_BRANCH=${{ steps.prep.outputs.branch }}
             COMMIT_SHA=${{ github.sha }}
             COMMIT_TAG=${{ steps.prep.outputs.tag }}
             COMMIT_DESCRIBE=${{ steps.prep.outputs.describe }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
-            stig-manager.last-migration.mysql=1.0.0-beta.35
+            stig-manager.last-migration.mysql=1.0.0-beta.39
             org.opencontainers.image.title=${{ fromJson(steps.repo.outputs.result).name }}
             org.opencontainers.image.description=${{ fromJson(steps.repo.outputs.result).description }}
             org.opencontainers.image.url=${{ fromJson(steps.repo.outputs.result).html_url }}

--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.0.40",
+      "version": "1.0.41",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.0",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/docs/_build/html/_sources/the-project/DockerHub_Readme.md.txt
+++ b/docs/_build/html/_sources/the-project/DockerHub_Readme.md.txt
@@ -9,9 +9,9 @@ STIG Manager is an API and Web client for managing the assessment of Information
 **Source:** [https://github.com/NUWCDIVNPT/stig-manager](https://github.com/NUWCDIVNPT/stig-manager)
 
 ## Supported tags
-- From the `node:lts-alpine` base image (the default if no tag is provided)
+- From the latest `node:lts-alpine` base image (the default if no tag is provided)
   - `latest`, `latest-alpine`
-- From the [Iron Bank Node.js base image](https://repo1.dso.mil/dsop/opensource/nodejs/nodejs14/)
+- From the latest [Iron Bank Node.js LTS base image](https://repo1.dso.mil/dsop/opensource/nodejs/)
   - `latest-ironbank`
 
 In addition, we provide a limited selection of releases tagged as *`release`*`[-`*`distro`*`]`, where `distro` defauts to `alpine`. For example, `1.0.40` or `1.0.40-ironbank`

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,13 @@
+1.0.41
+------
+fix: filter grid on asset name (#498)
+feat: UI support for STIG/revision delete (#491)
+refactor: unhandled rejections (#490)
+doc: Additional documentation updates, links. (#489)
+doc: Added project security policy, security docs, docker trust public key, stigman sample .ckl (#486)
+feat: choice to export mono- or multi-STIG CKLs (#480)
+refactor: await _migrations table (#476)
+
 1.0.40
 ------
 fix: allowReserved for office query param (#474)


### PR DESCRIPTION
fix: filter grid on asset name (#498)
feat: UI support for STIG/revision delete (#491)
refactor: unhandled rejections (#490)
doc: Additional documentation updates, links. (#489)
doc: Added project security policy, security docs, docker trust public key, stigman sample .ckl (#486)
feat: choice to export mono- or multi-STIG CKLs (#480)
refactor: await _migrations table (#476)
