### PR TITLE
fix: dark-mode mask; collection dropdown height

### DIFF
--- a/client/src/css/dark-mode.css
+++ b/client/src/css/dark-mode.css
@@ -1334,7 +1334,7 @@ a.x-menu-item {
     background-color: transparent;
 }
 .ext-el-mask {
-    background-color: rgb(53, 57, 59);
+    background-color: rgb(0 0 0 / 65%);
 }
 .ext-el-mask-msg {
     border-color: rgb(39, 76, 124);
@@ -2631,7 +2631,7 @@ body.x-body-masked .x-window-plain .x-window-mc {
     background-image: url("../ext/resources/images/default/window/icon-error.gif");
 }
 .ext-el-mask {
-    background-color: rgb(53, 57, 59);
+    background-color: rgb(0 0 0 / 65%);
 }
 .ext-el-mask-msg {
     border-color: rgb(77, 83, 86);

--- a/client/src/js/SM/CollectionGrant.js
+++ b/client/src/js/SM/CollectionGrant.js
@@ -199,6 +199,7 @@ SM.CollectionGrantsGrid = Ext.extend(Ext.grid.GridPanel, {
         const collectionSelectionField = new SM.CollectionSelectionField({
             submitValue: false,
             grid: this,
+            maxHeight: 150,
             filteringStore: grantStore,
             getListParent: function() {
                 return this.grid.editor.el;


### PR DESCRIPTION
- sets transparency for the dark-mode masks
- sets height of the Collection dropdown in the User Properties dialog to 150px, which keeps it entirely in view