### PR TITLE
Create revision string only if STIG version and Release info supports it.

### DIFF
--- a/client/src/js/SM/Parsers.js
+++ b/client/src/js/SM/Parsers.js
@@ -123,13 +123,14 @@
       iStigElement.forEach(iStig => {
         let checklist = {}
         // get benchmarkId
-        let stigIdElement = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'stigid' )[0]
+        let stigIdElement = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'stigid' )?.[0]
         checklist.benchmarkId = stigIdElement.SID_DATA.replace('xccdf_mil.disa.stig_benchmark_', '')
-        // get revision
-        const stigVersion = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'version' )[0].SID_DATA
-        let stigReleaseInfo = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'releaseinfo' )[0].SID_DATA
-        const stigRelease = stigReleaseInfo.match(/Release:\s*(.+?)\s/)[1]
-        const stigRevisionStr = `V${stigVersion}R${stigRelease}`
+        // get revision data. Extract digits from version and release fields to create revisionStr, if possible.
+        const stigVersionData = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'version' )?.[0].SID_DATA
+        let stigVersion = stigVersionData.match(/(\d+)/)?.[1]
+        let stigReleaseInfo = iStig.STIG_INFO[0].SI_DATA.filter( d => d.SID_NAME === 'releaseinfo' )?.[0].SID_DATA
+        const stigRelease = stigReleaseInfo.match(/Release:\s*(.+?)\s/)?.[1]
+        const stigRevisionStr = stigVersion && stigRelease ? `V${stigVersion}R${stigRelease}` : null
         checklist.revisionStr = stigRevisionStr
   
         if (checklist.benchmarkId) {


### PR DESCRIPTION
Create revision string only if STIG version and Release info supports it. Otherwise null.