### PR TITLE
hotfix: bump release to 1.2.2

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "async-retry": "^1.3.1",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,11 @@
+1.2.2
+-----
+Changes:
+- Fix a UI regresssion that incorrectly hides the "Accept" button and disables the "Reject" feature
+
+Commits:
+- fix: accept button incorrectly hidden (#571)
+
 1.2.1
 -----
 Changes:

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,10 +1,18 @@
 1.2.2
 -----
 Changes:
+
 - Fix a UI regresssion that incorrectly hides the "Accept" button and disables the "Reject" feature
+- The experimental AppData feature now supports Review history items
 
 Commits:
+
 - fix: accept button incorrectly hidden (#571)
+- feat: include review history in appdata export/import (#562)
+- remove: CORS proxy for OIDC (#558)
+- refactor: fetchStig/Scap logging (#557)
+- chore: Build updates (#556) 
+- doc: remove videos from source and build
 
 1.2.1
 -----


### PR DESCRIPTION
Hotfix release to fix a UI regresssion that incorrectly hides the "Accept" button and disables the "Reject" feature