### PR TITLE
refactor: token handling for Azure AD and Okta

### DIFF
--- a/api/launchers/stig-manager.bat
+++ b/api/launchers/stig-manager.bat
@@ -83,7 +83,8 @@
 ::
 ::  | No default. | OAuth2 scopes to request in addition to "stig-manager:stig"
 ::  "stig-manager:stig:read" "stig-manager:collection" "stig-manager:user"
-::  "stig-manager:user:read" "stig-manager:op"
+::  "stig-manager:user:read" "stig-manager:op". Some OIDC providers (Okta)
+::  generate a refresh token only if the scope "offline_access" is requested
 ::
 ::  Affects: Client
 ::==============================================================================
@@ -101,7 +102,7 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_OIDC_PROVIDER
 ::
-::  | Default: Value | of "STIGMAN_OIDC_PROVIDER" Client override of the base
+::  | Default: Value of "STIGMAN_OIDC_PROVIDER" | Client override of the base
 ::  URL of the OIDC provider issuing signed JWTs for the API.  The string
 ::  "/.well-known/openid-configuration" will be appended by the client when
 ::  fetching metadata.
@@ -114,8 +115,9 @@
 :: STIGMAN_CLIENT_SCOPE_PREFIX
 ::
 ::  | No default. | String used as a prefix for each scope when authenticating
-::  to the OIDC Provider. Some providers (Azure AD) require a string in the
-::  format "api://<application_id>"
+::  to the OIDC Provider. Some providers (Azure AD) expect scope requests in the
+::  format "api://<application_id>/<scope>", where "api://<application_id>/" is
+::  the required prefix.
 ::
 ::  Affects: Client
 ::==============================================================================
@@ -378,17 +380,6 @@
 ::  Affects: API, Client
 ::==============================================================================
 :: set STIGMAN_JWT_SCOPE_CLAIM=
-
-::==============================================================================
-:: STIGMAN_JWT_SCOPE_FORMAT
-::
-::  | Default: "rfc" | The format used for the value of the access token scope
-::  claim. Available values: "rfc" "json". Some OIDC Providers (Okta) use "json"
-::  format
-::
-::  Affects: API, Client
-::==============================================================================
-:: set STIGMAN_JWT_SCOPE_FORMAT=
 
 ::==============================================================================
 :: STIGMAN_JWT_SERVICENAME_CLAIM

--- a/api/launchers/stig-manager.bat
+++ b/api/launchers/stig-manager.bat
@@ -1,7 +1,8 @@
 ::==============================================================================
 :: STIGMAN_API_ADDRESS
 ::
-::  Default: "0.0.0.0" The IP address on which the the API server will listen
+::  | Default: "0.0.0.0" | The IP address on which the the API server will
+::  listen
 ::
 ::  Affects: API
 ::==============================================================================
@@ -10,7 +11,7 @@
 ::==============================================================================
 :: STIGMAN_API_MAX_JSON_BODY
 ::
-::  Default: "5242880"   The maximum size in bytes of the request body when
+::  | Default: "5242880" | The maximum size in bytes of the request body when
 ::  Content-Type is application/json
 ::
 ::  Affects: API
@@ -20,8 +21,8 @@
 ::==============================================================================
 :: STIGMAN_API_MAX_UPLOAD
 ::
-::  Default: "1073741824" The maximum size in bytes of the file uploaded with
-::  Content-Type multipart/form-data
+::  | Default: "1073741824" | The maximum size in bytes of the file uploaded
+::  with Content-Type multipart/form-data
 ::
 ::  Affects: API
 ::==============================================================================
@@ -30,7 +31,7 @@
 ::==============================================================================
 :: STIGMAN_API_PORT
 ::
-::  Default: "54000" The TCP port on which the server will listen
+::  | Default: "54000" | The TCP port on which the server will listen
 ::
 ::  Affects: API
 ::==============================================================================
@@ -39,8 +40,8 @@
 ::==============================================================================
 :: STIGMAN_CLASSIFICATION
 ::
-::  Default: "U" Sets the classification banner, if any. Available values:
-::  "NONE" "U" "FOUO" "C" "S" "TS" "SCI"
+::  | Default: "U" | Sets the classification banner, if any. Available values:
+::  "NONE" "U" "CUI" "C" "S" "TS" "SCI"
 ::
 ::  Affects: API, Client
 ::==============================================================================
@@ -49,8 +50,8 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_API_BASE
 ::
-::  Default: "./api" The base URL for Client requests to the API relative to the
-::  sever root at /
+::  | Default: "./api" | The base URL for Client requests to the API relative to
+::  the sever root at /
 ::
 ::  Affects: Client
 ::==============================================================================
@@ -59,10 +60,10 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_DIRECTORY
 ::
-::  Default: "./clients" The location of the web client files, relative to the
-::  API source directory. Note that if running source from a clone of the GitHub
-::  repository, the client is located at `../../clients` relative to the API
-::  directory.
+::  | Default: "./clients" | The location of the web client files, relative to
+::  the API source directory. Note that if running source from a clone of the
+::  GitHub repository, the client is located at `../../clients` relative to the
+::  API directory.
 ::
 ::  Affects: API, Client
 ::==============================================================================
@@ -71,7 +72,7 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_DISABLED
 ::
-::  Default: "false" Whether to *not* serve the reference web client
+::  | Default: "false" | Whether to *not* serve the reference web client
 ::
 ::  Affects: Client
 ::==============================================================================
@@ -80,7 +81,7 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_EXTRA_SCOPES
 ::
-::  No default. OAuth2 scopes to request in addition to "stig-manager:stig"
+::  | No default. | OAuth2 scopes to request in addition to "stig-manager:stig"
 ::  "stig-manager:stig:read" "stig-manager:collection" "stig-manager:user"
 ::  "stig-manager:user:read" "stig-manager:op"
 ::
@@ -91,7 +92,7 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_ID
 ::
-::  Default: "stig-manager" The OIDC clientId of the web client
+::  | Default: "stig-manager" | The OIDC clientId of the web client
 ::
 ::  Affects: Client
 ::==============================================================================
@@ -100,29 +101,40 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_OIDC_PROVIDER
 ::
-::  Default: Value of "STIGMAN_OIDC_PROVIDER" Client override of the base URL of
-::  the OIDC provider issuing signed JWTs for the API.  The string "/.well-
-::  known/openid-configuration" will be appended by the client when fetching
-::  metadata.
+::  | Default: Value | of "STIGMAN_OIDC_PROVIDER" Client override of the base
+::  URL of the OIDC provider issuing signed JWTs for the API.  The string
+::  "/.well-known/openid-configuration" will be appended by the client when
+::  fetching metadata.
 ::
 ::  Affects: Client 
 ::==============================================================================
 :: set STIGMAN_CLIENT_OIDC_PROVIDER=
 
 ::==============================================================================
+:: STIGMAN_CLIENT_SCOPE_PREFIX
+::
+::  | No default. | String used as a prefix for each scope when authenticating
+::  to the OIDC Provider. Some providers (Azure AD) require a string in the
+::  format "api://<application_id>"
+::
+::  Affects: Client
+::==============================================================================
+:: set STIGMAN_CLIENT_SCOPE_PREFIX=
+
+::==============================================================================
 :: STIGMAN_CLIENT_REFRESH_DISABLED
 ::
-::  Default: "false" Whether the web client should expect the OIDC provider to
-::  *not* issue an OAuth2 refresh token
+::  | Default: "false" | Whether the web client should use a provided refresh
+::  token to update the access token
 ::
-::  Affects: Client 
+::  Affects: Client
 ::==============================================================================
 :: set STIGMAN_CLIENT_REFRESH_DISABLED=
 
 ::==============================================================================
 :: STIGMAN_CLIENT_WELCOME_IMAGE 
 ::
-::  No default.  An image URL that will be rendered in the Home tab Welcome
+::  | No default. | An image URL that will be rendered in the Home tab Welcome
 ::  widget. The image will be scaled to a max width or height of 125 pixels - If
 ::  no alternate image is specified, the seal of the Department of the Navy (the
 ::  project sponsor)  will be displayed.
@@ -134,8 +146,8 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_WELCOME_LINK
 ::
