### PR TITLE
fix: Initial adjustments to OAS and API to bring the two into alignment.

### DIFF
--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -18,8 +18,7 @@ exports.queryCollections = async function (inProjection = [], inPredicates = {},
       'c.name',
       'c.description',
       'c.settings',
-      'c.metadata',
-      'c.created'
+      'c.metadata'
     ]
     let joins = [
       'collection c',

--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -18,7 +18,8 @@ exports.queryCollections = async function (inProjection = [], inPredicates = {},
       'c.name',
       'c.description',
       'c.settings',
-      'c.metadata'
+      'c.metadata',
+      'c.created'
     ]
     let joins = [
       'collection c',
@@ -293,6 +294,7 @@ exports.queryFindings = async function (aggregator, inProjection = [], inPredica
     columns.push(`cast(concat('[', group_concat(distinct json_object (
       'ruleId', ru.ruleId,
       'title', ru.title,
+      'version', ru.version,
       'severity', ru.severity) order by ru.ruleId), ']') as json) as "rules"`)
   }
   if (inProjection.includes('groups')) {

--- a/api/source/service/mysql/STIGService.js
+++ b/api/source/service/mysql/STIGService.js
@@ -223,7 +223,7 @@ exports.queryBenchmarkRules = async function ( benchmarkId, revisionStr, inProje
           json_object(
             'cci', rc.cci,
             'apAcronym', cci.apAcronym,
-            'control',  cr.indexDisa
+            'definition',  cci.definition
           )
         ) 
         from
@@ -356,7 +356,7 @@ exports.queryRules = async function ( ruleId, inProjection ) {
           json_object(
             'cci', rc.cci,
             'apAcronym', cci.apAcronym,
-            'control',  cr.indexDisa
+            'definition',  cci.definition
           )
         ) 
         from

--- a/api/source/service/mysql/STIGService.js
+++ b/api/source/service/mysql/STIGService.js
@@ -186,7 +186,6 @@ exports.queryBenchmarkRules = async function ( benchmarkId, revisionStr, inProje
   // PROJECTIONS
   if ( inProjection && inProjection.includes('detail') ) {
     columns.push(`json_object(
-      'version', r.version,
       'weight', r.weight,
       'vulnDiscussion', r.vulnDiscussion,
       'falsePositives', r.falsePositives,
@@ -1331,7 +1330,7 @@ exports.getRevisionByString = async function(benchmarkId, revisionStr, userObjec
     `SELECT
       ${ro.table_alias}.benchmarkId,
       concat('V', ${ro.table_alias}.version, 'R', ${ro.table_alias}.release) as "revisionStr",
-      ${ro.table_alias}.version,
+      cast(${ro.table_alias}.version as char) as version,
       ${ro.table_alias}.release,
       date_format(${ro.table_alias}.benchmarkDateSql,'%Y-%m-%d') as "benchmarkDate",
       ${ro.table_alias}.status,
@@ -1370,7 +1369,7 @@ exports.getRevisionsByBenchmarkId = async function(benchmarkId, userObject) {
     `SELECT
       r.benchmarkId,
       concat('V', r.version, 'R', r.release) as "revisionStr",
-      r.version,
+      CAST(r.version as char) as version,
       r.release,
       date_format(r.benchmarkDateSql,'%Y-%m-%d') as "benchmarkDate",
       r.status,

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -3075,6 +3075,8 @@ components:
           type: array
           items:
             type: string
+    BenchmarkId:
+        type: string           
     Cci:
       type: object
       additionalProperties: false
@@ -3114,6 +3116,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CciReferenceRev4'
+    CciBasicArrayItem:
+      type: object
+      additionalProperties: false
+      properties:
+        cci:
+          type: string
+        apAcronym:
+          type: string
+        control:
+          type: string
+        definition:
+          type: string          
     CciListItem:
       type: object
       additionalProperties: false
@@ -3800,28 +3814,49 @@ components:
       type: object
       additionalProperties: false
       properties:
+        assetCount:
+          type: integer
         ruleId:
-          type: string
-        ruleTitle:
-          type: string
+          type: string      
         groupId:
           type: string
+        cci:
+          type: string
+        title:
+          type: string
+        definition:
+          type: string              
         groupTitle:
           type: string
+        apAcronym:
+          type: string          
         severity:
           $ref: '#/components/schemas/RuleSeverity'
-        ccis:
-          type: array
-          items:
-            $ref: '#/components/schemas/CciBasic'
-        benchmarkIds:
-          type: array
-          items:
-            type: string
+
+        # benchmarkIds:
+        #   type: array
+        #   items:
+        #     type: string
         assets:
           type: array
           items:
             $ref: '#/components/schemas/AssetBasic'
+        ccis:
+          type: array
+          items:
+            $ref: '#/components/schemas/CciBasicArrayItem'            
+        groups:
+          type: array
+          items:
+            $ref: '#/components/schemas/GroupProjected'
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuleAbbr'      
+        stigs:
+          type: array
+          items:
+            $ref: '#/components/schemas/BenchmarkId'                              
     Fix:
       type: object
       additionalProperties: false
@@ -3838,6 +3873,8 @@ components:
           type: string
         title:
           type: string
+        severity:
+          type: string          
         rules:
             type: array
             items:
@@ -4453,7 +4490,7 @@ components:
             mitigations:
               type: string
               nullable: true
-            securityOverrideGuidance:
+            severityOverrideGuidance:
               type: string
               nullable: true
             potentialImpacts:
@@ -4471,7 +4508,7 @@ components:
         ccis:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/CciBasicArrayItem'
         checks:
           type: array
           items:

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -3110,24 +3110,10 @@ components:
       properties:
         cci:
           type: string
-        emassAp:
-          type: string
-        controls:
-          type: array
-          items:
-            $ref: '#/components/schemas/CciReferenceRev4'
-    CciBasicArrayItem:
-      type: object
-      additionalProperties: false
-      properties:
-        cci:
-          type: string
         apAcronym:
           type: string
-        control:
-          type: string
         definition:
-          type: string          
+          type: string
     CciListItem:
       type: object
       additionalProperties: false
@@ -3518,7 +3504,6 @@ components:
         - description
         - settings
         - metadata
-        - created    
       additionalProperties: false
       properties:
         collectionId:
@@ -3534,9 +3519,6 @@ components:
           $ref: '#/components/schemas/CollectionSettings'
         metadata:
           $ref: '#/components/schemas/Metadata'
-        created:
-          type: string
-          format: date-time    
         assets:
           type: array
           items:
@@ -3567,7 +3549,6 @@ components:
         - description
         - settings
         - metadata
-        - created     
       additionalProperties: false
       properties:
         collectionId:
@@ -3583,9 +3564,6 @@ components:
           $ref: '#/components/schemas/CollectionSettings'
         metadata:
           $ref: '#/components/schemas/Metadata'
-        created:
-          type: string
-          format: date-time    
         owners:
           type: array
           items:
@@ -3826,17 +3804,10 @@ components:
           type: string
         definition:
           type: string              
-        groupTitle:
-          type: string
         apAcronym:
           type: string          
         severity:
           $ref: '#/components/schemas/RuleSeverity'
-
-        # benchmarkIds:
-        #   type: array
-        #   items:
-        #     type: string
         assets:
           type: array
           items:
@@ -3844,7 +3815,7 @@ components:
         ccis:
           type: array
           items:
-            $ref: '#/components/schemas/CciBasicArrayItem'            
+            $ref: '#/components/schemas/CciBasic'            
         groups:
           type: array
           items:
@@ -4508,7 +4479,7 @@ components:
         ccis:
           type: array
           items:
-            $ref: '#/components/schemas/CciBasicArrayItem'
+            $ref: '#/components/schemas/CciBasic'
         checks:
           type: array
           items:

--- a/api/source/utils/auth.js
+++ b/api/source/utils/auth.js
@@ -27,7 +27,8 @@ const verifyRequest = async function (req, requiredScopes, securityDefinition) {
         req.bearer = token
         req.userObject = {
             username: decoded[config.oauth.claims.username] || decoded[config.oauth.claims.servicename] || 'null',
-            display: decoded[config.oauth.claims.name] || decoded[config.oauth.claims.username] || decoded[config.oauth.claims.servicename] || 'USER'
+            displayName: decoded[config.oauth.claims.name] || decoded[config.oauth.claims.username] || decoded[config.oauth.claims.servicename] || 'USER',
+            email: decoded[config.oauth.claims.email] ||  'None Provided'
         }
 
         let grantedScopes = decoded[config.oauth.claims.scope]?.split(' ')

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "89cd345d-b482-4b65-b68f-d4a5a7e27a5f",
+		"_postman_id": "0895f99a-ad58-45ff-8d4b-5b7b55103e61",
 		"name": "STIGMan OSS",
 		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:\n Name: Carl Smigielski\n Email: carl.a.smigielski@saic.com",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -13439,6 +13439,9 @@
 											"console.log(\"requestToTest: \" + JSON.stringify(requestToTest));\r",
 											"\r",
 											"\r",
+											"// created now being returned, but don't know what value it will be.\r",
+											"// response validation will verify that the property exists.\r",
+											"delete respJson.created;\r",
 											"\r",
 											"pm.test(\"Response matches request\", function () {\r",
 											"    pm.expect(collectionGetToPost(respJson))\r",


### PR DESCRIPTION
Adjustments to OAS/API to bring the two into alignment.

**OAS**:
(Changes to OAS are to match what API is currently returning, to avoid issues in Clients at this time.)
**New schemas:** 
- BenchmarkId

**changed:**

- Findings Projected (this endpoint can return objects with many different structures/properties):
> **added**:
> assetCount
> cci
> title
> definition
> apAcronym
> groups
> rules
> stigs
> **removed**:
> ruleTitle
> groupTitle

- CciBasic:
> **added**:
> definition
> **removed**:
> control

- GroupProjected:
> **added**:
> severity

- RuleProjected:
> changed securityOverrideGuidance to severityOverrideGuidance

**API**:
(Most changes are to add data or change types so they match OAS spec. Avoid changing property names to avoid client issues)
**auth.js**:
added "email" to userObject and changed "display" to "displayName"

**CollectionService**:
queryFindings:
- Added rule version to response object for rules projection

**StigService**:
queryBenchmarkRules:
- added "version" to STIG detail projection response

getRevisionByString and getRevisionsByBenchmarkId:
- return version as string, rather than integer

**userService**: 
queryUsers:
- added displayName and email to response
- adjusted time format in response to statistics projection