### PR TITLE
fix: collection review - no column wrap

### DIFF
--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -815,7 +815,7 @@ async function addCollectionReview ( params ) {
 					dataIndex: 'detail',
 					renderer: function (v) {
 						v = v?.length > SM.TruncateLimit ? v.slice(0,SM.TruncateLimit) + '...' : SM.styledEmptyRenderer(v)
-						return columnWrap.apply(this, arguments)
+						return v
 					},
 					sortable: true,
 					filter: {
@@ -851,7 +851,7 @@ async function addCollectionReview ( params ) {
 					dataIndex: 'comment',
 					renderer: function (v) {
 						v = v?.length > SM.TruncateLimit ? v.slice(0,SM.TruncateLimit) + '...' : SM.styledEmptyRenderer(v)
-						return columnWrap.apply(this, arguments)
+						return v
 					},
 					filter: {
 						type: 'string'


### PR DESCRIPTION
In Collection Review of a STIG, do not wrap the text in `detail` or `comment`. This ensures each row has a consistent height, which is a requirement for `BufferView` to correctly render.