-::  No default. Value of an optional link that will follow the Welcome message
-::  in the Home tab Welcome widget.
+::  | No default. | Value of an optional link that will follow the Welcome
+::  message in the Home tab Welcome widget.
 ::
 ::  Affects: Client Appearance
 ::==============================================================================
@@ -144,7 +156,7 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_WELCOME_MESSAGE 
 ::
-::  No default. Text that will be displayed in the Home tab Welcome widget.
+::  | No default. | Text that will be displayed in the Home tab Welcome widget.
 ::
 ::  Affects: Client Appearance     
 ::==============================================================================
@@ -153,8 +165,8 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_WELCOME_TITLE 
 ::
-::  Default: "Support" The tile that will be displayed for the custom Home tab
-::  Welcome message.
+::  | Default: "Support" | The tile that will be displayed for the custom Home
+::  tab Welcome message.
 ::
 ::  Affects: Client Appearance
 ::==============================================================================
@@ -163,7 +175,7 @@
 ::==============================================================================
 :: STIGMAN_DB_HOST
 ::
-::  Default: "localhost" The database hostname or IP from to the API server
+::  | Default: "localhost" | The database hostname or IP from to the API server
 ::
 ::  Affects: API
 ::==============================================================================
@@ -172,7 +184,7 @@
 ::==============================================================================
 :: STIGMAN_DB_MAX_CONNECTIONS
 ::
-::  Default: "25" The maximum size of the database connection pool
+::  | Default: "25" | The maximum size of the database connection pool
 ::
 ::  Affects: API
 ::==============================================================================
@@ -181,7 +193,7 @@
 ::==============================================================================
 :: STIGMAN_DB_PASSWORD
 ::
-::  No default. The password used to login to the database
+::  | No default. | The password used to login to the database
 ::
 ::  Affects: API
 ::==============================================================================
@@ -190,7 +202,7 @@
 ::==============================================================================
 :: STIGMAN_DB_PORT
 ::
-::  Default: "3306" The database TCP port relative to the API server
+::  | Default: "3306" | The database TCP port relative to the API server
 ::
 ::  Affects: API          
 ::==============================================================================
@@ -199,7 +211,7 @@
 ::==============================================================================
 :: STIGMAN_DB_SCHEMA
 ::
-::  Default: "stigman" The schema where the STIG Manager object are found
+::  | Default: "stigman" | The schema where the STIG Manager object are found
 ::
 ::  Affects: API          
 ::==============================================================================
@@ -208,8 +220,8 @@
 ::==============================================================================
 :: STIGMAN_DB_TLS_CA_FILE
 ::
-::  No default. A file/path relative to the API /tls directory that contains the
-::  PEM encoded CA certificate used to sign the database TLS certificate.
+::  | No default. | A file/path relative to the API /tls directory that contains
+::  the PEM encoded CA certificate used to sign the database TLS certificate.
 ::  Setting this variable enables TLS connections to the database.
 ::
 ::  Affects: API          
@@ -219,10 +231,10 @@
 ::==============================================================================
 :: STIGMAN_DB_TLS_CERT_FILE
 ::
-::  No default. A file/path relative to the API /tls directory that contains the
-::  PEM encoded Client certificate used when authenticating the database client.
-::  Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE" and
-::  "STIGMAN_DB_TLS_KEY_FILE".
+::  | No default. | A file/path relative to the API /tls directory that contains
+::  the PEM encoded Client certificate used when authenticating the database
+::  client. Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE"
+::  and "STIGMAN_DB_TLS_KEY_FILE".
 ::
 ::  Affects: API          
 ::==============================================================================
@@ -231,10 +243,10 @@
 ::==============================================================================
 :: STIGMAN_DB_TLS_KEY_FILE
 ::
-::  No default. A file/path relative to the API /tls directory that contains the
-::  PEM encoded Client private key used when authenticating the database client.
-::  Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE" and
-::  "STIGMAN_DB_TLS_CERT_FILE".
+::  | No default. | A file/path relative to the API /tls directory that contains
+::  the PEM encoded Client private key used when authenticating the database
+::  client. Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE"
+::  and "STIGMAN_DB_TLS_CERT_FILE".
 ::
 ::  Affects: API          
 ::==============================================================================
@@ -243,7 +255,7 @@
 ::==============================================================================
 :: STIGMAN_DB_TYPE
 ::
-::  Default: "mysql" The database type. Valid values are "mysql"
+::  | Default: "mysql" | The database type. Valid values are "mysql"
 ::
 ::  Affects: API          
 ::==============================================================================
@@ -252,7 +264,7 @@
 ::==============================================================================
 :: STIGMAN_DB_USER
 ::
-::  Default: "stigman" The user account used to login to the database
+::  | Default: "stigman" | The user account used to login to the database
 ::
 ::  Affects: API    
 ::==============================================================================
@@ -261,10 +273,10 @@
 ::==============================================================================
 :: STIGMAN_DOCS_DIRECTORY
 ::
-::  Default: "./docs" The location of the documentation files, relative to the
-::  API source directory. Note that if running source from a clone of the GitHub
-::  repository, the docs are located at `../../docs/_build/html` relative to the
-::  API directory.
+::  | Default: "./docs" | The location of the documentation files, relative to
+::  the API source directory. Note that if running source from a clone of the
+::  GitHub repository, the docs are located at `../../docs/_build/html` relative
+::  to the API directory.
 ::
 ::  Affects: API, documentation
 ::==============================================================================
@@ -273,8 +285,8 @@
 ::==============================================================================
 :: STIGMAN_DOCS_DISABLED
 ::
-::  Default: "false" Whether to *not* serve the project Documentation.  NOTE: If
-::  you choose to serve the Client from the API container but not the
+::  | Default: "false" | Whether to *not* serve the project Documentation.
+::  NOTE: If you choose to serve the Client from the API container but not the
 ::  Documentation, the links do the Docs on the home page will not work.
 ::
 ::  Affects: Documentation                
@@ -284,8 +296,8 @@
 ::==============================================================================
 :: STIGMAN_INIT_IMPORT_SCAP
 ::
-::  Default: "false" Whether to fetch and import current DISA SCAP content from
-::  public.cyber.mil on initial database migration
+::  | Default: "false" | Whether to fetch and import current DISA SCAP content
+::  from public.cyber.mil on initial database migration
 ::
 ::  Affects: API          
 ::==============================================================================
@@ -294,8 +306,8 @@
 ::==============================================================================
 :: STIGMAN_INIT_IMPORT_STIGS
 ::
-::  Default: "false" Whether to fetch and import the current DISA STIG Library
-::  compilation from public.cyber.mil on initial database migration
+::  | Default: "false" | Whether to fetch and import the current DISA STIG
+::  Library compilation from public.cyber.mil on initial database migration
 ::
 ::  Affects: API
 ::==============================================================================
@@ -304,8 +316,8 @@
 ::==============================================================================
 :: STIGMAN_LOG_LEVEL
 ::
-::  Default: "3" Controls the granularity of the generated log output, from 1 to
-::  4. Each level is inclusive of the ones before it. Level 1 will log only
+::  | Default: "3" | Controls the granularity of the generated log output, from
+::  1 to 4. Each level is inclusive of the ones before it. Level 1 will log only
 ::  errors, level 2 includes warnings, level 3 includes status and transaction
 ::  logs, and level 4 includes debug-level logs
 ::
@@ -316,8 +328,8 @@
 ::==============================================================================
 :: STIGMAN_LOG_MODE
 ::
-::  Default: "combined" Controls whether the logs will create one “combined” log
-::  entry for http requests that includes both the request and response
+::  | Default: "combined" | Controls whether the logs will create one “combined”
+::  log entry for http requests that includes both the request and response
 ::  information; or two separate log entries, one for the request and one for
 ::  the response, that can be correlated via a generated Request GUID in each
 ::  entry
@@ -329,7 +341,7 @@
 ::==============================================================================
 :: STIGMAN_JWT_EMAIL_CLAIM
 ::
-::  Default: "email" The access token claim whose value is the user's email
+::  | Default: "email" | The access token claim whose value is the user's email
 ::  address
 ::
 ::  Affects: API, Client
@@ -339,7 +351,8 @@
 ::==============================================================================
 :: STIGMAN_JWT_NAME_CLAIM
 ::
