### PR TITLE
fix: include disabled field values

### DIFF
--- a/client/src/js/review.js
+++ b/client/src/js/review.js
@@ -1263,7 +1263,7 @@ async function addReview( params ) {
       // })
       // masktask.delay(100)
 
-      let fvalues = fp.getForm().getFieldValues(false, false) // dirtyOnly=false, getDisabled=true
+      let fvalues = fp.getForm().getFieldValues(false, true) // dirtyOnly=false, getDisabled=true
       let jsonData = {
         result: fvalues.result,
         detail: fvalues.detail,


### PR DESCRIPTION
Saving  a Review with a disabled commentary field produces an illegal request to the API. This PR fixes that by getting all field values, including disabled fields.