### PR TITLE
fix: manage stig grid reload

### DIFF
--- a/client/src/js/SM/CollectionStig.js
+++ b/client/src/js/SM/CollectionStig.js
@@ -617,7 +617,6 @@ async function showCollectionStigProps( benchmarkId, parentGrid ) {
                             jsonData: values.assets
                         })
                         const apiStigAssets = JSON.parse(result.response.responseText)
-                        parentGrid.getStore().reload()
                         SM.Dispatcher.fireEvent('stigassetschanged', btn.collectionId, values.benchmarkId, apiStigAssets)
                         appwindow.close()
                     }

--- a/client/src/js/overrides.js
+++ b/client/src/js/overrides.js
@@ -78,10 +78,10 @@ Ext.getBody = function () {
 Ext.LoadMask.prototype.onBeforeLoad = function() {
     if(!this.disabled){
         if (this.store.smMaskDelay) {
-            this.smTask = new Ext.util.DelayedTask(function () {
-                this.el.mask(this.msg, this.msgCls)
-            }, this)
-            this.smTask.delay(this.store.smMaskDelay)
+            if (this.smTask) {
+                clearTimeout(this.smTask)
+            }
+            this.smTask = setTimeout(this.el.mask.bind(this.el), this.store.smMaskDelay, this.msg, this.msgCls)
         }
         else {
             this.el.mask(this.msg, this.msgCls)
@@ -90,7 +90,7 @@ Ext.LoadMask.prototype.onBeforeLoad = function() {
 }
 Ext.LoadMask.prototype.onLoad = function() {
     if (this.smTask) {
-        this.smTask.cancel()
+        clearTimeout(this.smTask)
     }
     this.el.unmask(this.removeMask);
 }


### PR DESCRIPTION
Resolves an issue observed in the wild where the Collection Manage -> STIG grid was not removing its load mask.

- removes a redundant call to reload the grid after an update
- refactors the override to Ext.LodMask which delays the display of the load mask, ensuring that any existing timers are cancelled.