### PR TITLE
feat: service worker handles streaming downloads

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -77,6 +77,10 @@ cp -r $SrcDir/img $DistDir
 echo "Preparing HTML resources"
 cp -r $SrcDir/index.html $DistDir/index.html
 
+# Service Worker
+echo "Preparing Service Worker resources"
+cp -r $SrcDir/serviceWorker.js $DistDir/serviceWorker.js
+
 # JS
 echo "Preparing JavaScript resources"
 mkdir $DistDir/js
@@ -88,6 +92,7 @@ uglifyjs \
 'js/SM/Global.js' \
 'js/SM/EventDispatcher.js' \
 'js/SM/Cache.js' \
+'js/SM/ServiceWorker.js' \
 'js/SM/TipContent.js' \
 'js/SM/Ajax.js' \
 'js/SM/Warnings.js' \

--- a/client/src/js/SM/ServiceWorker.js
+++ b/client/src/js/SM/ServiceWorker.js
@@ -1,0 +1,21 @@
+Ext.ns('SM.ServiceWorker')
+
+SM.ServiceWorker.getDownloadUrl = async function (request) {
+  const messageChannel = new MessageChannel()
+  if (navigator.serviceWorker?.controller) {
+    navigator.serviceWorker.controller.postMessage({
+      type: 'proxy-url-request',
+      request
+    }, [messageChannel.port1])
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(resolve, 3000)
+      messageChannel.port2.onmessage = (event) => {
+        clearTimeout(timer)
+        resolve(event.data)
+      }
+    })
+  }
+  else {
+    return null
+  }
+}

--- a/client/src/js/init.js
+++ b/client/src/js/init.js
@@ -88,6 +88,7 @@ function loadScripts() {
         'js/SM/Global.js',
         'js/SM/EventDispatcher.js',
         'js/SM/Cache.js',
+        'js/SM/ServiceWorker.js',
         'js/SM/TipContent.js',
         'js/SM/Ajax.js',
         'js/SM/Warnings.js',

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -29,6 +29,9 @@ Ext.Ajax.disableCaching = false
 async function start () {
 	let timer
 	try {
+		if ('serviceWorker' in navigator) {
+			await navigator.serviceWorker.register('serviceWorker.js')
+		}
 		timer = setTimeout(() => {
 			Ext.get( 'loading-text' ).dom.innerHTML = "Getting configuration..."
 		}, 250)

--- a/client/src/serviceWorker.js
+++ b/client/src/serviceWorker.js
@@ -1,0 +1,30 @@
+let counter = 0
+const requests = {}
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.onmessage = (event) => {
+  if (event.data?.type === 'proxy-url-request' && event.data.request) {
+    const port = event.ports[0]
+    const ourCounter = ++counter
+    requests[`${ourCounter}`] = event.data.request
+    port.postMessage(`service-proxy-${ourCounter}`)  
+  }
+}
+
+self.onfetch = (event) => {
+  if (event.request.url.includes('service-proxy-')) {
+    const key = event.request.url.match(/service-proxy-(\d+)/)[1]
+    const {url, ...init} = requests[key]
+    event.respondWith(fetch(url, init));
+  } 
+  else {
+    event.respondWith(fetch(event.request));
+  }
+}


### PR DESCRIPTION
Introduces a Web app service worker.

The service worker generates proxy URLs for streaming CKL/XCCDF requests that will trigger browser downloading when the proxy URL is assigned to `window.location`.