### PR TITLE
feat: grid context-menu for clipboard copy

### DIFF
--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -2077,9 +2077,6 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   width: 12px;
 }
 
-.sm-selectable, .sm-selectable * {
-  user-select: text;
-}
 .x-menu-item-active {
 	background-image: none;
 	background-color: #e5e5e5

--- a/client/src/img/copy.svg
+++ b/client/src/img/copy.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="800px"
+   height="800px"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg12"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs16" />
+  <title
+     id="title2">copy-icon</title>
+  <rect
+     x="128"
+     y="128"
+     width="336"
+     height="336"
+     rx="57"
+     ry="57"
+     style="fill:none;stroke:#7f7f7f;stroke-linejoin:round;stroke-width:32px;stroke-opacity:1"
+     id="rect4" />
+  <path
+     d="M383.5,128l.5-24a56.16,56.16,0,0,0-56-56H112a64.19,64.19,0,0,0-64,64V328a56.16,56.16,0,0,0,56,56h24"
+     style="fill:none;stroke:#7f7f7f;stroke-linecap:round;stroke-linejoin:round;stroke-width:32px;stroke-opacity:1"
+     id="path6" />
+  <metadata
+     id="metadata4658">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>copy-icon</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -229,7 +229,7 @@ SM.CollectionPanel.AggGrid = Ext.extend(Ext.grid.GridPanel, {
         <div class="sm-dynamic-width">
           <div class="sm-info">${v}</div>
         </div>
-        <div class="sm-static-width"><img class="sm-grid-cell-toolbar-edit" style="user-select: none" ext:qtip="Open checklist" src="img/shield-green-check.svg" width="14" height="14"></div>
+        <div class="sm-static-width"><img class="sm-grid-cell-toolbar-edit" ext:qtip="Open checklist" src="img/shield-green-check.svg" width="14" height="14"></div>
       </div>`
     }
 
@@ -536,7 +536,7 @@ SM.CollectionPanel.UnaggGrid = Ext.extend(Ext.grid.GridPanel, {
         <div class="sm-dynamic-width">
           <div class="sm-info">${v}</div>
         </div>
-        <div class="sm-static-width"><img class="sm-grid-cell-toolbar-edit" style="user-select: none" ext:qtip="Open checklist" src="img/shield-green-check.svg" width="14" height="14"></div>
+        <div class="sm-static-width"><img class="sm-grid-cell-toolbar-edit" ext:qtip="Open checklist" src="img/shield-green-check.svg" width="14" height="14"></div>
       </div>`
     }
 

--- a/client/src/js/SM/Global.js
+++ b/client/src/js/SM/Global.js
@@ -403,3 +403,102 @@ SM.RuleContentTpl = new Ext.XTemplate(
         SM.Global.HelperComboBox.superclass.initComponent.call(this)
     }
 })
