### PR TITLE
feat: show stig diff even when ruleId is unchanged

### DIFF
--- a/client/src/js/SM/TipContent.js
+++ b/client/src/js/SM/TipContent.js
@@ -37,6 +37,7 @@ SM.TipContent.AccessLevels = `
 `
 
 SM.TipContent.RulePropertyDiffs = `<b>Changes to these rule properties are detected</b><br>
+- ruleId<br>
 - title<br>
 - groupId<br>
 - groupTitle<br>


### PR DESCRIPTION
The STIG compare feature only shows differences when the `ruleId` associated with a `STIGId` has changed between revisions. We discovered cases when `ruleId` is not changed but other properties, such as the check content, have changed. This PR modifies the feature to show these differences.