### PR TITLE
chore: update actions to avoid deprecation warnings

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -9,7 +9,9 @@ jobs:
     steps:
       - 
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - 
         name: Install uglify-js
         run: npm install -g uglify-js
@@ -19,7 +21,7 @@ jobs:
         run: ./build.sh
       - 
         name: Upload distribution
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: client-dist
           path: ./client/dist

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,14 +9,16 @@ jobs:
     steps:
       - 
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       -
         name: run image, generating docs
         working-directory: ./docs
         run: ./build.sh
       - 
         name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: docs-build
           path: ./docs/_build/html

--- a/.github/workflows/pub-docker.yml
+++ b/.github/workflows/pub-docker.yml
@@ -30,29 +30,29 @@ jobs:
     steps:
       - 
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ref: main
+          ref: ${{ github.ref }}
           fetch-depth: 0
       -
         name: Download client distribution
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: client-dist
           path: ./client/dist
       -
         name: Download documentation
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docs-build
           path: ./docs/_build/html          
       - 
         name: Get repository metadata
         id: repo
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
-            const repo = await github.repos.get(context.repo)
+            const repo = await github.rest.repos.get(context.repo)
             return repo.data
       - 
         name: Prepare variables
@@ -65,26 +65,26 @@ jobs:
           TAG=$(git describe --tags --abbrev=0)
           TAGS=${DOCKER_IMAGE}:latest
           [[ ${{ github.ref_type }} == "tag" ]] && TAGS="$TAGS,${DOCKER_IMAGE}:${{ github.ref_name }}" 
-          echo ::set-output name=version::${TAG}
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=tag::${TAG}
-          echo ::set-output name=branch::${BRANCH}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=describe::${DESCRIBE}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')                    
+          echo "version=${TAG}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "tab=${TAG}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - 
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - 
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_ORG_OWNER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_OWNER_PW }}
       - 
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile
@@ -126,29 +126,29 @@ jobs:
     steps:
       - 
         name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: main
           fetch-depth: 0
       -
         name: Download client distribution
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: client-dist
           path: ./client/dist
       -
         name: Download documentation
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: docs-build
           path: ./docs/_build/html          
       - 
         name: Get repository metadata
         id: repo
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
-            const repo = await github.repos.get(context.repo)
+            const repo = await github.rest.repos.get(context.repo)
             return repo.data
       - 
         name: Prepare variables
@@ -161,25 +161,25 @@ jobs:
           TAG=$(git describe --tags --abbrev=0)
           TAGS="${DOCKER_IMAGE}:latest-ironbank"
           [[ ${{ github.ref_type }} == "tag" ]] && TAGS="$TAGS,${DOCKER_IMAGE}:${{ github.ref_name }}-ironbank" 
-          echo ::set-output name=version::${TAG}
-          echo ::set-output name=sha::${SHA}
-          echo ::set-output name=tag::${TAG}
-          echo ::set-output name=branch::${BRANCH}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=describe::${DESCRIBE}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')                    
+          echo "version=${TAG}" >> $GITHUB_OUTPUT
+          echo "sha=${SHA}" >> $GITHUB_OUTPUT
+          echo "tab=${TAG}" >> $GITHUB_OUTPUT
+          echo "branch=${BRANCH}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "describe=${DESCRIBE}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - 
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - 
         name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_ORG_OWNER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ORG_OWNER_PW }}
       - 
         name: Login to Iron Bank
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: registry1.dso.mil
           username: ${{ secrets.IRONBANK_USERNAME }}
@@ -187,7 +187,7 @@ jobs:
       - 
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Updates the external scripts used in the Docker Publish actions so warnings are no longer generated.

Also, updates statements that produce the output of the `prep` step in accordance with [GitHub guidance](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).