### PR TITLE
fix: include client node_modules in container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 **/test
 **/uploads
 **/docker
+!client/**/node_modules


### PR DESCRIPTION
Modified `.dockerignore` to permit the client `node_modules` directory to be in the build context