### PR TITLE
fix: handle CKL with no root XML comment

### DIFF
--- a/client/src/js/SM/Parsers.js
+++ b/client/src/js/SM/Parsers.js
@@ -75,7 +75,7 @@
     if (!parsed.CHECKLIST[0].STIGS) throw (new Error("No STIGS element"))
   
     const comments = parsed['__comment']
-    const resultEngineCommon = comments.length ? processRootXmlComments(comments) : null
+    const resultEngineCommon = comments?.length ? processRootXmlComments(comments) : null
   
     let returnObj = {}
     returnObj.target = processAsset(parsed.CHECKLIST[0].ASSET[0])


### PR DESCRIPTION
CKL serializer was failing when parsing CKL with no root XML comment. Added the optional chaining operator.