### PR TITLE
chore: bump release to 1.2.4

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "async-retry": "^1.3.1",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,22 @@
+1.2.4
+-----
+
+Changes:
+
+- (API/App) Endpoint and UI for deployment-wide usage statistics
+- (App) CKL export fixes
+- (App) Changed incorrectly named column headers on the Collection Manage workspace
+- (API/App) Require a compliance result (pass, fail, notapplicable) to submit a Review
+- (Docs) Updates regarding "submit" status requirements
+  
+Commits:
+
+- 8f0905f docs: updates regarding "submit" status requirements (#595)
+- 86a9890 fix: require a compliance result to submit review (#594)
+- b506920 fix: headers don't match API (#592)
+- 0c7ecf5 fix: CKL export fails to include all rules (#591)
+- 98025ce feat: endpoint and ui for /op/details (#570)
+
 1.2.3
 -----
 


### PR DESCRIPTION
1.2.4
-----

Changes:

- (API/App) Endpoint and UI for deployment-wide usage statistics
- (App) CKL export fixes
- (App) Changed incorrectly named column headers on the Collection Manage workspace
- (API/App) Require a compliance result (pass, fail, notapplicable) to submit a Review
- (Docs) Updates regarding "submit" status requirements
  
Commits:

- 8f0905f docs: updates regarding "submit" status requirements (#595)
- 86a9890 fix: require a compliance result to submit review (#594)
- b506920 fix: headers don't match API (#592)
- 0c7ecf5 fix: CKL export fails to include all rules (#591)
- 98025ce feat: endpoint and ui for /op/details (#570)
