### PR TITLE
feat: retry transactions on deadlock

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -18,7 +18,7 @@ module.exports.createAsset = async function createAsset (req, res, next) {
 
     if ( elevate || (collectionGrant && collectionGrant.accessLevel >= 3) ) {
       try {
-        let asset = await Asset.createAsset( body, projection, elevate, req.userObject)
+        let asset = await Asset.createAsset( body, projection, elevate, req.userObject, res.svcStatus)
         res.status(201).json(asset)
       }
       catch (err) {
@@ -435,7 +435,8 @@ module.exports.replaceAsset = async function replaceAsset (req, res, next) {
       body,
       projection,
       transferring,
-      req.userObject
+      req.userObject,
+      res.svcStatus
     )
     res.json(response)
   }
@@ -640,7 +641,8 @@ module.exports.updateAsset = async function updateAsset (req, res, next) {
       body,
       projection,
       transferring,
-      req.userObject
+      req.userObject,
+      res.svcStatus
     )
     res.json(response)
   }

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -19,7 +19,7 @@ module.exports.createCollection = async function createCollection (req, res, nex
     const body = req.body
     if ( elevate || req.userObject.privileges.canCreateCollection ) {
       try {
-        const response = await CollectionSvc.createCollection( body, projection, req.userObject)
+        const response = await CollectionSvc.createCollection( body, projection, req.userObject, res.svcStatus)
         res.status(201).json(response)
       }
       catch (err) {
@@ -249,7 +249,7 @@ module.exports.getStigsByCollection = async function getStigsByCollection (req, 
   }
 }
 
-module.exports.replaceCollection = async function updateCollection (req, res, next) {
+module.exports.replaceCollection = async function replaceCollection (req, res, next) {
   try {
     const elevate = req.query.elevate
     const collectionId = req.params.collectionId
@@ -257,7 +257,7 @@ module.exports.replaceCollection = async function updateCollection (req, res, ne
     const body = req.body
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if ( elevate || (collectionGrant && collectionGrant.accessLevel >= 3) ) {
-      const response = await CollectionSvc.replaceCollection(collectionId, body, projection, req.userObject)
+      const response = await CollectionSvc.replaceCollection(collectionId, body, projection, req.userObject, res.svcStatus)
       res.json(response)
     }
     else {
@@ -279,7 +279,7 @@ module.exports.setStigAssetsByCollectionUser = async function setStigAssetsByCol
     if ( collectionGrant && collectionGrant.accessLevel >= 3 ) {
       const collectionResponse = await CollectionSvc.getCollection(collectionId, ['grants'], false, req.userObject )
       if (collectionResponse.grants.filter( grant => grant.accessLevel === 1 && grant.user.userId === userId).length > 0) {
-        const setResponse = await CollectionSvc.setStigAssetsByCollectionUser(collectionId, userId, stigAssets, req.userObject ) 
+        const setResponse = await CollectionSvc.setStigAssetsByCollectionUser(collectionId, userId, stigAssets, res.svcStatus ) 
         const getResponse = await CollectionSvc.getStigAssetsByCollectionUser(collectionId, userId, req.userObject )
         res.json(getResponse)    
       }
@@ -304,7 +304,7 @@ module.exports.updateCollection = async function updateCollection (req, res, nex
     const body = req.body
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if ( elevate || (collectionGrant && collectionGrant.accessLevel >= 3) ) {
-      let response = await CollectionSvc.replaceCollection(collectionId, body, projection, req.userObject)
+      let response = await CollectionSvc.replaceCollection(collectionId, body, projection, req.userObject, res.svcStatus)
       res.json(response)
     }
     else {
@@ -551,7 +551,7 @@ module.exports.putAssetsByCollectionLabelId = async function (req, res, next) {
     let collection = await CollectionSvc.getCollection( collectionId, ['assets'], false, req.userObject)
     let collectionAssets = collection.assets.map( a => a.assetId)
     if (assetIds.every( a => collectionAssets.includes(a))) {
-      await CollectionSvc.putAssetsByCollectionLabelId( collectionId, labelId, assetIds )
+      await CollectionSvc.putAssetsByCollectionLabelId( collectionId, labelId, assetIds, res.svcStatus )
       const response = await CollectionSvc.getAssetsByCollectionLabelId( collectionId, req.params.labelId, req.userObject )
       res.json(response)
     }

--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -25,7 +25,7 @@ module.exports.importBenchmark = async function importManualBenchmark (req, res,
       throw new SmError.UnprocessableError('SCAP Benchmarks are not imported.')
     }
     else {
-      response = await STIG.insertManualBenchmark(benchmark, xmlData)
+      response = await STIG.insertManualBenchmark(benchmark, res.svcStatus)
     }
     res.json(response)
   }
@@ -45,7 +45,7 @@ module.exports.deleteRevisionByString = async function deleteRevisionByString (r
 
     }
     else {
-      await STIG.deleteRevisionByString(benchmarkId, revisionStr, req.userObject)
+      await STIG.deleteRevisionByString(benchmarkId, revisionStr, res.svcStatus)
       res.json(response)
     }
   }
@@ -58,7 +58,7 @@ module.exports.deleteStigById = async function deleteStigById (req, res, next) {
   if ( req.userObject.privileges.canAdmin ) {
     try {
       let benchmarkId = req.params.benchmarkId
-      let response = await STIG.deleteStigById(benchmarkId, req.userObject)
+      let response = await STIG.deleteStigById(benchmarkId, req.userObject, res.svcStatus)
       res.json(response)
     }
     catch (err) {

--- a/api/source/controllers/User.js
+++ b/api/source/controllers/User.js
@@ -23,7 +23,7 @@ module.exports.createUser = async function createUser (req, res, next) {
         }
       }
       try {
-        let response = await User.createUser(body, projection, elevate, req.userObject)
+        let response = await User.createUser(body, projection, elevate, req.userObject, res.svcStatus)
         res.status(201).json(response)
       }
       catch (err) {
@@ -134,7 +134,7 @@ module.exports.replaceUser = async function replaceUser (req, res, next) {
         }
       }
 
-      let response = await User.replaceUser(userId, body, projection, elevate, req.userObject)
+      let response = await User.replaceUser(userId, body, projection, elevate, req.userObject, res.svcStatus)
       res.json(response)
     }
     else {
@@ -164,7 +164,7 @@ module.exports.updateUser = async function updateUser (req, res, next) {
         }
       }
 
-      let response = await User.replaceUser(userId, body, projection, elevate, req.userObject)
+      let response = await User.replaceUser(userId, body, projection, elevate, req.userObject, res.svcStatus)
       res.json(response)
     }
     else {

--- a/api/source/utils/fetchStigs.js
+++ b/api/source/utils/fetchStigs.js
@@ -84,7 +84,7 @@ async function processZip (f) {
         logger.writeWarning(logComponent, logType, { message: `Did not import SCAP benchmark`, member: xml })      
       }
       else {
-        response = await STIG.insertManualBenchmark(benchmark, xmlData)
+        response = await STIG.insertManualBenchmark(benchmark)
       }
       logger.writeInfo(logComponent, logType, { message: `imported`, member: xml })      
     }

--- a/api/source/utils/logger.js
+++ b/api/source/utils/logger.js
@@ -90,6 +90,7 @@ function requestLogger (req, res, next) {
   req._startTime = undefined
   res._startAt = undefined
   res._startTime = undefined
+  res.svcStatus = {}
 
   // Response body handling for privileged requests
   let responseBody = undefined
@@ -111,26 +112,28 @@ function requestLogger (req, res, next) {
     writeInfo('rest', 'request', serializeRequest(req))
   }
 
-  function logResponse (err, response) {
+  function logResponse () {
     if (config.log.mode === 'combined') {
       writeInfo(req.component || 'rest', 'transaction', {
-        request: serializeRequest(response.req),
+        request: serializeRequest(res.req),
         response: {
           date: res._startTime,
-          status: response.statusCode,
-          headers: response.getHeaders(),
-          errorBody: response.errorBody,
+          status: res.statusCode,
+          headers: res.getHeaders(),
+          errorBody: res.errorBody,
           responseBody
         },
+        retries: res.svcStatus?.retries,
         durationMs: Number(res._startTime - req._startTime)
       })  
     }
     else {
       writeInfo(req.component || 'rest', 'response', {
-        requestId: response.req.requestId,
-        status: response.statusCode,
-        headers: response.getHeaders(),
-        errorBody: response.errorBody
+        requestId: res.req.requestId,
+        status: res.statusCode,
+        headers: res.getHeaders(),
+        errorBody: res.errorBody,
+        retries: res.svcStatus?.retries,
       })  
     }
   }


### PR DESCRIPTION
Resolves #670 

For the MySQL services, wraps each multi-statement transaction with a method suitable for use with `async-retry`. The method is  retried if the transaction generates a deadlock error, otherwise the method throws as normal. The retry logic accepts a `statusObj` object which is used to provide the retry count to the output logs.

The `async-retry` options are
```
{
    retries: 15,
    factor: 1,
    minTimeout: 200,
    maxTimeout: 200
}
```