### PR TITLE
fix: provide last fetched metrics when onlyRefreshView = true

### DIFF
--- a/client/src/js/SM/Metrics.js
+++ b/client/src/js/SM/Metrics.js
@@ -1456,7 +1456,7 @@ SM.Metrics.addCollectionMetricsTab = async function (options) {
     const { collectionId, collectionName, treePath, initialLabelIds } = options
     let currentBaseParams = initialLabelIds.length ? { labelId: initialLabelIds } : undefined
     let currentLabelIds = initialLabelIds
-    let lastApiRefresh
+    let lastApiRefresh, lastApiCollectionMetrics
     const updateDataDelay = 300000
     const updateOverviewTitleDelay = 60000
     let updateDataTimer, refreshViewTimer, updateOverviewTitleInterval
@@ -1480,7 +1480,8 @@ SM.Metrics.addCollectionMetricsTab = async function (options) {
         params
       })
       lastApiRefresh = new Date()
-      return JSON.parse(results.response.responseText)
+      lastApiCollectionMetrics = JSON.parse(results.response.responseText)
+      return lastApiCollectionMetrics
     }
     
     const overviewPanel = new SM.Metrics.OverviewPanel({
@@ -1615,7 +1616,7 @@ SM.Metrics.addCollectionMetricsTab = async function (options) {
     async function updateData (onlyRefreshView = false) {
       try {
         console.log(`${collectionName}: executing updateData(${onlyRefreshView})`)
-        let apiMetricsCollection
+        let apiMetricsCollection = lastApiCollectionMetrics
         if (!onlyRefreshView) {
           console.log(`${collectionName}: cancelling refreshView timer, id ${refreshViewTimer}`)
           clearTimeout(refreshViewTimer)

--- a/client/src/js/SM/Metrics.js
+++ b/client/src/js/SM/Metrics.js
@@ -1456,7 +1456,7 @@ SM.Metrics.addCollectionMetricsTab = async function (options) {
     const { collectionId, collectionName, treePath, initialLabelIds } = options
     let currentBaseParams = initialLabelIds.length ? { labelId: initialLabelIds } : undefined
     let currentLabelIds = initialLabelIds
-    let lastApiRefresh, lastApiCollectionMetrics
+    let lastApiRefresh, lastApiMetricsCollection
     const updateDataDelay = 300000
     const updateOverviewTitleDelay = 60000
     let updateDataTimer, refreshViewTimer, updateOverviewTitleInterval
@@ -1480,8 +1480,8 @@ SM.Metrics.addCollectionMetricsTab = async function (options) {
         params
       })
       lastApiRefresh = new Date()
-      lastApiCollectionMetrics = JSON.parse(results.response.responseText)
-      return lastApiCollectionMetrics
+      lastApiMetricsCollection = JSON.parse(results.response.responseText)
+      return lastApiMetricsCollection
     }
     
     const overviewPanel = new SM.Metrics.OverviewPanel({
@@ -1616,7 +1616,7 @@ SM.Metrics.addCollectionMetricsTab = async function (options) {
     async function updateData (onlyRefreshView = false) {
       try {
         console.log(`${collectionName}: executing updateData(${onlyRefreshView})`)
-        let apiMetricsCollection = lastApiCollectionMetrics
+        let apiMetricsCollection = lastApiMetricsCollection
         if (!onlyRefreshView) {
           console.log(`${collectionName}: cancelling refreshView timer, id ${refreshViewTimer}`)
           clearTimeout(refreshViewTimer)


### PR DESCRIPTION
The Metrics Report is generating error popups every 30 seconds if the Oldest, Newest or Updated fields show a duration < 1 hour ago. In this situation, the updateData handler is being called with `onlyRefreshView = true`, which skips fetching a value for `apiMetricsCollection`. The uninitialized value is then being passed to the component updaters, which generate errors when trying to access its properties.

This PR adds a closure variable `lastApiMetricsCollection` to hold the last fetched metrics. This value is assigned to `apiMetricsCollection` when `onlyRefreshView = true`