### PR TITLE
fix: transfer assets request uses scoped variable

### DIFF
--- a/client/src/js/SM/CollectionAsset.js
+++ b/client/src/js/SM/CollectionAsset.js
@@ -329,7 +329,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                           })
                           let returnedAsset = JSON.parse(result.response.responseText)
                           result = await Ext.Ajax.requestPromise({
-                            url: `${STIGMAN.Env.apiBase}/collections/${collectionId}/metrics/summary/asset`,
+                            url: `${STIGMAN.Env.apiBase}/collections/${me.collectionId}/metrics/summary/asset`,
                             method: 'GET',
                             params: {
                                 assetId: thisRecord.data.assetId


### PR DESCRIPTION
After successfully transferring an asset, the Asset grid fails to reload. This PR fixes that.