-::  Default: "name" The access token claim whose value is the user's full name
+::  | Default: "name" | The access token claim whose value is the user's full
+::  name
 ::
 ::  Affects: API, Client
 ::==============================================================================
@@ -348,7 +361,7 @@
 ::==============================================================================
 :: STIGMAN_JWT_PRIVILEGES_CLAIM
 ::
-::  Default: "realm_access.roles" The access token claim whose value is the
+::  | Default: "realm_access.roles" | The access token claim whose value is the
 ::  user’s privileges
 ::
 ::  Affects: API, Client
@@ -356,9 +369,32 @@
 :: set STIGMAN_JWT_PRIVILEGES_CLAIM=
 
 ::==============================================================================
+:: STIGMAN_JWT_SCOPE_CLAIM
+::
+::  | Default: "scope" | The access token claim whose value is the user's
+::  scopes. Some OIDC Providers (Okta, Azure AD) use the claim "scp" to
+::  enumerate scopes
+::
+::  Affects: API, Client
+::==============================================================================
+:: set STIGMAN_JWT_SCOPE_CLAIM=
+
+::==============================================================================
+:: STIGMAN_JWT_SCOPE_FORMAT
+::
+::  | Default: "rfc" | The format used for the value of the access token scope
+::  claim. Available values: "rfc" "json". Some OIDC Providers (Okta) use "json"
+::  format
+::
+::  Affects: API, Client
+::==============================================================================
+:: set STIGMAN_JWT_SCOPE_FORMAT=
+
+::==============================================================================
 :: STIGMAN_JWT_SERVICENAME_CLAIM
 ::
-::  Default: "clientId" The access token claim whose value is the user's client
+::  | Default: "clientId" | The access token claim whose value is the user's
+::  client
 ::
 ::  Affects: API, Client
 ::==============================================================================
@@ -367,7 +403,7 @@
 ::==============================================================================
 :: STIGMAN_JWT_USERNAME_CLAIM
 ::
-::  Default: "preferred_username" The access token claim whose value is the
+::  | Default: "preferred_username" | The access token claim whose value is the
 ::  user's username
 ::
 ::  Affects: API, Client
@@ -377,7 +413,7 @@
 ::==============================================================================
 :: STIGMAN_OIDC_PROVIDER
 ::
-::  Default: "http://localhost:8080/auth/realms/stigman"  The base URL of the
+::  | Default: "http://localhost:8080/auth/realms/stigman" | The base URL of the
 ::  OIDC provider issuing signed JWTs for the API.  The string "/.well-
 ::  known/openid-configuration" will be appended when fetching metadata.
 ::
@@ -386,20 +422,9 @@
 :: set STIGMAN_OIDC_PROVIDER=
 
 ::==============================================================================
-:: STIGMAN_OIDC_PROXY_HOST
-::
-::  No default. The "Host:" header value to be used by the CORS proxy for
-::  outbound requests. Some OIDC providers return configuration metadata with
-::  endpoint URLs having this value as their base.
-::
-::  Affects: API, Client
-::==============================================================================
-:: set STIGMAN_OIDC_PROXY_HOST=
-
-::==============================================================================
 :: STIGMAN_SWAGGER_ENABLED
 ::
-::  Default: "false" Whether to enable the SwaggerUI SPA at /api-docs
+::  | Default: "false" | Whether to enable the SwaggerUI SPA at /api-docs
 ::
 ::  Affects: API
 ::==============================================================================
@@ -408,10 +433,10 @@
 ::==============================================================================
 :: STIGMAN_SWAGGER_OIDC_PROVIDER
 ::
-::  Default: Value of "STIGMAN_OIDC_PROVIDER" SwaggerUI override of the base URL
-::  of the OIDC provider issuing signed JWTs for the API.  The string "/.well-
-::  known/openid-configuration" will be appended by the SwaggerUI when fetching
-::  metadata.
+::  | Default: Value of "STIGMAN_OIDC_PROVIDER" | SwaggerUI override of the base
+::  URL of the OIDC provider issuing signed JWTs for the API.  The string
+::  "/.well-known/openid-configuration" will be appended by the SwaggerUI when
+::  fetching metadata.
 ::
 ::  Affects: API  
 ::==============================================================================
@@ -420,8 +445,8 @@
 ::==============================================================================
 :: STIGMAN_SWAGGER_REDIRECT
 ::
-::  Default: "http://localhost:54000/api-docs/oauth2-redirect.html" The redirect
-::  URL sent by SwaggerUI to the OIDC provider when authorizing
+::  | Default: "http://localhost:54000/api-docs/oauth2-redirect.html" | The
+::  redirect URL sent by SwaggerUI to the OIDC provider when authorizing
 ::
 ::  Affects: API
 ::==============================================================================
@@ -430,7 +455,7 @@
 ::==============================================================================
 :: STIGMAN_SWAGGER_SERVER
 ::
-::  Default: "http://localhost:54000/api" The API server URL relative to the
+::  | Default: "http://localhost:54000/api" | The API server URL relative to the
 ::  SwaggerUI
 ::
 ::  Affects: API

--- a/api/launchers/stig-manager.sh
+++ b/api/launchers/stig-manager.sh
@@ -1,7 +1,7 @@
 #==============================================================================
 # STIGMAN_API_ADDRESS
 #
-#  Default: "0.0.0.0" The IP address on which the the API server will listen
+#  | Default: "0.0.0.0" | The IP address on which the the API server will listen
 #
 #  Affects: API
 #==============================================================================
@@ -10,7 +10,7 @@
 #==============================================================================
 # STIGMAN_API_MAX_JSON_BODY
 #
-#  Default: "5242880"   The maximum size in bytes of the request body when
+#  | Default: "5242880" | The maximum size in bytes of the request body when
 #  Content-Type is application/json
 #
 #  Affects: API
@@ -20,7 +20,7 @@
 #==============================================================================
 # STIGMAN_API_MAX_UPLOAD
 #
-#  Default: "1073741824" The maximum size in bytes of the file uploaded with
+#  | Default: "1073741824" | The maximum size in bytes of the file uploaded with
 #  Content-Type multipart/form-data
 #
 #  Affects: API
@@ -30,7 +30,7 @@
 #==============================================================================
 # STIGMAN_API_PORT
 #
-#  Default: "54000" The TCP port on which the server will listen
+#  | Default: "54000" | The TCP port on which the server will listen
 #
 #  Affects: API
 #==============================================================================
@@ -39,8 +39,8 @@
 #==============================================================================
 # STIGMAN_CLASSIFICATION
 #
-#  Default: "U" Sets the classification banner, if any. Available values: "NONE"
-#  "U" "FOUO" "C" "S" "TS" "SCI"
+#  | Default: "U" | Sets the classification banner, if any. Available values:
+#  "NONE" "U" "CUI" "C" "S" "TS" "SCI"
 #
 #  Affects: API, Client
 #==============================================================================
@@ -49,8 +49,8 @@
 #==============================================================================
 # STIGMAN_CLIENT_API_BASE
 #
-#  Default: "./api" The base URL for Client requests to the API relative to the
-#  sever root at /
+#  | Default: "./api" | The base URL for Client requests to the API relative to
+#  the sever root at /
 #
 #  Affects: Client
 #==============================================================================
@@ -59,10 +59,10 @@
 #==============================================================================
 # STIGMAN_CLIENT_DIRECTORY
 #
-#  Default: "./clients" The location of the web client files, relative to the
-#  API source directory. Note that if running source from a clone of the GitHub
-#  repository, the client is located at `../../clients` relative to the API
-#  directory.
+#  | Default: "./clients" | The location of the web client files, relative to
+#  the API source directory. Note that if running source from a clone of the
+#  GitHub repository, the client is located at `../../clients` relative to the
+#  API directory.
 #
 #  Affects: API, Client
 #==============================================================================
@@ -71,7 +71,7 @@
 #==============================================================================
 # STIGMAN_CLIENT_DISABLED
 #
-#  Default: "false" Whether to *not* serve the reference web client
+#  | Default: "false" | Whether to *not* serve the reference web client
 #
 #  Affects: Client
 #==============================================================================
@@ -80,7 +80,7 @@
 #==============================================================================
 # STIGMAN_CLIENT_EXTRA_SCOPES
 #
