### PR TITLE
fix: empty commentary removes commentary

### DIFF
--- a/client/src/js/review.js
+++ b/client/src/js/review.js
@@ -1230,8 +1230,8 @@ async function addReview( params ) {
       let fvalues = fp.getForm().getFieldValues(false, false) // dirtyOnly=false, getDisabled=true
       let jsonData = {
         result: fvalues.result,
-        detail: fvalues.detail || null,
-        comment: fvalues.comment || null,
+        detail: fvalues.detail,
+        comment: fvalues.comment,
         resultEngine: fp.resultChanged() ? null : fvalues.resultEngine
       }
       let result, reviewFromApi
@@ -1261,7 +1261,7 @@ async function addReview( params ) {
             params: {
               projection: 'history'
             },
-            jsonData: jsonData
+            jsonData
           })
           reviewFromApi = JSON.parse(result.response.responseText)
           break
@@ -1274,7 +1274,7 @@ async function addReview( params ) {
             params: {
               projection: 'history'
             },
-            jsonData: jsonData
+            jsonData
           })
           reviewFromApi = JSON.parse(result.response.responseText)
           break
@@ -1287,7 +1287,7 @@ async function addReview( params ) {
             params: {
               projection: 'history'
             },
-            jsonData: jsonData
+            jsonData
           })
           reviewFromApi = JSON.parse(result.response.responseText)
           break


### PR DESCRIPTION
### Previous behavior
In the Asset/STIG workspace, saving (with or without submitting) an empty `detail` or `comment` generates a PUT request with a `null` value for the field (which the API defines as a request to preserve the existing value). This makes it impossible for users to clear commentary using the workspace.

### This PR
In the Asset/STIG workspace, saving (with or without submitting) an empty `detail` or `comment` generates a PUT request to the API with an empty string `''` value for the field (which the API applies to update the value). This makes it possible for users to clear commentary using the workspace.