+
+SM.Global.GridCellContextMenu = new Ext.menu.Menu({
+    items: [
+        {
+            text: `Copy value`,
+            itemId: 'copycell',
+            iconCls: 'sm-copy-icon'
+        },
+        '-',
+        {
+            text: `Copy row as CSV`,
+            itemId: 'copyrow',
+            iconCls: 'sm-copy-icon'
+        }
+    ],
+    onCellContextMenu: function (grid, rowIndex, cellIndex, e) {
+        const menu = SM.Global.GridCellContextMenu
+        menu.grid = grid
+        menu.rowIndex = rowIndex
+        menu.cellIndex = cellIndex
+        menu.cellText = grid.getView().getCell(rowIndex, cellIndex).innerText
+        const cellDisplay = `"${menu.cellText.length > 24 ? menu.cellText.slice(0, 24) + '...' : menu.cellText + '"'}`
+        menu.items.items[0].setText(`Copy value <b>${cellDisplay}</b>`)
+        menu.showAt(e.xy)
+    },
+    listeners: {
+        click: function (menu, item) {
+            if (item.itemId === 'copycell') {
+                navigator.clipboard.writeText(menu.cellText)
+            }
+            else {
+                let csv = ''
+                const rowArray = []
+                const columns = menu.grid.getColumnModel().getColumnsBy(() => true)
+                const rowDiv = menu.grid.getView().getRow(menu.rowIndex)
+                // headerArray[] will hold data for the CSV header row
+                const headerArray = []
+                // ci[] will hold only the column indexes for which we will encode cell data
+                const ci = []
+                for (let x = 0; x < columns.length; x++) {
+                    const c = columns[x]
+                    // Criteria for inclusion of the column
+                    if (c.dataIndex != "" && c.header != "" && !c.hidden) {
+                        // Build an element to hold the column header's HTML
+                        const el = document.createElement('html')
+                        el.innerHTML = c.header
+                        // Try to find the first child element with an 'exportvalue' attribute
+                        const ev = el.querySelector('[exportvalue]')
+                        if (ev != null) {
+                            // An element with an 'exportvalue' attribute was found. The CSV column header will be the value of 'exportvalue'
+                            headerArray.push('"' + ev.getAttribute('exportvalue') + '"')
+                        }
+                        else {
+                            // No element with an 'exportvalue' attribute was found was found. The CSV column header will be the quoted UI column header
+                            headerArray.push('"' + c.header + '"')
+                        }
+                        // Add this column index to ci[]
+                        ci.push(x)
+                    }
+                }
+                // Comma separate the header data and append to the CSV 
+                csv += headerArray.join(',') + "\n"
+                const rowCells = rowDiv.getElementsByTagName('tr')[0].cells
+                // Iterate across the included column indexes 
+                for (let x = 0; x < ci.length; x++) {
+                    const ev = rowCells[ci[x]].querySelector('[exportvalue]')
+                    if (ev != null) {
+                        // An element with an 'exportvalue' attribute was found was found. The CSV data will be the value of 'exportvalue'
+                        rowArray.push('"' + ev.getAttribute('exportvalue') + '"')
+                    }
+                    else {
+                        // No element with an 'exportvalue' attribute was found was found. The CSV data will be the quoted and escaped textContent of the <td>'s firstChild
+                        const value = '"' + rowCells[ci[x]].firstChild.textContent.replace(/"/g, '""').trim() + '"'
+                        rowArray.push(value)
+                    }
+                }
+                // Comma separate the row data and append to the CSV 
+                csv += rowArray.join(',') + "\n"
+                navigator.clipboard.writeText(csv)
+            }
+        }
+    }
+})
+
+// Global copy-to-clipboard context menu for GridPanel
+// Source: carl.a.smigielski@saic.com
+Ext.override(Ext.grid.GridPanel, {
+    initEvents: function () {
+        Ext.grid.GridPanel.superclass.initEvents.call(this)
+        // override code: add handler for cellcontextmenu event
+        this.on('cellcontextmenu', SM.Global.GridCellContextMenu.onCellContextMenu, this)
+
+        if (this.loadMask) {
+            this.loadMask = new Ext.LoadMask(this.bwrap,
+                Ext.apply({ store: this.store }, this.loadMask));
+        }
+    }
+})
+

--- a/client/src/js/overrides.js
+++ b/client/src/js/overrides.js
@@ -804,11 +804,6 @@ Ext.override(Ext.grid.GridView,{
             '<div class="x-grid3-resize-proxy">&#160;</div>',
         '</div>'
     ),
-    cellTpl: new Ext.Template(
-        '<td class="x-grid3-col x-grid3-cell x-grid3-td-{id} {css}" style="{style}" tabIndex="0" {cellAttr}>',
-            '<div class="x-grid3-cell-inner x-grid3-col-{id} sm-selectable" {attr}>{value}</div>',
-        '</td>'
-    ),
     doRender : function(columns, records, store, startRow, colCount, stripe) {
         var templates = this.templates,
             cellTemplate = templates.cell,


### PR DESCRIPTION
Reverts fa6249e
Reverts PR #921 

Adds a context menu to all grid cells with menu items to
- copy the cell's value to the clipboard
- copy the CSV representation of the cell's row to the clipboard

![image](https://github.com/NUWCDIVNPT/stig-manager/assets/33138761/e58d0eaf-7847-4351-9aa2-4fb2c27ada02)
