### PR TITLE
docs: disable pdf generation, remove deprecated python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,11 +10,10 @@ sphinx:
    configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+# formats:
+   # - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
    install:
    - requirements: docs/requirements.txt


### PR DESCRIPTION
readTheDocs latest fails to generate pdfs, resulting in entire build failure.
Removing pdf generation.