-#  No default. OAuth2 scopes to request in addition to "stig-manager:stig"
+#  | No default. | OAuth2 scopes to request in addition to "stig-manager:stig"
 #  "stig-manager:stig:read" "stig-manager:collection" "stig-manager:user" "stig-
 #  manager:user:read" "stig-manager:op"
 #
@@ -91,7 +91,7 @@
 #==============================================================================
 # STIGMAN_CLIENT_ID
 #
-#  Default: "stig-manager" The OIDC clientId of the web client
+#  | Default: "stig-manager" | The OIDC clientId of the web client
 #
 #  Affects: Client
 #==============================================================================
@@ -100,8 +100,8 @@
 #==============================================================================
 # STIGMAN_CLIENT_OIDC_PROVIDER
 #
-#  Default: Value of "STIGMAN_OIDC_PROVIDER" Client override of the base URL of
-#  the OIDC provider issuing signed JWTs for the API.  The string "/.well-
+#  | Default: Value | of "STIGMAN_OIDC_PROVIDER" Client override of the base URL
+#  of the OIDC provider issuing signed JWTs for the API.  The string "/.well-
 #  known/openid-configuration" will be appended by the client when fetching
 #  metadata.
 #
@@ -110,32 +110,43 @@
 # export STIGMAN_CLIENT_OIDC_PROVIDER=
 
 #==============================================================================
+# STIGMAN_CLIENT_SCOPE_PREFIX
+#
+#  | No default. | String used as a prefix for each scope when authenticating to
+#  the OIDC Provider. Some providers (Azure AD) require a string in the format
+#  "api://<application_id>"
+#
+#  Affects: Client
+#==============================================================================
+# export STIGMAN_CLIENT_SCOPE_PREFIX=
+
+#==============================================================================
 # STIGMAN_CLIENT_REFRESH_DISABLED
 #
-#  Default: "false" Whether the web client should expect the OIDC provider to
-#  *not* issue an OAuth2 refresh token
+#  | Default: "false" | Whether the web client should use a provided refresh
+#  token to update the access token
 #
-#  Affects: Client 
+#  Affects: Client
 #==============================================================================
 # export STIGMAN_CLIENT_REFRESH_DISABLED=
 
 #==============================================================================
 # STIGMAN_CLIENT_WELCOME_IMAGE 
 #
-#  No default.  An image URL that will be rendered in the Home tab Welcome
+#  | No default. | An image URL that will be rendered in the Home tab Welcome
 #  widget. The image will be scaled to a max width or height of 125 pixels - If
 #  no alternate image is specified, the seal of the Department of the Navy (the
 #  project sponsor)  will be displayed.
 #
 #  Affects: Client Appearance
 #==============================================================================
-# export STIGMAN_CLIENT_WELCOME_IMAGE=
+# export STIGMAN_CLIENT_WELCOME_IMAGE =
 
 #==============================================================================
 # STIGMAN_CLIENT_WELCOME_LINK
 #
-#  No default. Value of an optional link that will follow the Welcome message in
-#  the Home tab Welcome widget.
+#  | No default. | Value of an optional link that will follow the Welcome
+#  message in the Home tab Welcome widget.
 #
 #  Affects: Client Appearance
 #==============================================================================
@@ -144,26 +155,26 @@
 #==============================================================================
 # STIGMAN_CLIENT_WELCOME_MESSAGE 
 #
-#  No default. Text that will be displayed in the Home tab Welcome widget.
+#  | No default. | Text that will be displayed in the Home tab Welcome widget.
 #
 #  Affects: Client Appearance     
 #==============================================================================
-# export STIGMAN_CLIENT_WELCOME_MESSAGE=
+# export STIGMAN_CLIENT_WELCOME_MESSAGE =
 
 #==============================================================================
 # STIGMAN_CLIENT_WELCOME_TITLE 
 #
-#  Default: "Support" The tile that will be displayed for the custom Home tab
-#  Welcome message.
+#  | Default: "Support" | The tile that will be displayed for the custom Home
+#  tab Welcome message.
 #
 #  Affects: Client Appearance
 #==============================================================================
-# export STIGMAN_CLIENT_WELCOME_TITLE=
+# export STIGMAN_CLIENT_WELCOME_TITLE =
 
 #==============================================================================
 # STIGMAN_DB_HOST
 #
-#  Default: "localhost" The database hostname or IP from to the API server
+#  | Default: "localhost" | The database hostname or IP from to the API server
 #
 #  Affects: API
 #==============================================================================
@@ -172,7 +183,7 @@
 #==============================================================================
 # STIGMAN_DB_MAX_CONNECTIONS
 #
-#  Default: "25" The maximum size of the database connection pool
+#  | Default: "25" | The maximum size of the database connection pool
 #
 #  Affects: API
 #==============================================================================
@@ -181,7 +192,7 @@
 #==============================================================================
 # STIGMAN_DB_PASSWORD
 #
-#  No default. The password used to login to the database
+#  | No default. | The password used to login to the database
 #
 #  Affects: API
 #==============================================================================
@@ -190,7 +201,7 @@
 #==============================================================================
 # STIGMAN_DB_PORT
 #
-#  Default: "3306" The database TCP port relative to the API server
+#  | Default: "3306" | The database TCP port relative to the API server
 #
 #  Affects: API          
 #==============================================================================
@@ -199,7 +210,7 @@
 #==============================================================================
 # STIGMAN_DB_SCHEMA
 #
-#  Default: "stigman" The schema where the STIG Manager object are found
+#  | Default: "stigman" | The schema where the STIG Manager object are found
 #
 #  Affects: API          
 #==============================================================================
@@ -208,9 +219,9 @@
 #==============================================================================
 # STIGMAN_DB_TLS_CA_FILE
 #
-#  No default. A file/path relative to the API /tls directory that contains the
-#  PEM encoded CA certificate used to sign the database TLS certificate. Setting
-#  this variable enables TLS connections to the database.
+#  | No default. | A file/path relative to the API /tls directory that contains
+#  the PEM encoded CA certificate used to sign the database TLS certificate.
+#  Setting this variable enables TLS connections to the database.
 #
 #  Affects: API          
 #==============================================================================
@@ -219,9 +230,9 @@
 #==============================================================================
 # STIGMAN_DB_TLS_CERT_FILE
 #
-#  No default. A file/path relative to the API /tls directory that contains the
-#  PEM encoded Client certificate used when authenticating the database client.
-#  Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE" and
+#  | No default. | A file/path relative to the API /tls directory that contains
+#  the PEM encoded Client certificate used when authenticating the database
+#  client. Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE" and
 #  "STIGMAN_DB_TLS_KEY_FILE".
 #
 #  Affects: API          
@@ -231,9 +242,9 @@
 #==============================================================================
 # STIGMAN_DB_TLS_KEY_FILE
 #
-#  No default. A file/path relative to the API /tls directory that contains the
-#  PEM encoded Client private key used when authenticating the database client.
-#  Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE" and
+#  | No default. | A file/path relative to the API /tls directory that contains
+#  the PEM encoded Client private key used when authenticating the database
+#  client. Additionally requires setting values for "STIGMAN_DB_TLS_CA_FILE" and
 #  "STIGMAN_DB_TLS_CERT_FILE".
 #
 #  Affects: API          
@@ -243,7 +254,7 @@
 #==============================================================================
 # STIGMAN_DB_TYPE
 #
-#  Default: "mysql" The database type. Valid values are "mysql"
+#  | Default: "mysql" | The database type. Valid values are "mysql"
 #
 #  Affects: API          
 #==============================================================================
@@ -252,7 +263,7 @@
 #==============================================================================
 # STIGMAN_DB_USER
 #
-#  Default: "stigman" The user account used to login to the database
+#  | Default: "stigman" | The user account used to login to the database
 #
 #  Affects: API    
 #==============================================================================
@@ -261,10 +272,10 @@
 #==============================================================================
 # STIGMAN_DOCS_DIRECTORY
 #
