### PR TITLE
pin sphinx container tag

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SPHINX_IMAGE=sphinxdoc/sphinx
+SPHINX_IMAGE=sphinxdoc/sphinx:5.3.0
 
 # Change to this script directory
 cd "$(dirname "$(realpath "$0")")"


### PR DESCRIPTION
A recent change to the sphinx image broke our docs build script.
Changed build script to specify tag of last known version that worked for us, instead of implied "latest". 