### PR TITLE
hotfix: restore commented out code

### DIFF
--- a/client/src/js/overrides.js
+++ b/client/src/js/overrides.js
@@ -791,7 +791,6 @@ Ext.override(Ext.grid.GridView,{
             '<div class="x-grid3-cell-inner x-grid3-col-{id} sm-selectable" {attr}>{value}</div>',
         '</td>'
     ),
-    /**
     doRender : function(columns, records, store, startRow, colCount, stripe) {
         var templates = this.templates,
             cellTemplate = templates.cell,


### PR DESCRIPTION
Restore XSS protection that was inadvertently commented out in commit fa6249e61923f707e33c9b29117c3010d0b5323d