### PR TITLE
feat: STIG title column, hidden by default

### DIFF
--- a/api/source/service/mysql/MetricsService.js
+++ b/api/source/service/mysql/MetricsService.js
@@ -98,7 +98,8 @@ module.exports.queryMetrics = async function ({
     'left join asset a on granted.assetId = a.assetId',
     'left join stig_asset_map sa on granted.saId = sa.saId',
     'left join default_rev dr on granted.collectionId = dr.collectionId and sa.benchmarkId = dr.benchmarkId',
-    'left join revision rev on dr.revId = rev.revId'
+    'left join revision rev on dr.revId = rev.revId',
+    'left join stig on rev.benchmarkId = stig.benchmarkId'
   ]
   const groupBy = []
   const orderBy = []
@@ -428,6 +429,7 @@ const baseCols = {
     'a.name',
     sqlLabels,
     'rev.benchmarkId',
+    'stig.title',
     'rev.revisionStr',
     'CASE WHEN dr.revisionPinned = 1 THEN CAST(true as json) ELSE CAST(false as json) END as revisionPinned',
   ],
@@ -449,6 +451,7 @@ const baseCols = {
   ],
   stig: [
     'rev.benchmarkId',
+    'stig.title',
     'rev.revisionStr',
     'CASE WHEN dr.revisionPinned = 1 THEN CAST(true as json) ELSE CAST(false as json) END as revisionPinned',
     'count(distinct a.assetId) as assets',
@@ -468,6 +471,7 @@ const baseColsFlat = {
     'a.name',
     sqlLabelsFlat,
     'rev.benchmarkId',
+    'stig.title',
     'rev.revisionStr',
     'CASE WHEN dr.revisionPinned = 1 THEN CAST(true as json) ELSE CAST(false as json) END as revisionPinned',
   ],
@@ -485,6 +489,7 @@ const baseColsFlat = {
   ],
   stig: [
     'rev.benchmarkId',
+    'stig.title',
     'rev.revisionStr',
     'CASE WHEN dr.revisionPinned = 1 THEN CAST(true as json) ELSE CAST(false as json) END as revisionPinned',
     'count(distinct a.assetId) as assets',

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -4838,6 +4838,7 @@ components:
         - name
         - labels
         - benchmarkId
+        - title
         - revisionStr
         - revisionPinned
       properties:
@@ -4851,6 +4852,8 @@ components:
             $ref: '#/components/schemas/LabelBasic'
         benchmarkId:
           $ref: '#/components/schemas/BenchmarkId'
+        title:
+          $ref: '#/components/schemas/String255'
         revisionStr:
           $ref: '#/components/schemas/RevisionStrRaw'
         revisionPinned:
@@ -4958,6 +4961,7 @@ components:
       type: object
       required:
         - benchmarkId
+        - title
         - assets
         - revisionStr
         - revisionPinned
@@ -4965,6 +4969,8 @@ components:
       properties:
         benchmarkId:
           $ref: '#/components/schemas/BenchmarkId'
+        title:
+          $ref: '#/components/schemas/String255'
         revisionStr:
           $ref: '#/components/schemas/RevisionStrRaw'
         revisionPinned:

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -364,6 +364,7 @@ SM.CollectionPanel.AggGrid = Ext.extend(Ext.grid.GridPanel, {
       case 'stig':
         fields.push(
           { name: 'benchmarkId', type: 'string' },
+          { name: 'title', type: 'string' },
           { name: 'revisionStr', type: 'string' },
           { name: 'revisionPinned' },
           'assets'
@@ -384,6 +385,14 @@ SM.CollectionPanel.AggGrid = Ext.extend(Ext.grid.GridPanel, {
                 }
               }
             }
+          },
+          {
+            header: "Title",
+            width: 175,
+            dataIndex: 'title',
+            sortable: true,
+            filter: { type: 'string' },
+            hidden: true
           },
           {
             header: "Revision",
@@ -523,6 +532,7 @@ SM.CollectionPanel.UnaggGrid = Ext.extend(Ext.grid.GridPanel, {
       { name: 'name', type: 'string' },
       { name: 'labelIds', type: 'string', convert: (v, r) => r.labels.map(l => l.labelId) },
       'benchmarkId',
+      'title',
       'revisionStr',
       'revisionPinned',
       ...SM.CollectionPanel.CommonFields
@@ -586,6 +596,14 @@ SM.CollectionPanel.UnaggGrid = Ext.extend(Ext.grid.GridPanel, {
             sortable: true,
             filter: { type: 'string' },
             renderer: renderWithToolbar
+          },
+          {
+            header: "Title",
+            width: 175,
+            dataIndex: 'title',
+            sortable: true,
+            filter: { type: 'string' },
+            hidden: true
           },
           {
             header: "Revision",


### PR DESCRIPTION
- (OAS/API) Adds the `title` property to Metric responses that include STIG data (benchmarkId, revisionStr)
- (UI) Adds a column for STIG title to grids populated from Metric endpoints. Affects grids in the Collection dashboard and Collection Management workspace. The column is initially hidden by default.