### PR TITLE
feat: logout button in navtree header

### DIFF
--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -1881,3 +1881,11 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   background-image: url(../img/line-height-down.svg);
   background-size: 16px 16px;
 }
+.x-tool.x-tool-logout {
+  background-image: url(../img/logout.svg);
+  background-repeat: no-repeat;
+  background-size: 14px 14px;
+}
+.x-tool.x-tool-logout:hover {
+  filter: brightness(125%)
+}

--- a/client/src/img/logout.svg
+++ b/client/src/img/logout.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg8"
+   sodipodi:docname="logout-2.svg"
+   inkscape:version="1.0.2 (1.0.2+r75+1)"><defs
+   id="defs12" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1023"
+   id="namedview10"
+   showgrid="false"
+   inkscape:zoom="0.852"
+   inkscape:cx="501.17371"
+   inkscape:cy="453.05164"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg8" />
+<metadata
+   id="metadata2"> Svg Vector Icons : http://www.onlinewebfonts.com/icon <rdf:RDF><cc:Work
+     rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata>
+<g
+   id="g6"
+   style="fill:#808080;fill-opacity:1"><path
+     d="M757.5,152.1c30.1,22,56.9,46.8,80.3,74.6c23.4,27.8,43.5,57.8,60.2,90.1c16.7,32.3,29.4,66.4,38.1,102.4c8.7,36,13.1,72.6,13.1,109.6c0,63.8-11.9,123.7-35.6,179.6c-23.7,55.9-55.9,104.7-96.4,146.2c-40.5,41.5-88,74.5-142.5,98.8C620.1,977.8,561.7,990,499.5,990c-61.6,0-119.6-12.2-174.1-36.5c-54.5-24.4-102.2-57.3-143-98.8c-40.8-41.5-72.9-90.3-96.4-146.2c-23.4-55.9-35.1-115.8-35.1-179.6c0-36.4,4.2-72.1,12.6-107.1c8.4-35,20.2-68.3,35.6-99.8c15.4-31.6,34.5-61.1,57.2-88.5c22.8-27.5,48.2-52.2,76.3-74.1c14.7-11,30.6-15.1,47.7-12.4c17.1,2.7,30.9,11.3,41.7,25.7c10.7,14.4,14.7,30.5,12,48.4c-2.7,17.8-11,32.3-25.1,43.2c-42.2,31.6-74.4,70.3-96.9,116.3c-22.4,46-33.6,95.4-33.6,148.2c0,45.3,8.4,88,25.1,128.2c16.7,40.1,39.6,75.1,68.8,105c29.1,29.9,63.2,53.5,102.4,71c39.1,17.5,80.8,26.3,125,26.3c44.2,0,85.8-8.8,125-26.3c39.1-17.5,73.3-41.2,102.4-71c29.1-29.9,52.2-64.9,69.3-105c17.1-40.2,25.6-82.9,25.6-128.2c0-53.5-12-104.1-36.1-151.8c-24.1-47.7-57.9-87-101.4-117.9c-14.7-10.3-23.6-24.4-26.6-42.2c-3-17.9,0.5-34.3,10.5-49.4c10-14.4,23.8-23.2,41.2-26.2C726.7,138.2,742.7,141.8,757.5,152.1L757.5,152.1z M499.5,531.9c-17.4,0-32.3-6.3-44.7-19c-12.4-12.7-18.6-28-18.6-45.8V75.9c0-17.8,6.2-33.3,18.6-46.3c12.4-13,27.3-19.6,44.7-19.6c18.1,0,33.3,6.5,45.7,19.6c12.4,13,18.6,28.5,18.6,46.3v391.2c0,17.8-6.2,33.1-18.6,45.8C532.8,525.6,517.6,531.9,499.5,531.9L499.5,531.9z"
+     id="path4"
+     style="fill:#808080;fill-opacity:1" /></g>
+</svg>

--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -427,7 +427,14 @@ SM.AppNavTree = Ext.extend(Ext.tree.TreePanel, {
           autoScroll: true,
           split: true,
           collapsible: true,
-          title: `<span onclick="window.oidcProvider.logout()">${curUser.displayName === 'USER' ? SM.he(curUser.username) : SM.he(curUser.displayName)} - Logout</span>`,
+          collapseFirst: false,
+          tools: [
+            {
+              id: 'logout',
+              handler: window.oidcProvider.logout
+            },
+          ],
+          title: `${curUser.displayName === 'USER' ? SM.he(curUser.username) : SM.he(curUser.displayName)}`,
           bodyStyle: 'padding:5px;',
           width: me.width || 300,
           minSize: 220,
@@ -1105,7 +1112,7 @@ SM.AppNavTree = Ext.extend(Ext.tree.TreePanel, {
     },
     treeRender: function (tree) {
       new Ext.ToolTip({
-          target: tree.header,
+          target: tree.header.dom.querySelector(`.${tree.headerTextCls}`),
           showDelay: 1000,
           dismissDelay: 0,
           width: 600,

--- a/client/src/js/oidcProvider.js
+++ b/client/src/js/oidcProvider.js
@@ -519,7 +519,7 @@
 
         kc.createLogoutUrl = function(options) {
             var url = kc.endpoints.logout()
-                + '?redirect_uri=' + encodeURIComponent(adapter.redirectUri(options, false));
+                + '';
 
             return url;
         }


### PR DESCRIPTION
The current logout functionality produces an error in current Keycloak (by sending a non-standard redirect_uri parameter).

This PR fixes that and changes the logout action from a click on the NavTree header to a header tool button.