-#  Default: "./docs" The location of the documentation files, relative to the
-#  API source directory. Note that if running source from a clone of the GitHub
-#  repository, the docs are located at `../../docs/_build/html` relative to the
-#  API directory.
+#  | Default: "./docs" | The location of the documentation files, relative to
+#  the API source directory. Note that if running source from a clone of the
+#  GitHub repository, the docs are located at `../../docs/_build/html` relative
+#  to the API directory.
 #
 #  Affects: API, documentation
 #==============================================================================
@@ -273,8 +284,8 @@
 #==============================================================================
 # STIGMAN_DOCS_DISABLED
 #
-#  Default: "false" Whether to *not* serve the project Documentation.  NOTE: If
-#  you choose to serve the Client from the API container but not the
+#  | Default: "false" | Whether to *not* serve the project Documentation.  NOTE:
+#  If you choose to serve the Client from the API container but not the
 #  Documentation, the links do the Docs on the home page will not work.
 #
 #  Affects: Documentation                
@@ -284,8 +295,8 @@
 #==============================================================================
 # STIGMAN_INIT_IMPORT_SCAP
 #
-#  Default: "false" Whether to fetch and import current DISA SCAP content from
-#  public.cyber.mil on initial database migration
+#  | Default: "false" | Whether to fetch and import current DISA SCAP content
+#  from public.cyber.mil on initial database migration
 #
 #  Affects: API          
 #==============================================================================
@@ -294,8 +305,8 @@
 #==============================================================================
 # STIGMAN_INIT_IMPORT_STIGS
 #
-#  Default: "false" Whether to fetch and import the current DISA STIG Library
-#  compilation from public.cyber.mil on initial database migration
+#  | Default: "false" | Whether to fetch and import the current DISA STIG
+#  Library compilation from public.cyber.mil on initial database migration
 #
 #  Affects: API
 #==============================================================================
@@ -304,8 +315,8 @@
 #==============================================================================
 # STIGMAN_LOG_LEVEL
 #
-#  Default: "3" Controls the granularity of the generated log output, from 1 to
-#  4. Each level is inclusive of the ones before it. Level 1 will log only
+#  | Default: "3" | Controls the granularity of the generated log output, from 1
+#  to 4. Each level is inclusive of the ones before it. Level 1 will log only
 #  errors, level 2 includes warnings, level 3 includes status and transaction
 #  logs, and level 4 includes debug-level logs
 #
@@ -316,8 +327,8 @@
 #==============================================================================
 # STIGMAN_LOG_MODE
 #
-#  Default: "combined" Controls whether the logs will create one “combined” log
-#  entry for http requests that includes both the request and response
+#  | Default: "combined" | Controls whether the logs will create one “combined”
+#  log entry for http requests that includes both the request and response
 #  information; or two separate log entries, one for the request and one for the
 #  response, that can be correlated via a generated Request GUID in each entry
 #
@@ -328,7 +339,7 @@
 #==============================================================================
 # STIGMAN_JWT_EMAIL_CLAIM
 #
-#  Default: "email" The access token claim whose value is the user's email
+#  | Default: "email" | The access token claim whose value is the user's email
 #  address
 #
 #  Affects: API, Client
@@ -338,7 +349,8 @@
 #==============================================================================
 # STIGMAN_JWT_NAME_CLAIM
 #
-#  Default: "name" The access token claim whose value is the user's full name
+#  | Default: "name" | The access token claim whose value is the user's full
+#  name
 #
 #  Affects: API, Client
 #==============================================================================
@@ -347,7 +359,7 @@
 #==============================================================================
 # STIGMAN_JWT_PRIVILEGES_CLAIM
 #
-#  Default: "realm_access.roles" The access token claim whose value is the
+#  | Default: "realm_access.roles" | The access token claim whose value is the
 #  user’s privileges
 #
 #  Affects: API, Client
@@ -355,9 +367,31 @@
 # export STIGMAN_JWT_PRIVILEGES_CLAIM=
 
 #==============================================================================
+# STIGMAN_JWT_SCOPE_CLAIM
+#
+#  | Default: "scope" | The access token claim whose value is the user's scopes.
+#  Some OIDC Providers (Okta, Azure AD) use the claim "scp" to enumerate scopes
+#
+#  Affects: API, Client
+#==============================================================================
+# export STIGMAN_JWT_SCOPE_CLAIM=
+
+#==============================================================================
+# STIGMAN_JWT_SCOPE_FORMAT
+#
+#  | Default: "rfc" | The format used for the value of the access token scope
+#  claim. Available values: "rfc" "json". Some OIDC Providers (Okta) use "json"
+#  format
+#
+#  Affects: API, Client
+#==============================================================================
+# export STIGMAN_JWT_SCOPE_FORMAT=
+
+#==============================================================================
 # STIGMAN_JWT_SERVICENAME_CLAIM
 #
-#  Default: "clientId" The access token claim whose value is the user's client
+#  | Default: "clientId" | The access token claim whose value is the user's
+#  client
 #
 #  Affects: API, Client
 #==============================================================================
@@ -366,7 +400,7 @@
 #==============================================================================
 # STIGMAN_JWT_USERNAME_CLAIM
 #
-#  Default: "preferred_username" The access token claim whose value is the
+#  | Default: "preferred_username" | The access token claim whose value is the
 #  user's username
 #
 #  Affects: API, Client
@@ -376,7 +410,7 @@
 #==============================================================================
 # STIGMAN_OIDC_PROVIDER
 #
-#  Default: "http://localhost:8080/auth/realms/stigman"  The base URL of the
+#  | Default: "http://localhost:8080/auth/realms/stigman" | The base URL of the
 #  OIDC provider issuing signed JWTs for the API.  The string "/.well-
 #  known/openid-configuration" will be appended when fetching metadata.
 #
@@ -385,20 +419,9 @@
 # export STIGMAN_OIDC_PROVIDER=
 
 #==============================================================================
-# STIGMAN_OIDC_PROXY_HOST
-#
-#  No default. The "Host:" header value to be used by the CORS proxy for
-#  outbound requests. Some OIDC providers return configuration metadata with
-#  endpoint URLs having this value as their base.
-#
-#  Affects: API, Client
-#==============================================================================
-# export STIGMAN_OIDC_PROXY_HOST=
-
-#==============================================================================
 # STIGMAN_SWAGGER_ENABLED
 #
-#  Default: "false" Whether to enable the SwaggerUI SPA at /api-docs
+#  | Default: "false" | Whether to enable the SwaggerUI SPA at /api-docs
 #
 #  Affects: API
 #==============================================================================
@@ -407,10 +430,10 @@
 #==============================================================================
 # STIGMAN_SWAGGER_OIDC_PROVIDER
 #
-#  Default: Value of "STIGMAN_OIDC_PROVIDER" SwaggerUI override of the base URL
-#  of the OIDC provider issuing signed JWTs for the API.  The string "/.well-
-#  known/openid-configuration" will be appended by the SwaggerUI when fetching
-#  metadata.
+#  | Default: Value of "STIGMAN_OIDC_PROVIDER" | SwaggerUI override of the base
+#  URL of the OIDC provider issuing signed JWTs for the API.  The string
+#  "/.well-known/openid-configuration" will be appended by the SwaggerUI when
+#  fetching metadata.
 #
 #  Affects: API  
 #==============================================================================
@@ -419,8 +442,8 @@
 #==============================================================================
 # STIGMAN_SWAGGER_REDIRECT
 #
-#  Default: "http://localhost:54000/api-docs/oauth2-redirect.html" The redirect
-#  URL sent by SwaggerUI to the OIDC provider when authorizing
+#  | Default: "http://localhost:54000/api-docs/oauth2-redirect.html" | The
+#  redirect URL sent by SwaggerUI to the OIDC provider when authorizing
 #
 #  Affects: API
 #==============================================================================
@@ -429,7 +452,7 @@
 #==============================================================================
 # STIGMAN_SWAGGER_SERVER
 #
-#  Default: "http://localhost:54000/api" The API server URL relative to the
+#  | Default: "http://localhost:54000/api" | The API server URL relative to the
 #  SwaggerUI
 #
 #  Affects: API

--- a/api/launchers/stig-manager.sh
+++ b/api/launchers/stig-manager.sh
@@ -82,7 +82,8 @@
 #
 #  | No default. | OAuth2 scopes to request in addition to "stig-manager:stig"
 #  "stig-manager:stig:read" "stig-manager:collection" "stig-manager:user" "stig-
