### PR TITLE
fix: non-compliance result disables submit

### DIFF
--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -1257,6 +1257,7 @@ async function addCollectionReview ( params ) {
 
 		function isReviewComplete (result, rcomment, acomment) {
 			if (!result) return false
+			if (result !== 'pass' && result !== 'fail' && result !== 'notapplicable') return false
       if (apiFieldSettings.detail.required === 'always' && !rcomment) return false
       if (apiFieldSettings.detail.required === 'findings' 
         && result === 'fail'


### PR DESCRIPTION
The Collection Review tab will allow attempted submission of reviews with a non-compliance result (informational, etc.). This PR adds a test to `isReviewComplete()` that returns false if a selected review has a non-compliance result.