### PR TITLE
hotfix: handle missing cci and include all ccis

### DIFF
--- a/api/source/service/mysql/STIGService.js
+++ b/api/source/service/mysql/STIGService.js
@@ -558,8 +558,7 @@ exports.insertManualBenchmark = async function (b, clobber, svcStatus = {}) {
         drop: 'drop table if exists temp_rule_cci',
         create: `CREATE${tempFlag ? ' TEMPORARY' : ''} TABLE temp_rule_cci (
           ruleId varchar(255) NOT NULL,
-          cci varchar(20),
-          UNIQUE KEY (cci))`
+          cci varchar(20))`
       }
     }
     const dml = {

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -4671,12 +4671,15 @@ components:
           type: string
         cci:
           type: string
+          nullable: true
         title:
           type: string
         definition:
-          type: string              
+          type: string
+          nullable: true
         apAcronym:
-          type: string          
+          type: string
+          nullable: true
         severity:
           $ref: '#/components/schemas/RuleSeverity'
         assets:
@@ -4685,6 +4688,7 @@ components:
             $ref: '#/components/schemas/AssetBasic'
         ccis:
           type: array
+          minLength: 0
           items:
             $ref: '#/components/schemas/CciBasic'            
         groups:


### PR DESCRIPTION
Resolves #969 

Updates the handler for `GET /collections/{collectionId}/findings`, which was regressed by #936 such that Rules without a CCI mapping were not being returned.

Updates the OAS to allow `null` values for cci name, description, and apAcronym.

Updates the handler for `POST /stigs` which was regressed by #936 such that only the first occurrence of a CCI in a Benchmark was mapped to a single rule.

