### PR TITLE
Refactored controllers to require <tag>Service

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -2,7 +2,7 @@
 
 const writer = require('../utils/writer');
 const config = require('../utils/config')
-const Asset = require(`../service/${config.database.type}/AssetService`);
+const AssetService = require(`../service/${config.database.type}/AssetService`);
 const Collection = require(`../service/${config.database.type}/CollectionService`);
 const dbUtils = require(`../service/${config.database.type}/utils`)
 const {XMLBuilder} = require("fast-xml-parser")
@@ -18,7 +18,7 @@ module.exports.createAsset = async function createAsset (req, res, next) {
 
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
       try {
-        let asset = await Asset.createAsset( {body, projection, elevate, userObject: req.userObject, svcStatus: res.svcStatus})
+        let asset = await AssetService.createAsset( {body, projection, elevate, userObject: req.userObject, svcStatus: res.svcStatus})
         res.status(201).json(asset)
       }
       catch (err) {
@@ -48,7 +48,7 @@ module.exports.deleteAsset = async function deleteAsset (req, res, next) {
     let projection = req.query.projection
 
     // fetch the Asset for access control checks and the response
-    let assetToAffect = await Asset.getAsset(assetId, projection, elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, projection, elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -56,7 +56,7 @@ module.exports.deleteAsset = async function deleteAsset (req, res, next) {
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
     // is the granted accessLevel high enough?
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
-      await Asset.deleteAsset( assetId, projection, elevate, req.userObject )
+      await AssetService.deleteAsset( assetId, projection, elevate, req.userObject )
       res.json(assetToAffect)
     }
     else {
@@ -75,7 +75,7 @@ module.exports.removeStigFromAsset = async function removeStigFromAsset (req, re
     let elevate = req.query.elevate
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, [], elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, [], elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -83,7 +83,7 @@ module.exports.removeStigFromAsset = async function removeStigFromAsset (req, re
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
     // is the granted accessLevel high enough?
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
-      let response = await Asset.removeStigFromAsset(assetId, benchmarkId, elevate, req.userObject )
+      let response = await AssetService.removeStigFromAsset(assetId, benchmarkId, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -101,7 +101,7 @@ module.exports.removeStigsFromAsset = async function removeStigsFromAsset (req, 
     let elevate = req.query.elevate
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, undefined, elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, undefined, elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -109,7 +109,7 @@ module.exports.removeStigsFromAsset = async function removeStigsFromAsset (req, 
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
     // is the granted accessLevel high enough?
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
-      let response = await Asset.removeStigsFromAsset(assetId, elevate, req.userObject )
+      let response = await AssetService.removeStigsFromAsset(assetId, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -156,7 +156,7 @@ module.exports.removeUsersFromAssetStig = async function removeUsersFromAssetSti
     let elevate = req.query.elevate
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, [], elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, [], elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -164,7 +164,7 @@ module.exports.removeUsersFromAssetStig = async function removeUsersFromAssetSti
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
     // is the granted accessLevel high enough?
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
-      let response = await Asset.removeUsersFromAssetStig(assetId, benchmarkId, elevate, req.userObject )
+      let response = await AssetService.removeUsersFromAssetStig(assetId, benchmarkId, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -177,7 +177,7 @@ module.exports.removeUsersFromAssetStig = async function removeUsersFromAssetSti
 }
 
 module.exports.exportAssets = async function exportAssets (projection, elevate, userObject) {
-  let assets =  await Asset.getAssets(null, null, null, null, null, null, projection, elevate, userObject )
+  let assets =  await AssetService.getAssets(null, null, null, null, null, null, projection, elevate, userObject )
   return assets
 } 
 
@@ -188,7 +188,7 @@ module.exports.getAsset = async function getAsset (req, res, next) {
     let elevate = req.query.elevate
     
     // If this user has no grants permitting access to the asset, the response will be undefined
-    let response = await Asset.getAsset(assetId, projection, elevate, req.userObject )
+    let response = await AssetService.getAsset(assetId, projection, elevate, req.userObject )
     if (!response) {
       throw new SmError.PrivilegeError()
     }
@@ -234,7 +234,7 @@ module.exports.getAssets = async function getAssets (req, res, next) {
           }
         }
       }
-      let response = await Asset.getAssets(collectionId, {labelIds, labelNames, labelMatch}, name, nameMatch, benchmarkId, metadata, projection, elevate, req.userObject )
+      let response = await AssetService.getAssets(collectionId, {labelIds, labelNames, labelMatch}, name, nameMatch, benchmarkId, metadata, projection, elevate, req.userObject )
       res.json(response)
     }
     else {
@@ -250,7 +250,7 @@ module.exports.getStigsByAsset = async function getStigsByAsset (req, res, next)
   try {
     let assetId = req.params.assetId
     let elevate = req.query.elevate
-    let response = await Asset.getStigsByAsset(assetId, elevate, req.userObject )
+    let response = await AssetService.getStigsByAsset(assetId, elevate, req.userObject )
     res.json(response)
   }
   catch (err) {
@@ -278,7 +278,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
     const revisionStr = req.params.revisionStr
     const format = req.query.format || 'json'
     if (await dbUtils.userHasAssetStigs(assetId, [benchmarkId], false, req.userObject)) {
-      const response = await Asset.getChecklistByAssetStig(assetId, benchmarkId, revisionStr, format, false, req.userObject )
+      const response = await AssetService.getChecklistByAssetStig(assetId, benchmarkId, revisionStr, format, false, req.userObject )
       if (format === 'json') {
         res.json(response)
       }
@@ -337,7 +337,7 @@ module.exports.getChecklistByAsset = async function getChecklistByAssetStig (req
     const format = req.query.format //default of .ckl provided by EOV
 
     // If this user has no grants permitting access to the asset, the response will be undefined
-    const assetResponse = await Asset.getAsset(assetId, ['stigs'], false, req.userObject )
+    const assetResponse = await AssetService.getAsset(assetId, ['stigs'], false, req.userObject )
     if (!assetResponse) {
       throw new SmError.PrivilegeError()
     }
@@ -355,7 +355,7 @@ module.exports.getChecklistByAsset = async function getChecklistByAssetStig (req
 
     const stigs = requestedBenchmarkIds.map( benchmarkId => ({benchmarkId, revisionStr: 'latest'}) )
 
-    const response = await Asset.getChecklistByAsset(assetId, stigs, format, false, req.userObject )
+    const response = await AssetService.getChecklistByAsset(assetId, stigs, format, false, req.userObject )
 
     if (format === 'cklb') {
       writer.writeInlineFile(res, JSON.stringify(response.cklb), `${response.assetName}.cklb`, 'application/json') 
@@ -394,7 +394,7 @@ module.exports.getAssetsByStig = async function getAssetsByStig (req, res, next)
 
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if ( elevate || collectionGrant ) {
-        let response = await Asset.getAssetsByStig( collectionId, benchmarkId, {labelIds, labelNames, labelMatch}, projection, elevate, req.userObject )
+        let response = await AssetService.getAssetsByStig( collectionId, benchmarkId, {labelIds, labelNames, labelMatch}, projection, elevate, req.userObject )
         res.json(response)
     }
     else {
@@ -414,7 +414,7 @@ module.exports.replaceAsset = async function replaceAsset (req, res, next) {
     const body = req.body
 
     // If this user has no grants permitting access to the asset, the response will be undefined
-    const currentAsset = await Asset.getAsset(assetId, projection, elevate, req.userObject )
+    const currentAsset = await AssetService.getAsset(assetId, projection, elevate, req.userObject )
     if (!currentAsset) {
       throw new SmError.PrivilegeError('User has insufficient privilege to modify this asset.')
     }
@@ -433,7 +433,7 @@ module.exports.replaceAsset = async function replaceAsset (req, res, next) {
         throw new SmError.PrivilegeError(`User has insufficient privilege in collectionId ${body.collectionId} to transfer this asset.`)
       }
     }
-    const response = await Asset.updateAsset({
+    const response = await AssetService.updateAsset({
       assetId,
       body,
       projection,
@@ -461,8 +461,8 @@ module.exports.attachAssetsToStig = async function attachAssetsToStig (req, res,
       let collection = await Collection.getCollection( collectionId, ['assets'], elevate, req.userObject)
       let collectionAssets = collection.assets.map( a => a.assetId)
       if (assetIds.every( a => collectionAssets.includes(a))) {
-        await Asset.attachAssetsToStig( collectionId, benchmarkId, assetIds, projection, elevate, req.userObject )
-        let response = await Asset.getAssetsByStig( collectionId, benchmarkId, null, projection, elevate, req.userObject )
+        await AssetService.attachAssetsToStig( collectionId, benchmarkId, assetIds, projection, elevate, req.userObject )
+        let response = await AssetService.getAssetsByStig( collectionId, benchmarkId, null, projection, elevate, req.userObject )
         res.json(response)
       }
       else {
@@ -485,7 +485,7 @@ module.exports.attachStigToAsset = async function attachStigToAsset (req, res, n
     let elevate = req.query.elevate
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, [], elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, [], elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -493,7 +493,7 @@ module.exports.attachStigToAsset = async function attachStigToAsset (req, res, n
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
     // is the granted accessLevel high enough?
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
-      let response = await Asset.attachStigToAsset(assetId, benchmarkId, elevate, req.userObject )
+      let response = await AssetService.attachStigToAsset(assetId, benchmarkId, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -512,7 +512,7 @@ module.exports.attachStigsToAsset = async function attachStigsToAsset (req, res,
     let body = req.body
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, [], elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, [], elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -520,7 +520,7 @@ module.exports.attachStigsToAsset = async function attachStigsToAsset (req, res,
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
     // is the granted accessLevel high enough?
     if ( elevate || (collectionGrant?.accessLevel >= 3) ) {
-      let response = await Asset.attachStigsToAsset(assetId, body, elevate, req.userObject )
+      let response = await AssetService.attachStigsToAsset(assetId, body, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -540,7 +540,7 @@ module.exports.setAssetStigGrant = async function setAssetStigGrant (req, res, n
     let elevate = req.query.elevate
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, projection, elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, projection, elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -559,7 +559,7 @@ module.exports.setAssetStigGrant = async function setAssetStigGrant (req, res, n
         // Can only map Users with an existing grant
         throw new SmError.ClientError(`The user has an incompatible or missing grant in collectionId ${body.collectionId}.`)
       }
-      let response = await Asset.setAssetStigGrant(assetId, benchmarkId, userId, elevate, req.userObject )
+      let response = await AssetService.setAssetStigGrant(assetId, benchmarkId, userId, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -579,7 +579,7 @@ module.exports.setAssetStigGrants = async function setAssetStigGrants (req, res,
     let elevate = req.query.elevate
 
     // fetch the Asset for access control checks
-    let assetToAffect = await Asset.getAsset(assetId, projection, elevate, req.userObject)
+    let assetToAffect = await AssetService.getAsset(assetId, projection, elevate, req.userObject)
     // can the user fetch this Asset?
     if (!assetToAffect) {
       throw new SmError.PrivilegeError()
@@ -601,7 +601,7 @@ module.exports.setAssetStigGrants = async function setAssetStigGrants (req, res,
           throw new SmError.ClientError(`One or more users have incompatible or missing grants in collectionId ${body.collectionId}.`)
         }
       }
-      let response = await Asset.setAssetStigGrants(assetId, benchmarkId, body, elevate, req.userObject )
+      let response = await AssetService.setAssetStigGrants(assetId, benchmarkId, body, elevate, req.userObject )
       res.json(response)
       }
     else {
@@ -621,7 +621,7 @@ module.exports.updateAsset = async function updateAsset (req, res, next) {
     const body = req.body
 
     // If this user has no grants permitting access to the asset, the response will be undefined
-    const currentAsset = await Asset.getAsset(assetId, projection, elevate, req.userObject )
+    const currentAsset = await AssetService.getAsset(assetId, projection, elevate, req.userObject )
     if (!currentAsset) {
       throw new SmError.PrivilegeError('User has insufficient privilege to modify this asset.')
     }
@@ -640,7 +640,7 @@ module.exports.updateAsset = async function updateAsset (req, res, next) {
         throw new SmError.PrivilegeError(`User has insufficient privilege in collectionId ${body.collectionId} to transfer this asset.`)
       }
     }
-    const response = await Asset.updateAsset({
+    const response = await AssetService.updateAsset({
       assetId,
       body,
       projection,
@@ -662,7 +662,7 @@ async function getAssetIdAndCheckPermission(request) {
   let assetId = request.params.assetId
 
   // fetch the Asset for access control checks and the response
-  let assetToAffect = await Asset.getAsset(assetId, [], elevate, request.userObject)
+  let assetToAffect = await AssetService.getAsset(assetId, [], elevate, request.userObject)
   // can the user fetch this Asset?
   if (!assetToAffect) {
     throw new SmError.PrivilegeError()
@@ -679,7 +679,7 @@ async function getAssetIdAndCheckPermission(request) {
 module.exports.getAssetMetadata = async function (req, res, next) {
   try {
     let assetId = await getAssetIdAndCheckPermission(req)
-    let result = await Asset.getAssetMetadata(assetId, req.userObject)
+    let result = await AssetService.getAssetMetadata(assetId, req.userObject)
     res.json(result)
   }
   catch (err) {
@@ -691,8 +691,8 @@ module.exports.patchAssetMetadata = async function (req, res, next) {
   try {
     let assetId = await getAssetIdAndCheckPermission(req)
     let metadata = req.body
-    await Asset.patchAssetMetadata(assetId, metadata)
-    let result = await Asset.getAssetMetadata(assetId)
+    await AssetService.patchAssetMetadata(assetId, metadata)
+    let result = await AssetService.getAssetMetadata(assetId)
     res.json(result)
   }
   catch (err) {
@@ -704,8 +704,8 @@ module.exports.putAssetMetadata = async function (req, res, next) {
   try {
     let assetId = await getAssetIdAndCheckPermission(req)
     let body = req.body
-    await Asset.putAssetMetadata(assetId, body)
-    let result = await Asset.getAssetMetadata(assetId)
+    await AssetService.putAssetMetadata(assetId, body)
+    let result = await AssetService.getAssetMetadata(assetId)
     res.json(result)
   }
   catch (err) {
@@ -716,7 +716,7 @@ module.exports.putAssetMetadata = async function (req, res, next) {
 module.exports.getAssetMetadataKeys = async function (req, res, next) {
   try {
     let assetId = await getAssetIdAndCheckPermission(req)
-    let result = await Asset.getAssetMetadataKeys(assetId, req.userObject)
+    let result = await AssetService.getAssetMetadataKeys(assetId, req.userObject)
     if (!result) {
       throw new SmError.NotFoundError('metadata keys not found')
     }
@@ -731,7 +731,7 @@ module.exports.getAssetMetadataValue = async function (req, res, next) {
   try {
     let assetId = await getAssetIdAndCheckPermission(req)
     let key = req.params.key
-    let result = await Asset.getAssetMetadataValue(assetId, key, req.userObject)
+    let result = await AssetService.getAssetMetadataValue(assetId, key, req.userObject)
     if (!result) { 
       throw new SmError.NotFoundError('metadata key not found')
     }
@@ -747,7 +747,7 @@ module.exports.putAssetMetadataValue = async function (req, res, next) {
     let assetId = await getAssetIdAndCheckPermission(req)
     let key = req.params.key
     let value = req.body
-    let result = await Asset.putAssetMetadataValue(assetId, key, value)
+    let result = await AssetService.putAssetMetadataValue(assetId, key, value)
     res.status(204).send()
   }
   catch (err) {
@@ -761,7 +761,7 @@ module.exports.deleteAssetMetadataKey = async function (req, res, next) {
     let assetId = await getAssetIdAndCheckPermission(req)
     let key = req.params.key
 
-    let result = await Asset.deleteAssetMetadataKey(assetId, key, req.userObject)
+    let result = await AssetService.deleteAssetMetadataKey(assetId, key, req.userObject)
     res.status(204).send()
   }
   catch (err) {

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -2,7 +2,7 @@
 
 const writer = require('../utils/writer')
 const config = require('../utils/config')
-const CollectionSvc = require(`../service/${config.database.type}/CollectionService`)
+const CollectionService = require(`../service/${config.database.type}/CollectionService`)
 const AssetSvc = require(`../service/${config.database.type}/AssetService`)
 const StigSvc = require(`../service/${config.database.type}/STIGService`)
 const Serialize = require(`../utils/serializers`)
@@ -43,7 +43,7 @@ module.exports.createCollection = async function createCollection (req, res, nex
         throw new SmError.UnprocessableError('Duplicate user in grant array')
       }  
       try {
-        const response = await CollectionSvc.createCollection( body, projection, req.userObject, res.svcStatus)
+        const response = await CollectionService.createCollection( body, projection, req.userObject, res.svcStatus)
         res.status(201).json(response)
       }
       catch (err) {
@@ -72,7 +72,7 @@ module.exports.deleteCollection = async function deleteCollection (req, res, nex
     const projection = req.query.projection
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if (elevate || (collectionGrant?.accessLevel === 4)) {
-      const response = await CollectionSvc.deleteCollection(collectionId, projection, elevate, req.userObject)
+      const response = await CollectionService.deleteCollection(collectionId, projection, elevate, req.userObject)
       res.json(response)
     }
     else {
@@ -86,7 +86,7 @@ module.exports.deleteCollection = async function deleteCollection (req, res, nex
 
 module.exports.exportCollections = async function exportCollections (projection, elevate, userObject) {
   try {
-    return await CollectionSvc.getCollections( {}, projection, elevate, userObject )
+    return await CollectionService.getCollections( {}, projection, elevate, userObject )
   }
   catch (err) {
     next(err)
@@ -100,7 +100,7 @@ module.exports.getChecklistByCollectionStig = async function getChecklistByColle
     const revisionStr = req.params.revisionStr
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if ( collectionGrant ) {
-      const response = await CollectionSvc.getChecklistByCollectionStig(collectionId, benchmarkId, revisionStr, req.userObject )
+      const response = await CollectionService.getChecklistByCollectionStig(collectionId, benchmarkId, revisionStr, req.userObject )
       res.json(response)
     }
     else {
@@ -120,7 +120,7 @@ module.exports.getCollection = async function getCollection (req, res, next) {
     
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if (collectionGrant || elevate ) {
-      const response = await CollectionSvc.getCollection(collectionId, projection, elevate, req.userObject )
+      const response = await CollectionService.getCollection(collectionId, projection, elevate, req.userObject )
       res.status(typeof response === 'undefined' ? 204 : 200).json(response)
     }
     else {
@@ -139,7 +139,7 @@ module.exports.getCollections = async function getCollections (req, res, next) {
     const name = req.query.name
     const nameMatch = req.query['name-match']
     const metadata = req.query.metadata
-    const response = await CollectionSvc.getCollections({
+    const response = await CollectionService.getCollections({
       name: name,
       nameMatch: nameMatch,
       metadata: metadata
@@ -161,7 +161,7 @@ module.exports.getFindingsByCollection = async function getFindingsByCollection 
     const projection = req.query.projection
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if (collectionGrant) {
-      const response = await CollectionSvc.getFindingsByCollection( collectionId, aggregator, benchmarkId, assetId, acceptedOnly, projection, req.userObject )
+      const response = await CollectionService.getFindingsByCollection( collectionId, aggregator, benchmarkId, assetId, acceptedOnly, projection, req.userObject )
       res.json(response)
       }
     else {
@@ -187,7 +187,7 @@ module.exports.getPoamByCollection = async function getFindingsByCollection (req
     }
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if (collectionGrant) {
-      const response = await CollectionSvc.getFindingsByCollection( collectionId, aggregator, benchmarkId, assetId, acceptedOnly, 
+      const response = await CollectionService.getFindingsByCollection( collectionId, aggregator, benchmarkId, assetId, acceptedOnly, 
         [
           'rulesWithDiscussion',
           'groups',
@@ -217,7 +217,7 @@ module.exports.getStatusByCollection = async function getStatusByCollection (req
     const assetIds = req.query.assetId
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if (collectionGrant) {
-      const response = await CollectionSvc.getStatusByCollection( collectionId, assetIds, benchmarkIds, req.userObject )
+      const response = await CollectionService.getStatusByCollection( collectionId, assetIds, benchmarkIds, req.userObject )
       res.json(response)
     }
     else {
@@ -236,7 +236,7 @@ module.exports.getStigAssetsByCollectionUser = async function getStigAssetsByCol
     
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if ( collectionGrant?.accessLevel >= 3 ) {
-      const response = await CollectionSvc.getStigAssetsByCollectionUser(collectionId, userId, req.userObject )
+      const response = await CollectionService.getStigAssetsByCollectionUser(collectionId, userId, req.userObject )
       res.json(response)
     }
     else {
@@ -255,7 +255,7 @@ module.exports.getStigsByCollection = async function getStigsByCollection (req, 
     const labelNames = req.query.labelName
     const labelMatch = req.query.labelMatch
     const projections = req.query.projection
-    const response = await CollectionSvc.getStigsByCollection({collectionId, labelIds, labelNames, labelMatch, projections, userObject: req.userObject})
+    const response = await CollectionService.getStigsByCollection({collectionId, labelIds, labelNames, labelMatch, projections, userObject: req.userObject})
     res.json(response)
   }
   catch (err) {
@@ -268,7 +268,7 @@ module.exports.getStigByCollection = async function getStigByCollection (req, re
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
     const benchmarkId = req.params.benchmarkId
     const projections = req.query.projection
-    const response = await CollectionSvc.getStigsByCollection({collectionId, projections, userObject: req.userObject, benchmarkId})
+    const response = await CollectionService.getStigsByCollection({collectionId, projections, userObject: req.userObject, benchmarkId})
     if (!response[0]) {
       res.status(204)
     }
@@ -288,14 +288,14 @@ module.exports.replaceCollection = async function replaceCollection (req, res, n
     if (!hasUniqueGrants(body.grants)) {
       throw new SmError.UnprocessableError('Duplicate user in grant array')
     }
-    const existingGrants = (await CollectionSvc.getCollection(collectionId, ['grants'], false, req.userObject ))
+    const existingGrants = (await CollectionService.getCollection(collectionId, ['grants'], false, req.userObject ))
       ?.grants
       .map(g => ({userId: g.user.userId, accessLevel: g.accessLevel}))
 
       if (!elevate && (collectionGrant.accessLevel !== Security.ACCESS_LEVEL.Owner && !requestedOwnerGrantsMatchExisting(body.grants, existingGrants))) {
         throw new SmError.PrivilegeError('Cannot create or modify owner grants.')
     }
-    let response = await CollectionSvc.replaceCollection(collectionId, body, projection, req.userObject, res.svcStatus)
+    let response = await CollectionService.replaceCollection(collectionId, body, projection, req.userObject, res.svcStatus)
     res.json(response)
   }
   catch (err) {
@@ -311,10 +311,10 @@ module.exports.setStigAssetsByCollectionUser = async function setStigAssetsByCol
     
     const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
     if ( collectionGrant?.accessLevel >= 3 ) {
-      const collectionResponse = await CollectionSvc.getCollection(collectionId, ['grants'], false, req.userObject )
+      const collectionResponse = await CollectionService.getCollection(collectionId, ['grants'], false, req.userObject )
       if (collectionResponse.grants.filter( grant => grant.accessLevel === 1 && grant.user.userId === userId).length > 0) {
-        const setResponse = await CollectionSvc.setStigAssetsByCollectionUser(collectionId, userId, stigAssets, res.svcStatus ) 
-        const getResponse = await CollectionSvc.getStigAssetsByCollectionUser(collectionId, userId, req.userObject )
+        const setResponse = await CollectionService.setStigAssetsByCollectionUser(collectionId, userId, stigAssets, res.svcStatus ) 
+        const getResponse = await CollectionService.getStigAssetsByCollectionUser(collectionId, userId, req.userObject )
         res.json(getResponse)    
       }
       else {
@@ -340,7 +340,7 @@ module.exports.updateCollection = async function updateCollection (req, res, nex
       if (!hasUniqueGrants(body.grants)) {
         throw new SmError.UnprocessableError('Duplicate user in grant array')
       }
-      const existingGrants = (await CollectionSvc.getCollection(collectionId, ['grants'], false, req.userObject ))
+      const existingGrants = (await CollectionService.getCollection(collectionId, ['grants'], false, req.userObject ))
         ?.grants
         .map(g => ({userId: g.user.userId, accessLevel: g.accessLevel}))
 
@@ -348,7 +348,7 @@ module.exports.updateCollection = async function updateCollection (req, res, nex
         throw new SmError.PrivilegeError('Cannot create or modify owner grants.')
       }
     }
-    let response = await CollectionSvc.replaceCollection(collectionId, body, projection, req.userObject, res.svcStatus)
+    let response = await CollectionService.replaceCollection(collectionId, body, projection, req.userObject, res.svcStatus)
     res.json(response)
   }
   catch (err) {
@@ -407,7 +407,7 @@ module.exports.getCollectionIdAndCheckPermission = getCollectionIdAndCheckPermis
 module.exports.getCollectionMetadata = async function (req, res, next) {
   try {
     let collectionId = getCollectionIdAndCheckPermission(req)
-    let result = await CollectionSvc.getCollectionMetadata(collectionId, req.userObject)
+    let result = await CollectionService.getCollectionMetadata(collectionId, req.userObject)
     res.json(result)
   }
   catch (err) {
@@ -419,8 +419,8 @@ module.exports.patchCollectionMetadata = async function (req, res, next) {
   try {
     let collectionId = getCollectionIdAndCheckPermission(req)
     let metadata = req.body
-    await CollectionSvc.patchCollectionMetadata(collectionId, metadata)
-    let result = await CollectionSvc.getCollectionMetadata(collectionId)
+    await CollectionService.patchCollectionMetadata(collectionId, metadata)
+    let result = await CollectionService.getCollectionMetadata(collectionId)
     res.json(result)
   }
   catch (err) {
@@ -432,8 +432,8 @@ module.exports.putCollectionMetadata = async function (req, res, next) {
   try {
     let collectionId = getCollectionIdAndCheckPermission(req)
     let body = req.body
-    await CollectionSvc.putCollectionMetadata( collectionId, body)
-    let result = await CollectionSvc.getCollectionMetadata(collectionId)
+    await CollectionService.putCollectionMetadata( collectionId, body)
+    let result = await CollectionService.getCollectionMetadata(collectionId)
     res.json(result)
   }
   catch (err) {
@@ -444,7 +444,7 @@ module.exports.putCollectionMetadata = async function (req, res, next) {
 module.exports.getCollectionMetadataKeys = async function (req, res, next) {
   try {
     let collectionId = getCollectionIdAndCheckPermission(req)
-    let result = await CollectionSvc.getCollectionMetadataKeys(collectionId, req.userObject)
+    let result = await CollectionService.getCollectionMetadataKeys(collectionId, req.userObject)
     if (!result) {
       throw new SmError.NotFoundError('metadata keys not found')
     } 
@@ -459,7 +459,7 @@ module.exports.getCollectionMetadataValue = async function (req, res, next) {
   try {
     let collectionId = getCollectionIdAndCheckPermission(req)
     let key = req.params.key
-    let result = await CollectionSvc.getCollectionMetadataValue(collectionId, key, req.userObject)
+    let result = await CollectionService.getCollectionMetadataValue(collectionId, key, req.userObject)
     if (!result) {
       throw new SmError.NotFoundError('metadata key not found')
     }
@@ -475,7 +475,7 @@ module.exports.putCollectionMetadataValue = async function (req, res, next) {
     let collectionId = getCollectionIdAndCheckPermission(req)
     let key = req.params.key
     let value = req.body
-    let result = await CollectionSvc.putCollectionMetadataValue(collectionId, key, value)
+    let result = await CollectionService.putCollectionMetadataValue(collectionId, key, value)
     res.status(204).send()
   }
   catch (err) {
@@ -487,7 +487,7 @@ module.exports.deleteCollectionMetadataKey = async function (req, res, next) {
   try {
     let collectionId = getCollectionIdAndCheckPermission(req)
     let key = req.params.key
-    let result = await CollectionSvc.deleteCollectionMetadataKey(collectionId, key, req.userObject)
+    let result = await CollectionService.deleteCollectionMetadataKey(collectionId, key, req.userObject)
     res.status(204).send()
   }
   catch (err) {
@@ -501,7 +501,7 @@ module.exports.deleteReviewHistoryByCollection = async function (req, res, next)
     const retentionDate = req.query.retentionDate
     const assetId = req.query.assetId
     
-    let result = await CollectionSvc.deleteReviewHistoryByCollection(collectionId, retentionDate, assetId)
+    let result = await CollectionService.deleteReviewHistoryByCollection(collectionId, retentionDate, assetId)
     res.json(result)
   }
   catch (err) {
@@ -518,7 +518,7 @@ module.exports.getReviewHistoryByCollection = async function (req, res, next) {
     const ruleId = req.query.ruleId
     const status = req.query.status
 
-    let result = await CollectionSvc.getReviewHistoryByCollection(collectionId, startDate, endDate, assetId, ruleId, status)
+    let result = await CollectionService.getReviewHistoryByCollection(collectionId, startDate, endDate, assetId, ruleId, status)
     res.json(result)
   }
   catch (err) {
@@ -536,7 +536,7 @@ module.exports.getReviewHistoryStatsByCollection = async function (req, res, nex
     const status = req.query.status
     const projection = req.query.projection
 
-    let result = await CollectionSvc.getReviewHistoryStatsByCollection(collectionId, startDate, endDate, assetId, ruleId, status, projection)
+    let result = await CollectionService.getReviewHistoryStatsByCollection(collectionId, startDate, endDate, assetId, ruleId, status, projection)
     res.json(result)
   }
   catch (err) {
@@ -547,7 +547,7 @@ module.exports.getReviewHistoryStatsByCollection = async function (req, res, nex
 module.exports.getCollectionLabels = async function (req, res, next) {
   try {
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
-    const response = await CollectionSvc.getCollectionLabels( collectionId, req.userObject )
+    const response = await CollectionService.getCollectionLabels( collectionId, req.userObject )
     res.json(response)
   }
   catch (err) {
@@ -558,8 +558,8 @@ module.exports.getCollectionLabels = async function (req, res, next) {
 module.exports.createCollectionLabel = async function (req, res, next) {
   try {
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Manage)
-    const labelId = await CollectionSvc.createCollectionLabel( collectionId, req.body )
-    const response = await CollectionSvc.getCollectionLabelById( collectionId, labelId, req.userObject )
+    const labelId = await CollectionService.createCollectionLabel( collectionId, req.body )
+    const response = await CollectionService.getCollectionLabelById( collectionId, labelId, req.userObject )
     res.status(201).json(response)
   }
   catch (err) {
@@ -570,7 +570,7 @@ module.exports.createCollectionLabel = async function (req, res, next) {
 module.exports.getCollectionLabelById = async function (req, res, next) {
   try {
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
-    const response = await CollectionSvc.getCollectionLabelById( collectionId, req.params.labelId, req.userObject )
+    const response = await CollectionService.getCollectionLabelById( collectionId, req.params.labelId, req.userObject )
     if (!response) {
       throw new SmError.NotFoundError()
     }
@@ -584,11 +584,11 @@ module.exports.getCollectionLabelById = async function (req, res, next) {
 module.exports.patchCollectionLabelById = async function (req, res, next) {
   try {
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Manage)
-    const affectedRows = await CollectionSvc.patchCollectionLabelById( collectionId, req.params.labelId, req.body )
+    const affectedRows = await CollectionService.patchCollectionLabelById( collectionId, req.params.labelId, req.body )
     if (affectedRows === 0) {
       throw new SmError.NotFoundError()
     }
-    const response = await CollectionSvc.getCollectionLabelById( collectionId, req.params.labelId, req.userObject )
+    const response = await CollectionService.getCollectionLabelById( collectionId, req.params.labelId, req.userObject )
     res.json(response)
   }
   catch (err) {
@@ -599,7 +599,7 @@ module.exports.patchCollectionLabelById = async function (req, res, next) {
 module.exports.deleteCollectionLabelById = async function (req, res, next) {
   try {
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Manage)
-    const affectedRows = await CollectionSvc.deleteCollectionLabelById(collectionId, req.params.labelId)
+    const affectedRows = await CollectionService.deleteCollectionLabelById(collectionId, req.params.labelId)
     if (affectedRows === 0) {
       throw new SmError.NotFoundError()
     }
@@ -613,7 +613,7 @@ module.exports.deleteCollectionLabelById = async function (req, res, next) {
 module.exports.getAssetsByCollectionLabelId = async function (req, res, next) {
   try {
     const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
-    const response = await CollectionSvc.getAssetsByCollectionLabelId( collectionId, req.params.labelId, req.userObject )
+    const response = await CollectionService.getAssetsByCollectionLabelId( collectionId, req.params.labelId, req.userObject )
     res.json(response)
   }
   catch (err) {
@@ -626,11 +626,11 @@ module.exports.putAssetsByCollectionLabelId = async function (req, res, next) {
     const collectionId = getCollectionIdAndCheckPermission(req)
     const labelId = req.params.labelId
     const assetIds = req.body
-    let collection = await CollectionSvc.getCollection( collectionId, ['assets'], false, req.userObject)
+    let collection = await CollectionService.getCollection( collectionId, ['assets'], false, req.userObject)
     let collectionAssets = collection.assets.map( a => a.assetId)
     if (assetIds.every( a => collectionAssets.includes(a))) {
-      await CollectionSvc.putAssetsByCollectionLabelId( collectionId, labelId, assetIds, res.svcStatus )
-      const response = await CollectionSvc.getAssetsByCollectionLabelId( collectionId, req.params.labelId, req.userObject )
+      await CollectionService.putAssetsByCollectionLabelId( collectionId, labelId, assetIds, res.svcStatus )
+      const response = await CollectionService.getAssetsByCollectionLabelId( collectionId, req.params.labelId, req.userObject )
       res.json(response)
     }
     else {
@@ -780,7 +780,7 @@ module.exports.getUnreviewedAssetsByCollection = async function (req, res, next)
     const labelIds = req.query.labelId || []
     const labelNames = req.query.labelName || []
     const projections = req.query.projection || []
-    const response = await CollectionSvc.getUnreviewedAssetsByCollection( {
+    const response = await CollectionService.getUnreviewedAssetsByCollection( {
       collectionId,
       benchmarkId,
       assetId,
@@ -806,7 +806,7 @@ module.exports.getUnreviewedRulesByCollection = async function (req, res, next) 
     const labelIds = req.query.labelId || []
     const labelNames = req.query.labelName || []
     const projections = req.query.projection || []
-    const response = await CollectionSvc.getUnreviewedRulesByCollection( {
+    const response = await CollectionService.getUnreviewedRulesByCollection( {
       collectionId,
       benchmarkId,
       ruleId,
@@ -962,14 +962,14 @@ module.exports.writeStigPropsByCollectionStig = async function (req, res, next) 
     }
     // The OAS layer mandated if assetIds is absent then defaultRevisionStr must be present
     // we do not permit setting the default revision of an unassigned STIG
-    if (!assetIds && !await CollectionSvc.doesCollectionIncludeStig({collectionId, benchmarkId})) {
+    if (!assetIds && !await CollectionService.doesCollectionIncludeStig({collectionId, benchmarkId})) {
       throw new SmError.UnprocessableError('Cannot set the default revision of a benchmarkId that has no mapped Assets')
     }
     if (assetIds && assetIds.length === 0 && defaultRevisionStr) {
       throw new SmError.UnprocessableError('Cannot set the default revision of a benchmarkId and also remove all mapped Assets')
     }
     if (assetIds?.length) {
-      const collectionHasAssets = await CollectionSvc.doesCollectionIncludeAssets({
+      const collectionHasAssets = await CollectionService.doesCollectionIncludeAssets({
         collectionId,
         assetIds
       })
@@ -977,14 +977,14 @@ module.exports.writeStigPropsByCollectionStig = async function (req, res, next) 
         throw new SmError.PrivilegeError('One or more assetId is not a Collection member.')
       }
     }
-    await CollectionSvc.writeStigPropsByCollectionStig( {
+    await CollectionService.writeStigPropsByCollectionStig( {
       collectionId,
       benchmarkId,
       assetIds,
       defaultRevisionStr,
       svcStatus: res.svcStatus
     })
-    const response = await CollectionSvc.getStigsByCollection({collectionId, userObject: req.userObject, benchmarkId})
+    const response = await CollectionService.getStigsByCollection({collectionId, userObject: req.userObject, benchmarkId})
     if (response[0]) {
       res.json(response[0])
     }
@@ -1016,7 +1016,7 @@ module.exports.cloneCollection = async function (req, res, next) {
       res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
       req.noCompression = true
 
-      const cloned = await CollectionSvc.cloneCollection({
+      const cloned = await CollectionService.cloneCollection({
         collectionId, 
         userObject: req.userObject, 
         name: req.body.name,
@@ -1026,7 +1026,7 @@ module.exports.cloneCollection = async function (req, res, next) {
         progressCb
       })
       if (cloned) {
-        const collection = await CollectionSvc.getCollection(cloned.destCollectionId, req.query.projection, false, req.userObject )
+        const collection = await CollectionService.getCollection(cloned.destCollectionId, req.query.projection, false, req.userObject )
         res.write(JSON.stringify({stage: 'result', collection}) + '\n')
       }
       res.end()
@@ -1055,7 +1055,7 @@ module.exports.exportToCollection = async function (req, res, next) {
     res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
     req.noCompression = true
 
-    await CollectionSvc.exportToCollection({
+    await CollectionService.exportToCollection({
       srcCollectionId,
       dstCollectionId,
       assetStigArguments: parsedRequest.assetStigArguments,

--- a/api/source/controllers/Metrics.js
+++ b/api/source/controllers/Metrics.js
@@ -1,5 +1,5 @@
 const config = require('../utils/config')
-const MetricsSvc = require(`../service/${config.database.type}/MetricsService`)
+const MetricsService = require(`../service/${config.database.type}/MetricsService`)
 const Collection = require('./Collection')
 const Security = require('../utils/accessLevels')
 const SmError = require('../utils/error')
@@ -17,7 +17,7 @@ async function getCollectionMetrics (req, res, next, {style, aggregation, firstR
       assetIds: req.query.assetId,
       benchmarkIds: req.query.benchmarkId,
     }
-    const rows = await MetricsSvc.queryMetrics({
+    const rows = await MetricsService.queryMetrics({
       inPredicates,
       userId: req.userObject.userId,
       style,

--- a/api/source/controllers/Operation.js
+++ b/api/source/controllers/Operation.js
@@ -1,6 +1,6 @@
 const writer = require('../utils/writer.js')
 const config = require('../utils/config')
-const Operation = require(`../service/${config.database.type}/OperationService`)
+const OperationService = require(`../service/${config.database.type}/OperationService`)
 const Asset = require(`./Asset`)
 const Collection = require(`./Collection`)
 const User = require(`./User`)
@@ -11,7 +11,7 @@ const SmError = require('../utils/error.js')
 
 module.exports.getConfiguration = async function getConfiguration (req, res, next) {
   try {
-    let dbConfigs = await Operation.getConfiguration()
+    let dbConfigs = await OperationService.getConfiguration()
     let version = {version: config.version}
     let commit = {commit: config.commit}
     let response = { ...version, ...commit, ...dbConfigs }
@@ -103,7 +103,7 @@ module.exports.replaceAppData = async function replaceAppData (req, res, next) {
         appdata = req.body
       }
       let options = []
-      let response = await Operation.replaceAppData(options, appdata, req.userObject, res )
+      let response = await OperationService.replaceAppData(options, appdata, req.userObject, res )
     }
     else {
       throw new SmError.PrivilegeError()
@@ -133,7 +133,7 @@ module.exports.getDetails = async function getDetails (req, res, next) {
   try {
     let elevate = req.query.elevate
     if ( elevate ) {
-      const response = await Operation.getDetails()
+      const response = await OperationService.getDetails()
       res.json(response)
     }
     else {

--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -3,7 +3,7 @@
 const config = require('../utils/config');
 const SmError = require('../utils/error');
 const parsers = require('../utils/parsers.js')
-const STIG = require(`../service/${config.database.type}/STIGService`)
+const STIGService = require(`../service/${config.database.type}/STIGService`)
 
 module.exports.importBenchmark = async function importManualBenchmark (req, res, next) {
   try {
@@ -22,7 +22,7 @@ module.exports.importBenchmark = async function importManualBenchmark (req, res,
     if (benchmark.scap) {
       throw new SmError.UnprocessableError('SCAP Benchmarks are not imported.')
     }
-    const revision = await STIG.insertManualBenchmark(benchmark, clobber, res.svcStatus)
+    const revision = await STIGService.insertManualBenchmark(benchmark, clobber, res.svcStatus)
     res.json(revision)
   }
   catch(err) {
@@ -37,12 +37,12 @@ module.exports.deleteRevisionByString = async function deleteRevisionByString (r
     const revisionStr = req.params.revisionStr
     const force = req.query.force
     try {
-      const response = await STIG.getRevisionByString(benchmarkId, revisionStr, req.userObject, true)
+      const response = await STIGService.getRevisionByString(benchmarkId, revisionStr, req.userObject, true)
       if(response === undefined) {
         throw new SmError.NotFoundError('No matching revisionStr found.')
       }
-      const existingRevisions = await STIG.getRevisionsByBenchmarkId(benchmarkId, req.userObject)
-      const stigAssigned = await STIG.getStigById(benchmarkId, req.userObject, true)
+      const existingRevisions = await STIGService.getRevisionsByBenchmarkId(benchmarkId, req.userObject)
+      const stigAssigned = await STIGService.getStigById(benchmarkId, req.userObject, true)
       if (stigAssigned.collectionIds.length && existingRevisions.length == 1 && !force) {
         throw new SmError.UnprocessableError("The revisionStr is the last remaining revision for this benchmark, which is assigned to one or more Collections. Set force=true to force the delete")
       }      
@@ -50,7 +50,7 @@ module.exports.deleteRevisionByString = async function deleteRevisionByString (r
         throw new SmError.UnprocessableError("The revisionStr is pinned to one or more Collections. Set force=true to force the delete")
       }
       else {
-        await STIG.deleteRevisionByString(benchmarkId, revisionStr, res.svcStatus)
+        await STIGService.deleteRevisionByString(benchmarkId, revisionStr, res.svcStatus)
         res.json(response)
       }
     }
@@ -68,14 +68,14 @@ module.exports.deleteStigById = async function deleteStigById (req, res, next) {
     try {
       const benchmarkId = req.params.benchmarkId
       const force = req.query.force
-      const response = await STIG.getStigById(benchmarkId, req.userObject, true)
+      const response = await STIGService.getStigById(benchmarkId, req.userObject, true)
       if(response === undefined) {
         throw new SmError.NotFoundError('No matching benchmarkId found.')
       }
       if (response.collectionIds.length && !force) {
         throw new SmError.UnprocessableError("The benchmarkId is assigned to one or more Collections. Set force=true to force the delete")
       }
-      await STIG.deleteStigById(benchmarkId, res.svcStatus)
+      await STIGService.deleteStigById(benchmarkId, res.svcStatus)
       res.json(response)
     }
     catch (err) {
@@ -91,7 +91,7 @@ module.exports.getCci = async function getCci (req, res, next) {
   let cci = req.params.cci
   let projection = req.query.projection
   try {
-    let response = await STIG.getCci(cci, projection, req.userObject)
+    let response = await STIGService.getCci(cci, projection, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -103,7 +103,7 @@ module.exports.getCcisByRevision = async function getCcisByRevision (req, res, n
   let benchmarkId = req.params.benchmarkId
   let revisionStr = req.params.revisionStr
   try {
-    let response = await STIG.getCcisByRevision(benchmarkId, revisionStr, req.userObject)
+    let response = await STIGService.getCcisByRevision(benchmarkId, revisionStr, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -117,7 +117,7 @@ module.exports.getGroupByRevision = async function getGroupByRevision (req, res,
   let revisionStr = req.params.revisionStr
   let groupId = req.params.groupId
   try {
-    let response = await STIG.getGroupByRevision(benchmarkId, revisionStr, groupId, projection, req.userObject)
+    let response = await STIGService.getGroupByRevision(benchmarkId, revisionStr, groupId, projection, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -130,7 +130,7 @@ module.exports.getGroupsByRevision = async function getGroupsByRevision (req, re
   let benchmarkId = req.params.benchmarkId
   let revisionStr = req.params.revisionStr
   try {
-    let response = await STIG.getGroupsByRevision(benchmarkId, revisionStr, projection, req.userObject)
+    let response = await STIGService.getGroupsByRevision(benchmarkId, revisionStr, projection, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -143,7 +143,7 @@ module.exports.getRevisionByString = async function getRevisionByString (req, re
   const revisionStr = req.params.revisionStr
   const elevate = req.query.elevate
   try {
-    const response = await STIG.getRevisionByString(benchmarkId, revisionStr, req.userObject, elevate)
+    const response = await STIGService.getRevisionByString(benchmarkId, revisionStr, req.userObject, elevate)
     res.json(response)
   }
   catch(err) {
@@ -155,7 +155,7 @@ module.exports.getRevisionsByBenchmarkId = async function getRevisionsByBenchmar
   const benchmarkId = req.params.benchmarkId
   const elevate = req.query.elevate
   try {
-    const response = await STIG.getRevisionsByBenchmarkId(benchmarkId, req.userObject, elevate)
+    const response = await STIGService.getRevisionsByBenchmarkId(benchmarkId, req.userObject, elevate)
     res.json(response)
   }
   catch(err) {
@@ -167,7 +167,7 @@ module.exports.getRuleByRuleId = async function getRuleByRuleId (req, res, next)
   let projection = req.query.projection
   let ruleId = req.params.ruleId
   try {
-    let response = await STIG.getRuleByRuleId(ruleId, projection, req.userObject)
+    let response = await STIGService.getRuleByRuleId(ruleId, projection, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -181,7 +181,7 @@ module.exports.getRuleByRevision = async function getRulesByRevision (req, res, 
   let revisionStr = req.params.revisionStr
   let ruleId = req.params.ruleId
   try {
-    let response = await STIG.getRuleByRevision(benchmarkId, revisionStr, ruleId, projection, req.userObject)
+    let response = await STIGService.getRuleByRevision(benchmarkId, revisionStr, ruleId, projection, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -194,7 +194,7 @@ module.exports.getRulesByRevision = async function getRulesByRevision (req, res,
   let benchmarkId = req.params.benchmarkId
   let revisionStr = req.params.revisionStr
   try {
-    let response = await STIG.getRulesByRevision(benchmarkId, revisionStr, projection, req.userObject)
+    let response = await STIGService.getRulesByRevision(benchmarkId, revisionStr, projection, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -207,7 +207,7 @@ module.exports.getSTIGs = async function getSTIGs (req, res, next) {
   const elevate = req.query.elevate
   const projection = req.query.projection || []
   try {
-    let response = await STIG.getSTIGs(title, projection, req.userObject, elevate)
+    let response = await STIGService.getSTIGs(title, projection, req.userObject, elevate)
     res.json(response)
   }
   catch(err) {
@@ -219,7 +219,7 @@ module.exports.getStigById = async function getStigById (req, res, next) {
   let benchmarkId = req.params.benchmarkId
   const elevate = req.query.elevate
   try {
-    let response = await STIG.getStigById(benchmarkId, req.userObject, elevate)
+    let response = await STIGService.getStigById(benchmarkId, req.userObject, elevate)
     res.json(response)
   }
   catch(err) {

--- a/api/source/controllers/User.js
+++ b/api/source/controllers/User.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const config = require('../utils/config')
-const User = require(`../service/${config.database.type}/UserService`)
+const UserService = require(`../service/${config.database.type}/UserService`)
 const Asset = require(`../service/${config.database.type}/AssetService`)
 const Collection = require(`../service/${config.database.type}/CollectionService`)
 const SmError = require('../utils/error')
@@ -23,7 +23,7 @@ module.exports.createUser = async function createUser (req, res, next) {
         }
       }
       try {
-        let response = await User.createUser(body, projection, elevate, req.userObject, res.svcStatus)
+        let response = await UserService.createUser(body, projection, elevate, req.userObject, res.svcStatus)
         res.status(201).json(response)
       }
       catch (err) {
@@ -51,12 +51,12 @@ module.exports.deleteUser = async function deleteUser (req, res, next) {
     if (elevate) {
       let userId = req.params.userId
       let projection = req.query.projection
-      let userData = await User.getUserByUserId(userId, ['statistics'], elevate, req.userObject)
+      let userData = await UserService.getUserByUserId(userId, ['statistics'], elevate, req.userObject)
       if (userData?.statistics?.lastAccess) {
         // User has accessed the system, so we need to reject the request
         throw new SmError.UnprocessableError('User has accessed the system. Use PATCH to remove collection grants or configure Authentication provider to reject user entirely.')
       }
-      let response = await User.deleteUser(userId, projection, elevate, req.userObject)
+      let response = await UserService.deleteUser(userId, projection, elevate, req.userObject)
       res.json(response)
     }
     else {
@@ -70,7 +70,7 @@ module.exports.deleteUser = async function deleteUser (req, res, next) {
 
 module.exports.exportUsers = async function exportUsers (projection, elevate, userObject) {
   if (elevate) {
-    return await User.getUsers(null, null, projection, elevate, userObject )
+    return await UserService.getUsers(null, null, projection, elevate, userObject )
   }
   else {
     throw new SmError.PrivilegeError()    
@@ -92,7 +92,7 @@ module.exports.getUserByUserId = async function getUserByUserId (req, res, next)
     if ( elevate ) {
       let userId = req.params.userId
       let projection = req.query.projection
-      let response = await User.getUserByUserId(userId, projection, elevate, req.userObject)
+      let response = await UserService.getUserByUserId(userId, projection, elevate, req.userObject)
       res.json(response)
     }
     else {
@@ -113,7 +113,7 @@ module.exports.getUsers = async function getUsers (req, res, next) {
     if ( !elevate && projection && projection.length > 0) {
       throw new SmError.PrivilegeError()
     }
-    let response = await User.getUsers( username, usernameMatch, projection, elevate, req.userObject)
+    let response = await UserService.getUsers( username, usernameMatch, projection, elevate, req.userObject)
     res.json(response)
   }
   catch(err) {
@@ -139,7 +139,7 @@ module.exports.replaceUser = async function replaceUser (req, res, next) {
         }
       }
 
-      let response = await User.replaceUser(userId, body, projection, elevate, req.userObject, res.svcStatus)
+      let response = await UserService.replaceUser(userId, body, projection, elevate, req.userObject, res.svcStatus)
       res.json(response)
     }
     else {
@@ -169,7 +169,7 @@ module.exports.updateUser = async function updateUser (req, res, next) {
         }
       }
 
-      let response = await User.replaceUser(userId, body, projection, elevate, req.userObject, res.svcStatus)
+      let response = await UserService.replaceUser(userId, body, projection, elevate, req.userObject, res.svcStatus)
       res.json(response)
     }
     else {
@@ -184,8 +184,8 @@ module.exports.updateUser = async function updateUser (req, res, next) {
 /* c8 ignore start */
 module.exports.setUserData = async function setUserData (username, fields) {
   try {
-    await User.setUserData(username, fields)
-    return await User.getUserByUsername(username)
+    await UserService.setUserData(username, fields)
+    return await UserService.getUserByUsername(username)
   }
   catch (e) {
     next(err)


### PR DESCRIPTION
Resolves: #1096 

All controllers have been improved for clarity/readability when calling their service.

FROM:
const Asset = require(../service/${config.database.type}/AssetService);

TO:
const AssetService = require(../service/${config.database.type}/AssetService);

By renaming the variable to AssetService, it becomes evident that this is sourced from our service.