### PR TITLE
fix: BufferView renders correctly when zoomed out

### DIFF
--- a/client/src/js/BufferView.js
+++ b/client/src/js/BufferView.js
@@ -70,13 +70,10 @@ Ext.ux.grid.BufferView = Ext.extend(Ext.grid.GridView, {
 		return Ext.isBorderBox ? (this.rowHeight + this.borderHeight) : this.rowHeight;
 	},
 
-	getCalculatedRowHeight : function(){
-		return this.rowHeight + this.borderHeight;
+	getCalculatedRowHeight: function () {
+		return this.scroller.dom.scrollHeight === this.scroller.dom.clientHeight ?
+		this.rowHeight + this.borderHeight : this.scroller.dom.scrollHeight / this.ds.getCount();
 	},
-	// getCalculatedRowHeight: function () {
-	// 	return this.scroller.dom.scrollHeight === this.scroller.dom.clientHeight ?
-	// 	this.rowHeight + this.borderHeight : this.scroller.dom.scrollHeight / this.ds.getCount();
-	// },
 
 	getVisibleRowCount : function(){
 		var rh = this.getCalculatedRowHeight(),


### PR DESCRIPTION
Changes to `BufferView.getCalculatedRowHeight()` caused the grid rows to render incorrectly when the page was zoomed out. I reverted to the original implementation, which was still present but commented out. The commented out section did not include an explanation of why the original method was modified and that method is testing fine now.