### PR TITLE
chore: bump release to 1.2.3

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "async-retry": "^1.3.1",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,19 @@
+1.2.3
+-----
+
+Changes:
+
+  - (App) Trim white space from exported CSV values
+  - (API) Include request body when logging at level 4
+  - (App) Corrected web app logic for XCCDF imports
+
+Commits:
+
+- a93f6fe fix: web app xccdf import logic (#582)
+- 22cbfe7 feat: log request body when logLevel = 4 (#581)
+- 4319979 feat: ExportButton trims values (#576)
+
+
 1.2.2
 -----
 Changes:


### PR DESCRIPTION
Changes:

  - (App) Trim white space from exported CSV values
  - (API) Include request body when logging at level 4
  - (App) Corrected web app logic for XCCDF imports

Commits:

- a93f6fe fix: web app xccdf import logic (#582)
- 22cbfe7 feat: log request body when logLevel = 4 (#581)
- 4319979 feat: ExportButton trims values (#576)
