### PR TITLE
feat: widen columns; default to groupId/ruleTitle

### DIFF
--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -7,6 +7,9 @@
 .x-menu-item-checked .x-menu-item-icon {
 	background-position: -24px 0px;
 }
+.x-menu-group-item .x-menu-item-icon {
+	background-image: none
+}
 .x-tree-node {
 	margin-bottom: 2px;
 	font-size: 11px;


### PR DESCRIPTION
Resolves #636 

- In the Collection/STIG Review checklist grid, the columns that count O, NF, NA, and NR were expanded to accommodate up to 4 digits. These columns remain fixed width and are not re-sizable by the user.
- In both the Asset/STIG Review and Collection/STIG Review checklist grids, the default visible columns were changed from "Group ID and Group Title" to "Group ID and Rule Title". This more closely reflects the observed preferences of many users.