### PR TITLE
fix: checkbox header behavior matches common use

### DIFF
--- a/client/src/js/overrides.js
+++ b/client/src/js/overrides.js
@@ -48,14 +48,21 @@ Ext.override(Ext.grid.CheckboxSelectionModel, {
             var hd = Ext.fly(t.parentNode);
             var isChecked = hd.hasClass('x-grid3-hd-checker-on');
             var isIndeterminate = hd.hasClass('x-grid3-hd-checker-ind');
-            if (isChecked || isIndeterminate) {
+            if (isChecked ) {
                 hd.removeClass('x-grid3-hd-checker-on');
-                hd.removeClass('x-grid3-hd-checker-ind');
-                this.clearSelections();
+                this.suspendEvents(false)
+                this.deselectRange(0, this.grid.store.getCount() - 1)
+                this.resumeEvents()
+                this.fireEvent('selectionchange', this)
+
             }
             else {
                 hd.addClass('x-grid3-hd-checker-on');
-                this.selectAll();
+                this.suspendEvents(false)
+                this.selectRange(0, this.grid.store.getCount() - 1)
+                this.resumeEvents()
+                this.fireEvent('selectionchange', this)
+        
             }
         }
     }


### PR DESCRIPTION
If any row is selected and the header shows the indeterminate state ("-"), clicking the header checkbox should *select* all records. This is the standard behavior in most UIs I've seen, but was not our behavior -- we were *deselecting* all records when the header checkbox show the indeterminate state. 

