### PR TITLE
chore: stigs and checklists keep getting bigger. Changed STIGMAN_API_MAX_JSON_BODY default value from 5mb to 10mb. 

### DIFF
--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -42,7 +42,7 @@ let config = {
     http: {
         address: process.env.STIGMAN_API_ADDRESS || "0.0.0.0",
         port: process.env.STIGMAN_API_PORT || 54000,
-        maxJsonBody: process.env.STIGMAN_API_MAX_JSON_BODY || "10485760",
+        maxJsonBody: process.env.STIGMAN_API_MAX_JSON_BODY || "31457280",
         maxUpload: process.env.STIGMAN_API_MAX_UPLOAD || "1073741824"
     },
     database: {

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -42,7 +42,7 @@ let config = {
     http: {
         address: process.env.STIGMAN_API_ADDRESS || "0.0.0.0",
         port: process.env.STIGMAN_API_PORT || 54000,
-        maxJsonBody: process.env.STIGMAN_API_MAX_JSON_BODY || "5242880",
+        maxJsonBody: process.env.STIGMAN_API_MAX_JSON_BODY || "10485760",
         maxUpload: process.env.STIGMAN_API_MAX_UPLOAD || "1073741824"
     },
     database: {


### PR DESCRIPTION
chore: stigs and checklists keep getting bigger. Changed STIGMAN_API_MAX_JSON_BODY default value from 5mb to 10mb. 
Resolves: #628