### PR TITLE
fix: further OAS/API reconciliation.

### DIFF
--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -1096,7 +1096,7 @@ from
 		rv.ruleId, 
 		json_arrayagg(
 		  json_object(
-        'ts', rh.ts,
+        'ts', DATE_FORMAT(rh.ts, '%Y-%m-%dT%TZ'),
         'result', result.api,
         'detail', rh.detail,
         'comment', rh.comment,
@@ -1112,7 +1112,8 @@ from
         ),        
         'userId', CAST(rh.userId as char),
         'username', ud.username,
-        'touchTs', rh.touchTs
+        'touchTs', DATE_FORMAT(rh.touchTs, '%Y-%m-%dT%TZ')
+
         )
 		) as 'history'
 	FROM

--- a/api/source/service/mysql/STIGService.js
+++ b/api/source/service/mysql/STIGService.js
@@ -319,7 +319,6 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   // PROJECTIONS
   if ( inProjection && inProjection.includes('detail') ) {
     columns.push(`json_object(
-      'version', r.version,
       'weight', r.weight,
       'vulnDiscussion', r.vulnDiscussion,
       'falsePositives', r.falsePositives,

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1148,6 +1148,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReviewAssetRuleRead'
+        '204':
+          description: The requested resource has no content.            
         default:
           description: unexpected error
           content:
@@ -1481,8 +1483,6 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
                   $ref: '#/components/schemas/Label'
         default:
           description: unexpected error
@@ -1587,7 +1587,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/String255'
+                  $ref: '#/components/schemas/AssetBasic'
         default:
           description: unexpected error
           content:
@@ -2140,7 +2140,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/STIG'
+                $ref: '#/components/schemas/STIGPostResponse'
         default:
           description: unexpected error
           content:
@@ -2613,7 +2613,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/UserProjected'
         default:
           description: unexpected error
           content:
@@ -2889,6 +2889,12 @@ components:
           type: string
         name:
           type: string
+        collectionId:
+          type: string  #This is redundant except when in response to a request that changed an Asset's collection. 
+        assetLabelIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/LabelId'          
         restrictedUserAccess:
           type: array
           items:
@@ -3166,6 +3172,8 @@ components:
       type: object
       additionalProperties: false  
       properties:
+        assetId:
+          type: string
         ruleId:
           type: string
         ruleTitle:
@@ -3593,6 +3601,10 @@ components:
           type: string
         assetName:
           type: string
+        assetLabelIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/LabelId'          
         benchmarkId:
           type: string
         minTs:
@@ -3754,18 +3766,25 @@ components:
           type: string
         tableRows:
           type: integer
+          nullable: true
         tableCollation:
           type: string
+          nullable: true
         avgRowLength:
           type: integer
+          nullable: true
         dataLength:
           type: integer
+          nullable: true
         maxDataLength:
           type: integer
+          nullable: true
         indexLength:
           type: integer
+          nullable: true
         autoIncrement:
           type: integer
+          nullable: true
         createTime:
           $ref: '#/components/schemas/StringDateTimeNullable'
         updateTime:
@@ -3782,12 +3801,14 @@ components:
         assessmentProcedure:
           type: string
     Error:
-      required:
-        - message
       type: object
       properties:
         message:
           type: string
+        error:
+          type: string
+        detail:
+          type: string          
     FindingProjected:
       type: object
       additionalProperties: false
@@ -3911,6 +3932,7 @@ components:
     ResultEngine:
       type: object
       additionalProperties: false
+      nullable: true
       properties:
         type:
           $ref: '#/components/schemas/ResultEngineType'
@@ -3933,6 +3955,7 @@ components:
     ResultEngineCheckContent:
       type: object
       additionalProperties: false
+      nullable: true
       properties:
         location:
           $ref: '#/components/schemas/String255'
@@ -4328,6 +4351,10 @@ components:
           $ref: '#/components/schemas/StringUuid'
         assetName:
           $ref: '#/components/schemas/String255'
+        assetLabelIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/LabelId'              
         ruleId:
           $ref: '#/components/schemas/String255'
         result:
@@ -4534,6 +4561,8 @@ components:
           items:
            type: string
            pattern: ^V\d+R\d+(\.\d+)?$     
+    STIGPostResponse:
+      type: object
     StigAsset:
       type: object
       required:

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -2882,7 +2882,6 @@ components:
       required:
         - assetId
         - name
-        - restrictedUserAccess
       additionalProperties: false
       properties:
         assetId:

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1453,7 +1453,7 @@ paths:
             schema:
               $ref: '#/components/schemas/LabelCreate'
       responses:
-        200:
+        201:
           description: Label response
           content:
             application/json:
@@ -3803,8 +3803,6 @@ components:
     Error:
       type: object
       properties:
-        message:
-          type: string
         error:
           type: string
         detail:


### PR DESCRIPTION
resolves: #496 
**OAS**:

'/collections/{collectionId}/reviews/{assetId}/{ruleId}':
  - added 204 response
 
'/collections/{collectionId}/labels':
  - POST - changed response code from 200 to 201

'/collections/{collectionId}/labels/{labelId}':
- removed "array" type as this returns a single labels info.

'/collections/{collectionId}/labels/{labelId}/assets':
- PUT - changed response to array of AssetBasic, rather than strings

/stigs:
- POST - added STIGPostResponse since this endpoint returns very free-form progress info (for now)
    STIGPostResponse:
      type: object

/user
- changed schema to UserProjected, rather than just User.

Schemas:
- AssetBasicProjected:
> added:
>         collectionId:
>           type: string  #This is redundant except when in response to a request that changed an Asset's collection. 
>         assetLabelIds:
>           type: array
>           items:
>             $ref: '#/components/schemas/LabelId'         	
			
- ChecklistAssetStig
> added:
>     assetId:
> 	 type: string
				
- CollectionStatus
> added:
>     assetLabelIds:
>         type: array
>         items:
>         $ref: '#/components/schemas/LabelId'     
			
- DetailMySqlTableInfo:
> made properties nullable, as they are all null for Views that are included in response. 
			
- Error:
> added:
> 	error:
> 	  type: string
> 	detail:
> 	  type: string      
> removed:
> 	  message

	  
**API**:
CollectionService:
	- Added some date formatting to history responses
STIGService:
	- removed "Version" from rule detail, as it is part of the default object.