### PR TITLE
fix: match review/history OAS defintions

### DIFF
--- a/api/source/controllers/Review.js
+++ b/api/source/controllers/Review.js
@@ -120,7 +120,7 @@ module.exports.postReviewsByAsset = async function postReviewsByAsset (req, res,
 }
 
 module.exports.deleteReviewByAssetRule = async function deleteReviewByAssetRule (req, res, next) {
-try {
+  try {
     let collectionId = req.params.collectionId
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
@@ -130,7 +130,7 @@ try {
       const userHasRule = await Review.checkRuleByAssetUser( ruleId, assetId, req.userObject )
       if (userHasRule) {
         let response = await Review.deleteReviewByAssetRule(assetId, ruleId, projection, req.userObject)
-        res.json(response)
+        res.status(response ? 204 : 200).json(response)
       }
       else {
         throw new SmError.PrivilegeError()

--- a/api/source/controllers/Review.js
+++ b/api/source/controllers/Review.js
@@ -130,7 +130,7 @@ module.exports.deleteReviewByAssetRule = async function deleteReviewByAssetRule 
       const userHasRule = await Review.checkRuleByAssetUser( ruleId, assetId, req.userObject )
       if (userHasRule) {
         let response = await Review.deleteReviewByAssetRule(assetId, ruleId, projection, req.userObject)
-        res.status(response ? 204 : 200).json(response)
+        res.status(response ? 200 : 204).json(response)
       }
       else {
         throw new SmError.PrivilegeError()

--- a/api/source/service/mysql/CollectionService.js
+++ b/api/source/service/mysql/CollectionService.js
@@ -1101,8 +1101,8 @@ from
 		  json_object(
         'ts', DATE_FORMAT(rh.ts, '%Y-%m-%dT%TZ'),
         'result', result.api,
-        'detail', LEFT(rh.detail,32767),
-        'comment', LEFT(rh.comment,32767),
+        'detail', COALESCE(LEFT(rh.detail,32767), ''),
+        'comment', COALESCE(LEFT(rh.comment,32767), ''),
         'autoResult', rh.autoResult = 1,
         'status', JSON_OBJECT(
           'label', status.api,

--- a/api/source/service/mysql/ReviewService.js
+++ b/api/source/service/mysql/ReviewService.js
@@ -498,13 +498,10 @@ exports.deleteReviewByAssetRule = async function(assetId, ruleId, projection, us
     
     connection = await dbUtils.pool.getConnection()
     await connection.query('START TRANSACTION')
-
     let sqlDelete = 'DELETE FROM review WHERE assetId = :assetId AND ruleId = :ruleId;';
-    await dbUtils.pool.query(sqlDelete, binds);
-
+    await connection.query(sqlDelete, binds);
     await dbUtils.updateStatsAssetStig( connection, { ruleId, assetId })
     await connection.commit()
-
     return (rows[0]);
   }
   catch (err) {

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1343,6 +1343,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ReviewAssetRuleRead'
+        '204':
+          description: No Content
         default:
           description: unexpected error
           content:

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "e928c328-f636-4e82-840d-0e3ce01094b7",
+		"_postman_id": "a6d57a4b-c56a-4131-a281-af470200d43b",
 		"name": "STIGMan OSS",
 		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:\n Name: Carl Smigielski\n Email: carl.a.smigielski@saic.com",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9301046"
+		"_exporter_id": "17450853"
 	},
 	"item": [
 		{
@@ -16184,8 +16184,8 @@
 											"    return;\r",
 											"}\r",
 											"else {\r",
-											"    pm.test(\"Status code is 200\", function () {\r",
-											"        pm.response.to.have.status(200);\r",
+											"    pm.test(\"Status code is 204\", function () {\r",
+											"        pm.response.to.have.status(204);\r",
 											"    });\r",
 											"}\r",
 											"if (pm.response.code !== 200) {\r",


### PR DESCRIPTION
Return responses in accordance with the OAS definitions for:
- `GET /collections/{collectionId}/review-history`
- `DELETE /collections/{collectionId}/reviews/{assetId}/{ruleId}`