-#  manager:user:read" "stig-manager:op"
+#  manager:user:read" "stig-manager:op". Some OIDC providers (Okta) generate a
+#  refresh token only if the scope "offline_access" is requested
 #
 #  Affects: Client
 #==============================================================================
@@ -100,7 +101,7 @@
 #==============================================================================
 # STIGMAN_CLIENT_OIDC_PROVIDER
 #
-#  | Default: Value | of "STIGMAN_OIDC_PROVIDER" Client override of the base URL
+#  | Default: Value of "STIGMAN_OIDC_PROVIDER" | Client override of the base URL
 #  of the OIDC provider issuing signed JWTs for the API.  The string "/.well-
 #  known/openid-configuration" will be appended by the client when fetching
 #  metadata.
@@ -113,8 +114,9 @@
 # STIGMAN_CLIENT_SCOPE_PREFIX
 #
 #  | No default. | String used as a prefix for each scope when authenticating to
-#  the OIDC Provider. Some providers (Azure AD) require a string in the format
-#  "api://<application_id>"
+#  the OIDC Provider. Some providers (Azure AD) expect scope requests in the
+#  format "api://<application_id>/<scope>", where "api://<application_id>/" is
+#  the required prefix.
 #
 #  Affects: Client
 #==============================================================================
@@ -375,17 +377,6 @@
 #  Affects: API, Client
 #==============================================================================
 # export STIGMAN_JWT_SCOPE_CLAIM=
-
-#==============================================================================
-# STIGMAN_JWT_SCOPE_FORMAT
-#
-#  | Default: "rfc" | The format used for the value of the access token scope
-#  claim. Available values: "rfc" "json". Some OIDC Providers (Okta) use "json"
-#  format
-#
-#  Affects: API, Client
-#==============================================================================
-# export STIGMAN_JWT_SCOPE_FORMAT=
 
 #==============================================================================
 # STIGMAN_JWT_SERVICENAME_CLAIM

--- a/api/source/index.js
+++ b/api/source/index.js
@@ -181,9 +181,9 @@ const STIGMAN = {
           disabled: ${config.client.refreshToken.disabled}
         },
         extraScopes: "${config.client.extraScopes ?? ''}",
