### PR TITLE
docs: include stub html directory

### DIFF
--- a/docs/_build/html/.gitignore
+++ b/docs/_build/html/.gitignore
@@ -1,4 +1,4 @@
-## Directory for the STIG Manager Sphinx documentation build
+## Directory for the STIG Manager Sphinx documentation HTML files
 
 # Content can be written here by executing:
 # $ ../build.sh
@@ -8,6 +8,5 @@
 # Ignore everything in this directory
 *
 
-# Except this file and the html directory
-!html
+# Except this file
 !.gitignore


### PR DESCRIPTION
Docker builds will fail when `docs/_build/html` does not exist. This path was incorrectly removed by [62011d8](https://github.com/NUWCDIVNPT/stig-manager/commit/62011d851b7c0771cb3b1f3abce4e5554f44a07b). This commit stubs out the necessary path.