### PR TITLE
chore: bump release to 1.2.6

### DIFF
--- a/api/launchers/stig-manager.sh
+++ b/api/launchers/stig-manager.sh
@@ -129,7 +129,7 @@
 #
 #  Affects: Client Appearance
 #==============================================================================
-# export STIGMAN_CLIENT_WELCOME_IMAGE =
+# export STIGMAN_CLIENT_WELCOME_IMAGE=
 
 #==============================================================================
 # STIGMAN_CLIENT_WELCOME_LINK
@@ -148,7 +148,7 @@
 #
 #  Affects: Client Appearance     
 #==============================================================================
-# export STIGMAN_CLIENT_WELCOME_MESSAGE =
+# export STIGMAN_CLIENT_WELCOME_MESSAGE=
 
 #==============================================================================
 # STIGMAN_CLIENT_WELCOME_TITLE 
@@ -158,7 +158,7 @@
 #
 #  Affects: Client Appearance
 #==============================================================================
-# export STIGMAN_CLIENT_WELCOME_TITLE =
+# export STIGMAN_CLIENT_WELCOME_TITLE=
 
 #==============================================================================
 # STIGMAN_DB_HOST

--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "MIT",
       "dependencies": {
         "async-retry": "^1.3.1",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/client/src/js/SM/CollectionForm.js
+++ b/client/src/js/SM/CollectionForm.js
@@ -1589,7 +1589,7 @@ SM.Collection.LabelArrayTpl = new Ext.XTemplate(
     '</tpl>'
 )
 SM.Collection.LabelEditTpl = new Ext.XTemplate(
-    '<span class=sm-label-sprite style="color:{[SM.getContrastYIQ(values.color)]};background-color:#{color};">{[SM.he(values.name)]}</span><img class="sm-label-edit-color" src="../img/color-picker.svg" width="12" height="12">'
+    '<span class=sm-label-sprite style="color:{[SM.getContrastYIQ(values.color)]};background-color:#{color};">{[SM.he(values.name)]}</span><img class="sm-label-edit-color" src="img/color-picker.svg" width="12" height="12">'
 )
 
 

--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -185,12 +185,6 @@ SM.CollectionNodeConfig = function (collection) {
     const toolsEl = areSomeLabelsInUse ? '<img class="sm-tree-toolbar" src="img/label.svg" width="12" height="12">' : ''
     return `${name} ${labelSpans} ${toolsEl}`
   }
-  function formatTextAndLabelsAndToolbar({name, labels}) {
-    return `${SM.he(name)} ${SM.Collection.LabelArrayTpl.apply(labels)} <img class="sm-tree-toolbar" src="../img/label.svg" width="12" height="12">`
-  }
-  function formatToolbar () {
-
-  }
   const labelsMenu = new SM.Collection.LabelsMenu({
     labels: collection.labels,
     showHeader: true,

--- a/docs/the-project/DockerHub_Readme.md
+++ b/docs/the-project/DockerHub_Readme.md
@@ -1,10 +1,8 @@
 # STIG Manager OSS on Docker Hub
 
-*This is pre-release software and the Docker images are made available for pilot testing only*
-
 STIG Manager is an API and Web client for managing the assessment of Information Systems for compliance with [security checklists](https://public.cyber.mil/stigs/) published by the United States (U.S.) Defense Information Systems Agency (DISA). STIG Manager supports DISA checklists [distributed](https://public.cyber.mil/stigs/downloads/) as either a Security Technical Implementation Guide (STIG) or a Security Requirements Guide (SRG).
 
-**Documentation:** [https://nuwcdivnpt.github.io/stig-manager](https://stig-manager.readthedocs.io/en/latest/)
+**Documentation:** [https://stig-manager.readthedocs.io/en/latest/](https://stig-manager.readthedocs.io/en/latest/)
 
 **Source:** [https://github.com/NUWCDIVNPT/stig-manager](https://github.com/NUWCDIVNPT/stig-manager)
 
@@ -65,12 +63,12 @@ services:
 ```
 $ docker-compose up -d && docker-compose logs -f
 ```
-- On initial container startup, STIG Manager will connect to [DoD Cyber Exchange](https://public.cyber.mil) and import the latest STIG Library Compilation and any available SCAP content.
-- When all the services have started, STIG Manager will output:
+- STIG Manager will wait for MySQL and Keycloak to become ready
+- When MySQL is ready, STIG Manager will perform an initial migration and create the necessary schema objects.
+- STIG Manager will then connect to [DoD Cyber Exchange](https://public.cyber.mil) and import the latest STIG Library Compilation and any available SCAP content.
+- When STIG Manager is ready to handle requests, it will output a JSON log entry similar to:
 ```
-Server is listening on port 54000
-API is available at /api
-Client is available at /
+{"date":"2022-02-18T18:25:50.749Z","level":3,"component":"index","type":"started","data":{"durationS":0.956811184,"port":"54000","api":"/api","client":"/","documentation":"/docs","swagger":"/api-docs"}}
 ```
 - Navigate to ```http://localhost:54000```
 - Login using credentials "admin/password", as documented for [the demonstration Keycloak image](https://hub.docker.com/r/nuwcdivnpt/stig-manager-auth)
@@ -78,7 +76,7 @@ Client is available at /
 
 ## STIG Manager OSS Environment Variables
 
-Refer to our documentation for the [environment variables consumed by STIG Manager](https://nuwcdivnpt.github.io/stig-manager/#/Environment_Variables) 
+Refer to our documentation for the [environment variables consumed by STIG Manager](https://stig-manager.readthedocs.io/en/latest/installation-and-setup/environment-variables.html) 
 
 ## STIG Manager Container Healthcheck
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,18 @@
+1.2.6
+-----
+
+Changes:
+
+  - (App) Rows in the Status and Finding report link to the corresponding Review tabs
+  - (API/App) CKL filenames contain the STIG revision string
+  - (App) Ensure the Label icon in the NavTree displays in all deployments
+
+Commits:
+
+  - 3ad3f21 fix: modify path to label.svg in NavTree (#626)
+  - 17c4705 fix: provide specific revision string in suggested filename, in place of "latest" (#623)
+  - ec8ebde feat: dblclick on a Status/Finding row opens the corresponding Review tab (#616)
+
 1.2.5
 -----
 ​


### PR DESCRIPTION
Includes:
- an update to the Docker Hub README
- a correction to the path for `img/color-picker.svg`
- minor corrections to the API's Linux build script