+        scopePrefix: "${config.client.scopePrefix ?? ''}",
         claims: {
           scope: "${config.oauth.claims.scope}",
-          scopeFormat: "${config.oauth.claims.scopeFormat}",
           username: "${config.oauth.claims.username}",
           servicename: "${config.oauth.claims.servicename}",
           name: "${config.oauth.claims.name}",

--- a/api/source/utils/auth.js
+++ b/api/source/utils/auth.js
@@ -15,14 +15,14 @@ let client
 const privilegeGetter = new Function("obj", "return obj?." + config.oauth.claims.privileges + " || [];");
 
 const verifyRequest = async function (req, requiredScopes, securityDefinition) {
-        let token = getBearerToken(req)
+        const token = getBearerToken(req)
         if (!token) {
             throw({status: 401, message: 'OIDC bearer token must be provided'})
         }
-        let options = {
+        const options = {
             algorithms: ['RS256']
         }
-        let decoded = await verifyAndDecodeToken (token, getKey, options)
+        const decoded = await verifyAndDecodeToken (token, getKey, options)
         req.access_token = decoded
         req.bearer = token
         req.userObject = {
@@ -31,8 +31,10 @@ const verifyRequest = async function (req, requiredScopes, securityDefinition) {
             email: decoded[config.oauth.claims.email] ||  'None Provided'
         }
 
-        let grantedScopes = decoded[config.oauth.claims.scope]?.split(' ')
-        let commonScopes = _.intersectionWith(grantedScopes, requiredScopes, function(gs,rs) {
+        const grantedScopes = typeof decoded[config.oauth.claims.scope] === 'string' ? 
+            decoded[config.oauth.claims.scope].split(' ') : 
+            decoded[config.oauth.claims.scope]
+        const commonScopes = _.intersectionWith(grantedScopes, requiredScopes, function(gs,rs) {
             if (gs === rs) return gs
             let gsTokens = gs.split(":").filter(i => i.length)
             let rsTokens = rs.split(":").filter(i => i.length)
@@ -70,7 +72,7 @@ const verifyRequest = async function (req, requiredScopes, securityDefinition) {
                 refreshFields.lastClaims = decoded
             }
             if (req.userObject.username && (refreshFields.lastAccess || refreshFields.lastClaims)) {
-                let userId = await User.setUserData(req.userObject, refreshFields)
+                const userId = await User.setUserData(req.userObject, refreshFields)
                 if (userId != req.userObject.userId) {
                     req.userObject.userId = userId.toString()
                 }

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -24,6 +24,7 @@ let config = {
         disabled: process.env.STIGMAN_CLIENT_DISABLED === "true",
         directory: process.env.STIGMAN_CLIENT_DIRECTORY || '../../client/dist',
         extraScopes: process.env.STIGMAN_CLIENT_EXTRA_SCOPES,
+        scopePrefix: process.env.STIGMAN_CLIENT_SCOPE_PREFIX,
         refreshToken: {
             disabled: process.env.STIGMAN_CLIENT_REFRESH_DISABLED ? process.env.STIGMAN_CLIENT_REFRESH_DISABLED === "true" : false,
         },
@@ -78,7 +79,6 @@ let config = {
         authority: process.env.STIGMAN_OIDC_PROVIDER || process.env.STIGMAN_API_AUTHORITY || "http://localhost:8080/auth/realms/stigman",
         claims: {
             scope: process.env.STIGMAN_JWT_SCOPE_CLAIM || "scope",
-            scopeFormat: process.env.STIGMAN_JWT_SCOPE_FORMAT || "rfc",
             username: process.env.STIGMAN_JWT_USERNAME_CLAIM || "preferred_username",
             servicename: process.env.STIGMAN_JWT_SERVICENAME_CLAIM || "clientId",
             name: process.env.STIGMAN_JWT_NAME_CLAIM || process.env.STIGMAN_JWT_USERNAME_CLAIM || "name",
@@ -94,7 +94,7 @@ let config = {
 
 function formatChain(path) {
     const components = path?.split('.')
-    if (!components?.length) return path
+    if (components?.length === 1) return path
     for (let x=0; x < components.length; x++) {
       components[x] = `['${components[x]}']`
     }

--- a/client/src/js/Env.js.example
+++ b/client/src/js/Env.js.example
@@ -27,9 +27,9 @@ const STIGMAN = {
           disabled: false
         },
         extraScopes: "",
+        scopePrefix: "",
         claims: {
           scope: "scope",
-          scopeFormat: "rfc",
           username: "preferred_username",
           servicename: "clientId",
           name: "name",

--- a/client/src/js/oidcProvider.js
+++ b/client/src/js/oidcProvider.js
@@ -617,7 +617,7 @@
         }
 
         kc.isTokenExpired = function(minValidity) {
-            if (!kc.tokenParsed || (!kc.refreshToken && kc.flow != 'implicit' )) {
+            if (!kc.tokenParsed) {
                 throw 'Not authenticated';
             }
 
@@ -640,7 +640,10 @@
             var promise = createPromise();
 
             if (!kc.refreshToken) {
-                promise.setError('No refresh token');
+                if (kc.isTokenExpired(minValidity)) {
+                    kc.clearToken();
+                }
+                promise.setSuccess(false);
                 return promise.promise;
             }
 
@@ -1005,7 +1008,7 @@
                     kc.refreshTokenParsed = decodeToken(refreshToken);
                 }
                 catch (e) {
-                    kc.refreshTokenParsed = {};
+                    kc.refreshTokenParsed = false;
                 }
             } else {
                 delete kc.refreshToken;

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,3 +1,7 @@
+.rst-content .line-block { 
+  margin-bottom: 0;
+}
+
 figcaption {
   padding-top: 10px;
   font-size: 85%;

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -1,43 +1,89 @@
 "Variable","Description","Affects"
-"STIGMAN_API_ADDRESS","**Default** ``0.0.0.0`` The IP address on which the the API server will listen ","API"
-"STIGMAN_API_MAX_JSON_BODY","**Default** ``5242880``   The maximum size in bytes of the request body when Content-Type is application/json","API"
-"STIGMAN_API_MAX_UPLOAD","**Default** ``1073741824`` The maximum size in bytes of the file uploaded with Content-Type multipart/form-data","API"
-"STIGMAN_API_PORT","**Default** ``54000`` The TCP port on which the server will listen ","API"
-"STIGMAN_CLASSIFICATION","**Default** ``U`` Sets the classification banner, if any. Available values: ``NONE`` ``U`` ``FOUO`` ``C`` ``S`` ``TS`` ``SCI`` ","API, Client"
-"STIGMAN_CLIENT_API_BASE","**Default** ``./api`` The base URL for Client requests to the API relative to the sever root at / ","Client"
-"STIGMAN_CLIENT_DIRECTORY","**Default** ``./clients`` The location of the web client files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the client is located at `../../clients` relative to the API directory. ","API, Client"
-"STIGMAN_CLIENT_DISABLED","**Default** ``false`` Whether to *not* serve the reference web client","Client"
-"STIGMAN_CLIENT_EXTRA_SCOPES","**No default** OAuth2 scopes to request in addition to ``stig-manager:stig`` ``stig-manager:stig:read`` ``stig-manager:collection`` ``stig-manager:user`` ``stig-manager:user:read`` ``stig-manager:op``","Client"
-"STIGMAN_CLIENT_ID","**Default** ``stig-manager`` The OIDC clientId of the web client","Client"
-"STIGMAN_CLIENT_OIDC_PROVIDER","**Default** Value of ``STIGMAN_OIDC_PROVIDER`` Client override of the base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended by the client when fetching metadata.","Client "
-"STIGMAN_CLIENT_REFRESH_DISABLED","**Default** ``false`` Whether the web client should expect the OIDC provider to *not* issue an OAuth2 refresh token","Client "
-"STIGMAN_CLIENT_WELCOME_IMAGE ","**No default**  An image URL that will be rendered in the Home tab Welcome widget. The image will be scaled to a max width or height of 125 pixels - If no alternate image is specified, the seal of the Department of the Navy (the project sponsor)  will be displayed. ","Client Appearance"
-"STIGMAN_CLIENT_WELCOME_LINK","**No default** Value of an optional link that will follow the Welcome message in the Home tab Welcome widget. ","Client Appearance"
-"STIGMAN_CLIENT_WELCOME_MESSAGE ","**No default** Text that will be displayed in the Home tab Welcome widget.","Client Appearance     "
-"STIGMAN_CLIENT_WELCOME_TITLE ","**Default** ``Support`` The tile that will be displayed for the custom Home tab Welcome message.","Client Appearance"
-"STIGMAN_DB_HOST","**Default** ``localhost`` The database hostname or IP from to the API server","API"
-"STIGMAN_DB_MAX_CONNECTIONS","**Default** ``25`` The maximum size of the database connection pool ","API"
-"STIGMAN_DB_PASSWORD","**No default** The password used to login to the database ","API"
-"STIGMAN_DB_PORT","**Default** ``3306`` The database TCP port relative to the API server","API          "
-"STIGMAN_DB_SCHEMA","**Default** ``stigman`` The schema where the STIG Manager object are found","API          "
-"STIGMAN_DB_TLS_CA_FILE","**No default** A file/path relative to the API /tls directory that contains the PEM encoded CA certificate used to sign the database TLS certificate. Setting this variable enables TLS connections to the database.","API          "
-"STIGMAN_DB_TLS_CERT_FILE","**No default** A file/path relative to the API /tls directory that contains the PEM encoded Client certificate used when authenticating the database client. Additionally requires setting values for ``STIGMAN_DB_TLS_CA_FILE`` and ``STIGMAN_DB_TLS_KEY_FILE``. ","API          "
-"STIGMAN_DB_TLS_KEY_FILE","**No default** A file/path relative to the API /tls directory that contains the PEM encoded Client private key used when authenticating the database client. Additionally requires setting values for ``STIGMAN_DB_TLS_CA_FILE`` and ``STIGMAN_DB_TLS_CERT_FILE``.","API          "
-"STIGMAN_DB_TYPE","**Default** ``mysql`` The database type. Valid values are ``mysql`` ","API          "
-"STIGMAN_DB_USER","**Default** ``stigman`` The user account used to login to the database ","API    "
-"STIGMAN_DOCS_DIRECTORY","**Default** ``./docs`` The location of the documentation files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the docs are located at `../../docs/_build/html` relative to the API directory. ","API, documentation"
-"STIGMAN_DOCS_DISABLED","**Default** ``false`` Whether to *not* serve the project Documentation.  NOTE: If you choose to serve the Client from the API container but not the Documentation, the links do the Docs on the home page will not work. ","Documentation                "
-"STIGMAN_INIT_IMPORT_SCAP","**Default** ``false`` Whether to fetch and import current DISA SCAP content from public.cyber.mil on initial database migration","API          "
-"STIGMAN_INIT_IMPORT_STIGS","**Default** ``false`` Whether to fetch and import the current DISA STIG Library compilation from public.cyber.mil on initial database migration ","API"
-"STIGMAN_LOG_LEVEL","**Default** ``3`` Controls the granularity of the generated log output, from 1 to 4. Each level is inclusive of the ones before it. Level 1 will log only errors, level 2 includes warnings, level 3 includes status and transaction logs, and level 4 includes debug-level logs","API"
-"STIGMAN_LOG_MODE","**Default** ``combined`` Controls whether the logs will create one “combined” log entry for http requests that includes both the request and response information; or two separate log entries, one for the request and one for the response, that can be correlated via a generated Request GUID in each entry","API"
-"STIGMAN_JWT_EMAIL_CLAIM","**Default** ``email`` The access token claim whose value is the user's email address","API, Client"
-"STIGMAN_JWT_NAME_CLAIM","**Default** ``name`` The access token claim whose value is the user's full name","API, Client"
-"STIGMAN_JWT_PRIVILEGES_CLAIM","**Default** ``realm_access.roles`` The access token claim whose value is the user’s privileges ","API, Client"
-"STIGMAN_JWT_SERVICENAME_CLAIM","**Default** ``clientId`` The access token claim whose value is the user's client","API, Client"
-"STIGMAN_JWT_USERNAME_CLAIM","**Default** ``preferred_username`` The access token claim whose value is the user's username","API, Client"
-"STIGMAN_OIDC_PROVIDER","**Default** ``http://localhost:8080/auth/realms/stigman``  The base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended when fetching metadata.","API, Client     "
-"STIGMAN_SWAGGER_ENABLED","**Default** ``false`` Whether to enable the SwaggerUI SPA at /api-docs ","API"
-"STIGMAN_SWAGGER_OIDC_PROVIDER","**Default** Value of ``STIGMAN_OIDC_PROVIDER`` SwaggerUI override of the base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended by the SwaggerUI when fetching metadata.","API  "
-"STIGMAN_SWAGGER_REDIRECT","**Default** ``http://localhost:54000/api-docs/oauth2-redirect.html`` The redirect URL sent by SwaggerUI to the OIDC provider when authorizing","API"
-"STIGMAN_SWAGGER_SERVER","**Default** ``http://localhost:54000/api`` The API server URL relative to the SwaggerUI ","API"
+"STIGMAN_API_ADDRESS","| **Default** ``0.0.0.0``
+| The IP address on which the the API server will listen ","API"
+"STIGMAN_API_MAX_JSON_BODY","| **Default** ``5242880``
+| The maximum size in bytes of the request body when Content-Type is application/json","API"
+"STIGMAN_API_MAX_UPLOAD","| **Default** ``1073741824``
+| The maximum size in bytes of the file uploaded with Content-Type multipart/form-data","API"
+"STIGMAN_API_PORT","| **Default** ``54000``
+| The TCP port on which the server will listen ","API"
+"STIGMAN_CLASSIFICATION","| **Default** ``U``
+| Sets the classification banner, if any. Available values: ``NONE`` ``U`` ``CUI`` ``C`` ``S`` ``TS`` ``SCI`` ","API, Client"
+"STIGMAN_CLIENT_API_BASE","| **Default** ``./api``
+| The base URL for Client requests to the API relative to the sever root at / ","Client"
+"STIGMAN_CLIENT_DIRECTORY","| **Default** ``./clients``
+| The location of the web client files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the client is located at `../../clients` relative to the API directory. ","API, Client"
+"STIGMAN_CLIENT_DISABLED","| **Default** ``false``
+| Whether to *not* serve the reference web client","Client"
+"STIGMAN_CLIENT_EXTRA_SCOPES","| **No default**
+| OAuth2 scopes to request in addition to ``stig-manager:stig`` ``stig-manager:stig:read`` ``stig-manager:collection`` ``stig-manager:user`` ``stig-manager:user:read`` ``stig-manager:op``. Some OIDC providers (Okta) generate a refresh token only if the scope ``offline_access`` is requested","Client"
+"STIGMAN_CLIENT_ID","| **Default** ``stig-manager``
+| The OIDC clientId of the web client","Client"
+"STIGMAN_CLIENT_OIDC_PROVIDER","| **Default** Value of ``STIGMAN_OIDC_PROVIDER``
+| Client override of the base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended by the client when fetching metadata.","Client "
+"STIGMAN_CLIENT_SCOPE_PREFIX","| **No default**
+| String used as a prefix for each scope when authenticating to the OIDC Provider. Some providers (Azure AD) expect scope requests in the format ``api://<application_id>/<scope>``, where ``api://<application_id>/`` is the required prefix.","Client"
+"STIGMAN_CLIENT_REFRESH_DISABLED","| **Default** ``false``
+| Whether the web client should use a provided refresh token to update the access token","Client"
+"STIGMAN_CLIENT_WELCOME_IMAGE ","| **No default**
+| An image URL that will be rendered in the Home tab Welcome widget. The image will be scaled to a max width or height of 125 pixels - If no alternate image is specified, the seal of the Department of the Navy (the project sponsor)  will be displayed. ","Client Appearance"
+"STIGMAN_CLIENT_WELCOME_LINK","| **No default**
+| Value of an optional link that will follow the Welcome message in the Home tab Welcome widget. ","Client Appearance"
+"STIGMAN_CLIENT_WELCOME_MESSAGE ","| **No default**
+| Text that will be displayed in the Home tab Welcome widget.","Client Appearance     "
+"STIGMAN_CLIENT_WELCOME_TITLE ","| **Default** ``Support``
+| The tile that will be displayed for the custom Home tab Welcome message.","Client Appearance"
+"STIGMAN_DB_HOST","| **Default** ``localhost``
+| The database hostname or IP from to the API server","API"
+"STIGMAN_DB_MAX_CONNECTIONS","| **Default** ``25``
+| The maximum size of the database connection pool ","API"
+"STIGMAN_DB_PASSWORD","| **No default**
+| The password used to login to the database ","API"
+"STIGMAN_DB_PORT","| **Default** ``3306``
+| The database TCP port relative to the API server","API          "
+"STIGMAN_DB_SCHEMA","| **Default** ``stigman``
+| The schema where the STIG Manager object are found","API          "
+"STIGMAN_DB_TLS_CA_FILE","| **No default**
+| A file/path relative to the API /tls directory that contains the PEM encoded CA certificate used to sign the database TLS certificate. Setting this variable enables TLS connections to the database.","API          "
+"STIGMAN_DB_TLS_CERT_FILE","| **No default**
+| A file/path relative to the API /tls directory that contains the PEM encoded Client certificate used when authenticating the database client. Additionally requires setting values for ``STIGMAN_DB_TLS_CA_FILE`` and ``STIGMAN_DB_TLS_KEY_FILE``. ","API          "
+"STIGMAN_DB_TLS_KEY_FILE","| **No default**
+| A file/path relative to the API /tls directory that contains the PEM encoded Client private key used when authenticating the database client. Additionally requires setting values for ``STIGMAN_DB_TLS_CA_FILE`` and ``STIGMAN_DB_TLS_CERT_FILE``.","API          "
+"STIGMAN_DB_TYPE","| **Default** ``mysql``
+| The database type. Valid values are ``mysql`` ","API          "
+"STIGMAN_DB_USER","| **Default** ``stigman``
+| The user account used to login to the database ","API    "
+"STIGMAN_DOCS_DIRECTORY","| **Default** ``./docs``
+| The location of the documentation files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the docs are located at `../../docs/_build/html` relative to the API directory. ","API, documentation"
+"STIGMAN_DOCS_DISABLED","| **Default** ``false``
+| Whether to *not* serve the project Documentation.  NOTE: If you choose to serve the Client from the API container but not the Documentation, the links do the Docs on the home page will not work. ","Documentation                "
+"STIGMAN_INIT_IMPORT_SCAP","| **Default** ``false``
+| Whether to fetch and import current DISA SCAP content from public.cyber.mil on initial database migration","API          "
+"STIGMAN_INIT_IMPORT_STIGS","| **Default** ``false``
+| Whether to fetch and import the current DISA STIG Library compilation from public.cyber.mil on initial database migration ","API"
+"STIGMAN_LOG_LEVEL","| **Default** ``3``
+| Controls the granularity of the generated log output, from 1 to 4. Each level is inclusive of the ones before it. Level 1 will log only errors, level 2 includes warnings, level 3 includes status and transaction logs, and level 4 includes debug-level logs","API"
+"STIGMAN_LOG_MODE","| **Default** ``combined``
+| Controls whether the logs will create one “combined” log entry for http requests that includes both the request and response information; or two separate log entries, one for the request and one for the response, that can be correlated via a generated Request GUID in each entry","API"
+"STIGMAN_JWT_EMAIL_CLAIM","| **Default** ``email``
+| The access token claim whose value is the user's email address","API, Client"
+"STIGMAN_JWT_NAME_CLAIM","| **Default** ``name``
+| The access token claim whose value is the user's full name","API, Client"
+"STIGMAN_JWT_PRIVILEGES_CLAIM","| **Default** ``realm_access.roles``
+| The access token claim whose value is the user’s privileges ","API, Client"
+"STIGMAN_JWT_SCOPE_CLAIM","| **Default** ``scope``
+| The access token claim whose value is the user's scopes. Some OIDC Providers (Okta, Azure AD) use the claim ``scp`` to enumerate scopes","API, Client"
+"STIGMAN_JWT_SERVICENAME_CLAIM","| **Default** ``clientId``
+| The access token claim whose value is the user's client","API, Client"
+"STIGMAN_JWT_USERNAME_CLAIM","| **Default** ``preferred_username``
+| The access token claim whose value is the user's username","API, Client"
+"STIGMAN_OIDC_PROVIDER","| **Default** ``http://localhost:8080/auth/realms/stigman``
+| The base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended when fetching metadata.","API, Client     "
+"STIGMAN_SWAGGER_ENABLED","| **Default** ``false``
+| Whether to enable the SwaggerUI SPA at /api-docs ","API"
+"STIGMAN_SWAGGER_OIDC_PROVIDER","| **Default** Value of ``STIGMAN_OIDC_PROVIDER``
+| SwaggerUI override of the base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended by the SwaggerUI when fetching metadata.","API  "
+"STIGMAN_SWAGGER_REDIRECT","| **Default** ``http://localhost:54000/api-docs/oauth2-redirect.html``
+| The redirect URL sent by SwaggerUI to the OIDC provider when authorizing","API"
+"STIGMAN_SWAGGER_SERVER","| **Default** ``http://localhost:54000/api``
+| The API server URL relative to the SwaggerUI ","API"


### PR DESCRIPTION
Resolves #666.

- Adds support in the web app for opaque, non-JWT refresh tokens (Azure AD and Okta)
- Adds an envvar (`STIGMAN_CLIENT_SCOPE_PREFIX`) that instructs the web app to add the provided prefix to each scope requested during authentication. This behavior is needed when using Azure AD, which requires each scope be prefixed by `api://<application_id>`.
- Add support to the web app for token responses that do not include a refresh token. Okta will not generate a refresh token unless scope `offline_access` is requested (which can be configured with envvar `STIGMAN_CLIENT_EXTRA_SCOPES = offline_access`)
- API now handles scope claim serializations that are not compliant with [RFC 8693, section 4.2](https://datatracker.ietf.org/doc/html/rfc8693#section-4.2). Okta produces a JSON array instead of the standard space separated string.