### PR TITLE
fix: remove non-compliant elevate parameter, fix regression preventing app management interface from updating Collections

### DIFF
--- a/client/src/js/SM/Assignments.js
+++ b/client/src/js/SM/Assignments.js
@@ -191,7 +191,6 @@ SM.AssignmentNavTree = Ext.extend(Ext.tree.TreePanel, {
             url: `${STIGMAN.Env.apiBase}/assets/`,
             method: 'GET',
             params: { 
-              elevate: `${curUser.privileges.canAdmin}`,
               collectionId: theNode.attributes.collectionId,
               projection: 'stigs'
             }
@@ -226,7 +225,6 @@ SM.AssignmentNavTree = Ext.extend(Ext.tree.TreePanel, {
             url: `${STIGMAN.Env.apiBase}/assets/${assetId}`,
             method: 'GET',
             params: { 
-              elevate: `${curUser.privileges.canAdmin}`,
               projection: 'stigs'
             }
           })
@@ -252,7 +250,6 @@ SM.AssignmentNavTree = Ext.extend(Ext.tree.TreePanel, {
             responseType: 'json',
             method: 'GET',
             params: { 
-              elevate: `${curUser.privileges.canAdmin}`,
               collectionId: theNode.attributes.collectionId,
               benchmarkId: theNode.attributes.benchmarkId,
               projection: 'stigs'

--- a/client/src/js/collectionAdmin.js
+++ b/client/src/js/collectionAdmin.js
@@ -300,7 +300,7 @@ async function showCollectionProps(collectionId) {
       btnHandler: async () => {
         try {
           let values = fp.getForm().getFieldValues()
-          await addOrUpdateCollection(0, values, {
+          await addOrUpdateCollection(collectionId, values, {
             elevate: true,
             showManager: true
           })


### PR DESCRIPTION
Removes the non-compliant elevate parameter from requests made during User Grant assignments.
Fixed regression preventing app management interface from updating Collections.