### PR TITLE
fix: initialize delimiter value from localStorage

### DIFF
--- a/client/src/js/SM/Inventory.js
+++ b/client/src/js/SM/Inventory.js
@@ -86,7 +86,7 @@ SM.Inventory.CsvAssetFieldSet = Ext.extend(Ext.form.FieldSet, {
         apiProperty: 'stigs',
         header: 'STIGs',
         delimitedProperty: 'benchmarkId',
-        delimiter: ','
+        delimiter: this.state.stigsDelimiter
       },
       checked: this.state.stigs,
       listeners: {
@@ -201,7 +201,7 @@ SM.Inventory.CsvStigFieldSet = Ext.extend(Ext.form.FieldSet, {
         apiProperty: 'assets',
         header: 'Assets',
         delimitedProperty: 'name',
-        delimiter: ','
+        delimiter: this.state.assetsDelimiter
       },
       checked: this.state.assets,
       listeners: {


### PR DESCRIPTION
Resolves #1114 

Web app Inventory->Export:
The `csvFields.delimiter` property of the STIG and Asset checkboxes is now set from localStorage instead of being hardcoded.