### PR TITLE
fix: duplicate collection name detection

### DIFF
--- a/api/source/service/mysql/migrations/0026.js
+++ b/api/source/service/mysql/migrations/0026.js
@@ -1,0 +1,21 @@
+const MigrationHandler = require('./lib/MigrationHandler')
+
+const upMigration = [
+
+  // table: collection
+  `ALTER TABLE collection 
+  CHANGE COLUMN isCloning isNameUnavailable TINYINT GENERATED ALWAYS AS ((case when (state = _utf8mb4'cloning') or (state = _utf8mb4'enabled') then 1 else NULL end)) VIRTUAL ;`,
+]
+
+const downMigration = [
+]
+
+const migrationHandler = new MigrationHandler(upMigration, downMigration)
+module.exports = {
+  up: async (pool) => {
+    await migrationHandler.up(pool, __filename)
+  },
+  down: async (pool) => {
+    await migrationHandler.down(pool, __filename)
+  }
+}


### PR DESCRIPTION
Renames the column `isCloning` to `isNameUnavailable` and sets the generated value to 1 if the `state` value is either `enabled` or `cloning`. The unique index `index3` which was attached to `isCloning` comes along for the ride and now works as intended.