### PR TITLE
fix: BufferView calls column renderer with proper scope

### DIFF
--- a/client/src/js/BufferView.js
+++ b/client/src/js/BufferView.js
@@ -117,7 +117,7 @@ Ext.ux.grid.BufferView = Ext.extend(Ext.grid.GridView, {
 					p.id = c.id;
 					p.css = i === 0 ? 'x-grid3-cell-first ' : (i == last ? 'x-grid3-cell-last ' : '');
 					p.attr = p.cellAttr = "";
-					p.value = c.renderer(r.data[c.name], p, r, rowIndex, i, ds);
+					p.value = c.renderer.call(c.scope || c, r.data[c.name], p, r, rowIndex, i, ds);
 					p.style = c.style;
 					if (p.value === undefined || p.value === "") {
 						p.value = "&#160;";

--- a/client/src/js/SM/Metrics.js
+++ b/client/src/js/SM/Metrics.js
@@ -7,7 +7,7 @@ Chart.defaults.font = {
 
 SM.Metrics.Renderers = {
   severityCount: function (v, md) {
-    return v === 0 ? '' : `<div class="sm-metrics-findings-count-cell sm-metrics-${this.scope?.dataIndex}-box">${v}</div>`
+    return v === 0 ? '' : `<div class="sm-metrics-findings-count-cell sm-metrics-${this.dataIndex}-box">${v}</div>`
   }
 }
 


### PR DESCRIPTION
Patches `BufferView` so column renderers are called with the correct scope. The previous implementation broke the `highlighterShim` provided by `SM.ColumnFilters.Renderers` and string filters would not highlight matching characters.

Also reverts a workaround added to the Metrics severity renderer to make it work with unpatched `BufferView`. The workaround is no longer needed. 