### PR TITLE
fix: sort assets when building tree node

### DIFF
--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -868,6 +868,7 @@ SM.AppNavTree = Ext.extend(Ext.tree.TreePanel, {
               params
             })
             let apiCollectionAssets = JSON.parse(result.response.responseText)
+            apiCollectionAssets.sort((a,b) => a.name.localeCompare(b.name))
             let content = apiCollectionAssets.map(asset => SM.AssetNodeConfig(collectionId, asset))
             cb(content, { status: true })
             return


### PR DESCRIPTION
Resolves #853 

Since the API response is not sorted, perform sort in the client when rendering Assets tree nodes.