### PR TITLE
fix: changed review status import option label from "Null" to "Keep Existing" for better clarity.

### DIFF
--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -721,7 +721,7 @@ SM.ReviewsImport.AutoStatusComboBox = Ext.extend(SM.ReviewsImport.HelperComboBox
             helpText: SM.TipContent.ImportOptions.AutoStatus
         }
         const data = [
-            ['null', 'Null'],
+            ['null', 'Keep Existing'],
             ['saved', 'Saved'],
             ['submitted', 'Submitted']
         ]

--- a/client/src/js/SM/TipContent.js
+++ b/client/src/js/SM/TipContent.js
@@ -3,7 +3,7 @@ Ext.ns('SM.TipContent')
 Ext.ns('SM.TipContent.ImportOptions')
 
 SM.TipContent.ImportOptions.AutoStatus = `Choose the "Goal" status for imported reviews.
-<br><br><b>Null:</b> Keep existing status, if possible. New reviews are set to "Saved" status.
+<br><br><b>Keep Existing:</b> Keep existing status, if possible. New reviews are set to "Saved" status. The resulting Status will also take into consideration the "Reset to Saved" configuration that is set in the Review Status section of Collection Settings. 
 <br><br><b>Saved:</b> Set Reviews to "Saved" status.
 <br><br><b>Submitted:</b> Set Review to "Submitted" status. If review does not meet Submit requirements, Review will be set to Saved.
 <br><br><b>Accepted:</b> If importing user has the proper grant, set Review to "Accepted". If they cannot Accept, Reviews will be set to "Submitted." If review does not meet Submit requirements, Review will be set to "Saved."

--- a/docs/user-guide/user-guide.rst
+++ b/docs/user-guide/user-guide.rst
@@ -823,7 +823,7 @@ These import setting preferences can be locked for your Collection, or you can a
 If possible, set Review status to:
   This setting allows you to set a "Goal" status for your review of Accepted, Submitted, Saved, OR, for existing reviews, to leave the status as it was, if possible. 
 
-  - **Null**: Leave the Status as it is.
+  - **Keep Existing**: Keep the existing Status, if possible. New reviews are set to "Saved" status. The resulting Status will also take into consideration the "Reset to Saved" configuration that is set in the Review Status section of Collection Settings. 
   - **Accepted**: If importing user has the proper grant, set Review to "Accepted." If they cannot Accept, Reviews will be set to "Submitted." If review does not meet Submit requirements, Review will be set to "Saved."
   - **Submitted**: Set Review to "Submitted" status. If review does not meet Submit requirements, Review will be set to Saved.
   - **Saved**:(**default setting**) Set Reviews to "Saved" status.


### PR DESCRIPTION
fix: changed review status import option label from "Null" to "Keep Existing" for better clarity. Updated tooltip and docs as well.