### PR TITLE
refactor: post/put/patch asset reviews

### DIFF
--- a/api/source/controllers/Review.js
+++ b/api/source/controllers/Review.js
@@ -9,119 +9,19 @@ const Security = require('../utils/accessLevels')
 
 const _this = this
 
-function isReviewSubmittable ( fieldSettings, review ) {
-  if (review.result !== 'pass' && review.result !== 'fail' && review.result !== 'notapplicable') return false
-
-  if (fieldSettings.detail.required === 'always' 
-    && !review.detail) return false
-
-  if (fieldSettings.detail.required === 'findings' 
-    && review.result === 'fail'
-    && !review.detail) return false
-
-  if (fieldSettings.comment.required === 'always'
-    && (!review.comment)) return false
-
-  if (fieldSettings.comment.required === 'findings'
-    && review.result === 'fail'
-    && (!review.comment)) return false
-
-  return true
-}
-
-function normalizeReview ( review ) {
-  if (typeof review.status === 'string') {
-    review.status = {
-      label: review.status,
-      text: null
-    }
-  }
-  if ((review.result && review.resultEngine === undefined) || review.resultEngine === null) {
-    // How this object's resultEngine property affects the resultEngine field in the database:
-    // A zero value instructs the service to set resultEngine = NULL
-    // A null value instructs the service to retain the existing resultEngine field
-    review.resultEngine = 0
-  }
-  return review
-}
-
-async function normalizeAndValidateReviews( reviews, collectionId, assetId, userObject ) {
-  const userRules = await ReviewService.getRulesByAssetUser( assetId, userObject )
-  const collectionSettings = await CollectionService.getCollectionSettings(collectionId)
-  const fieldSettings = collectionSettings.fields
-  const statusSettings = collectionSettings.status
-  const historySettings = collectionSettings.history
-  const collectionGrant = userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
-  const permitted = [], rejected = []
-  for (const review of reviews) {
-    if (userRules.has(review.ruleId)) {
-      normalizeReview(review)
-      if (!review.status || review.status.label === 'saved') {
-        permitted.push(review)
-      }
-      else {
-        if (isReviewSubmittable(fieldSettings, review)) {
-          if (review.status.label !== 'submitted') { // must be 'accepted' or 'rejected'
-            if (statusSettings.canAccept === true && collectionGrant.accessLevel >= statusSettings.minAcceptGrant) {
-              permitted.push(review)
-            }
-            else {
-              rejected.push({
-                ruleId: review.ruleId,
-                reason: `Requested status is not permitted by Collection Review status settings`
-              })
-            }
-          }
-          else {
-            permitted.push(review)
-          }
-        }
-        else {
-          rejected.push({
-            ruleId: review.ruleId,
-            reason: 'Requested status is not consistent with Collection Review field settings'
-          })
-        }
-      }
-    }
-    else {
-      rejected.push({
-        ruleId: review.ruleId,
-        reason: 'Cannot post reviews for this ruleId'
-      })
-    }
-  }
-  return {permitted, rejected, statusSettings, fieldSettings, historySettings}
-}
-
 module.exports.postReviewsByAsset = async function postReviewsByAsset (req, res, next) {
   try {
-    let collectionId = req.params.collectionId
-    let assetId = req.params.assetId
-    let reviewsRequested = req.body
-
-    const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
-    if ( collectionGrant ) {
-      const {permitted, rejected, statusSettings, historySettings} = await normalizeAndValidateReviews(reviewsRequested, collectionId, assetId, req.userObject)
-      let affected = { updated: 0, inserted: 0 }
-      if (permitted.length > 0) {
-        affected = await ReviewService.putReviewsByAsset({
-          assetId,
-          reviews: permitted,
-          userObject: req.userObject,
-          resetCriteria: statusSettings.resetCriteria,
-          svcStatus: res.svcStatus,
-          maxHistory: historySettings.maxReviews
-        })
-      }
-      res.json({
-        rejected,
-        affected
-      })
-    }
-    else {
-      throw new SmError.PrivilegeError()
-    }
+    const collectionId = Collection.getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    const assetId = req.params.assetId
+    const reviews = req.body
+    const result = await ReviewService.putReviewsByAsset({
+      assetId,
+      reviews,
+      collectionId, 
+      userId: req.userObject.userId,
+      svcStatus: res.svcStatus
+    })
+    res.json(result)
   }
   catch(err) {
     next(err)
@@ -244,44 +144,22 @@ module.exports.getReviewsByAsset = async function (req, res, next) {
 
 module.exports.putReviewByAssetRule = async function (req, res, next) {
   try {
-    let collectionId = req.params.collectionId
-    let assetId = req.params.assetId
-    let ruleId = req.params.ruleId
-    let review = req.body
-    let projection = req.query.projection
-    const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
-    if ( collectionGrant ) {
-      review.assetId = assetId
-      review.ruleId = ruleId
-      const {permitted, rejected, statusSettings, historySettings} = await normalizeAndValidateReviews([review], collectionId, assetId, req.userObject)
-      if (permitted.length > 0) {
-        const affected = await ReviewService.putReviewsByAsset({
-          assetId,
-          reviews: permitted,
-          userObject: req.userObject,
-          resetCriteria: statusSettings.resetCriteria,
-          tryInsert: true,
-          svcStatus: res.svcStatus,
-          maxHistory: historySettings.maxReviews
-        })
-        const rows =  await ReviewService.getReviews(projection, {
-          assetId: assetId,
-          ruleId: ruleId
-        }, req.userObject)
-        
-        if (affected.inserted > 0) {
-          res.status(201).json(rows[0])
-        } else {
-          res.json(rows[0])
-        }
-      }
-      else {
-        throw new SmError.PrivilegeError(rejected[0].reason)
-      }
+    const collectionId = Collection.getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    const {assetId, ruleId} = {...req.params}
+    const review = {...req.body, ruleId}
+    const projection = req.query.projection
+    const result = await ReviewService.putReviewsByAsset({
+      assetId,
+      reviews: [review],
+      collectionId, 
+      userId: req.userObject.userId,
+      svcStatus: res.svcStatus
+    })
+    if (result.rejected.length) {
+      throw new SmError.PrivilegeError(result.rejected[0].reason)
     }
-    else {
-      throw new SmError.PrivilegeError()
-    }
+    const rows =  await ReviewService.getReviews(projection, { assetId, ruleId }, req.userObject)
+    res.status(result.affected.inserted > 0 ? 201 : 200).json(rows[0])
   }
   catch (err) {
     next(err)
@@ -290,43 +168,26 @@ module.exports.putReviewByAssetRule = async function (req, res, next) {
 
 module.exports.patchReviewByAssetRule = async function (req, res, next) {
   try {
-    const collectionId = req.params.collectionId
-    const assetId = req.params.assetId
-    const ruleId = req.params.ruleId
-    const incomingReview = {...req.body, ruleId}
+    const collectionId = Collection.getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Restricted)
+    const {assetId, ruleId} = {...req.params}
+    const currentReviews =  await ReviewService.getReviews([], { assetId, ruleId }, req.userObject)
+    if (currentReviews.length === 0) {
+      throw new SmError.NotFoundError('Review must exist to be patched')
+    }
+    const review = {...req.body, ruleId}
     const projection = req.query.projection
-    const collectionGrant = req.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
-    if ( collectionGrant) {
-      const currentReviews =  await ReviewService.getReviews([], { assetId, ruleId }, req.userObject)
-      if (currentReviews.length === 0) {
-        throw new SmError.NotFoundError('Review must exist to be patched')
-      }
-      normalizeReview(incomingReview)
-      const review = { ...currentReviews[0], ...incomingReview }
-      if (currentReviews[0].resultEngine && incomingReview.result != currentReviews[0].result) {
-        review.resultEngine = null
-      }
-      const {permitted, rejected, statusSettings, historySettings} = await normalizeAndValidateReviews([review], collectionId, assetId, req.userObject)
-      if (permitted.length > 0) {
-        await ReviewService.putReviewsByAsset( {
-          assetId,
-          reviews: [incomingReview],
-          userObject: req.userObject,
-          resetCriteria: statusSettings.resetCriteria,
-          tryInsert: false,
-          svcStatus: res.svcStatus,
-          maxHistory: historySettings.maxReviews
-        })
-        const rows =  await ReviewService.getReviews(projection, { assetId, ruleId }, req.userObject)
-        res.json(rows[0])
-      }
-      else {
-        throw new SmError.PrivilegeError(rejected[0].reason)
-      }
+    const result = await ReviewService.putReviewsByAsset({
+      assetId,
+      reviews: [review],
+      collectionId, 
+      userId: req.userObject.userId,
+      svcStatus: res.svcStatus
+    })
+    if (result.rejected.length) {
+      throw new SmError.PrivilegeError(result.rejected[0].reason)
     }
-    else {
-      throw new SmError.PrivilegeError()
-    }
+    const rows =  await ReviewService.getReviews(projection, { assetId, ruleId }, req.userObject)
+    res.json(rows[0])
   }
   catch (err) {
     next(err)

--- a/api/source/service/mysql/ReviewService.js
+++ b/api/source/service/mysql/ReviewService.js
@@ -3,278 +3,6 @@ const dbUtils = require('./utils')
 
 let _this = this
 
-function cteReviewGen(obj) {
-  const cte = `SELECT
-  jtresult.resultId,
-  TRIM(jt.detail) as detail,
-  TRIM(jt.comment) as comment,
-  jt.resultEngine,
-  jt.metadata,
-  jtstatus.statusId,
-  jt.statusText
-  FROM
-  JSON_TABLE(
-    @review,
-    "$"
-    COLUMNS(
-    result VARCHAR(255) PATH "$.result",
-    detail MEDIUMTEXT PATH "$.detail" NULL ON EMPTY,
-    comment MEDIUMTEXT PATH "$.comment",
-    resultEngine JSON PATH "$.resultEngine" DEFAULT '0' ON EMPTY,
-    metadata JSON PATH "$.metadata",
-    statusLabel VARCHAR(255) PATH "$.status.label",
-    statusText VARCHAR(255) PATH "$.status.text"
-    )
-  ) as jt
-  left join result jtresult on (jtresult.api = jt.result)
-  left join status jtstatus on (jtstatus.api = jt.statusLabel)`
-  return `cteReview AS (${cte})`
-}
-
-function cteAssetGen({assetIds, benchmarkIds, labelIds, labelNames}) {
-  let cte
-  if (assetIds?.length) {
-    const json = JSON.stringify(assetIds)
-    const sql = `select jtAssets.assetId
-  from
-    json_table(
-      ?,
-      '$[*]'
-      COLUMNS (assetId INT PATH '$') 
-    ) as jtAssets`
-    cte = dbUtils.pool.format(sql,[json])
-  }
-  else if (benchmarkIds?.length) {
-    const sql = `select distinct assetId 
-    from
-      asset a
-      left join collection_grant cg on a.collectionId = cg.collectionId
-      left join stig_asset_map sa using (assetId)
-      left join user_stig_asset_map usa on sa.saId = usa.saId
-    where
-      a.collectionId = @collectionId 
-      and a.state = "enabled"
-      and cg.userId = @userId 
-      and (CASE WHEN cg.accessLevel = 1 THEN usa.userId = cg.userId ELSE TRUE END)
-      and sa.benchmarkId IN ?`
-    cte = dbUtils.pool.format(sql,[[benchmarkIds]])
-  }
-  return `cteAsset AS (${cte})`
-}
-
-function cteRuleGen({ruleIds, benchmarkIds, collectionId}) {
-  let cte
-  if (ruleIds?.length) {
-    const json = JSON.stringify(ruleIds)
-    const sql = `select jtRules.ruleId
-  from
-    json_table(
-      ?,
-      '$[*]'
-      COLUMNS (ruleId VARCHAR(255) PATH '$') 
-    ) as jtRules`
-    cte = dbUtils.pool.format(sql,[json])
-  }
-  else if (benchmarkIds?.length) {
-    const sql = `select rgr.ruleId from default_rev dr left join rev_group_rule_map rgr using (revId) where dr.benchmarkId IN ? and dr.collectionId = ?`
-    cte = dbUtils.pool.format(sql,[[benchmarkIds], collectionId])
-  }
-  return `cteRule AS (${cte})`
-}
-
-function cteGrantGen() {
-  const cte = `select
-  distinct a.assetId,
-  rgr.ruleId 
-from 
-  asset a
-  left join collection_grant cg on a.collectionId = cg.collectionId
-  left join stig_asset_map sa using (assetId)
-  left join user_stig_asset_map usa on sa.saId = usa.saId
-  left join revision rev using (benchmarkId)
-  left join rev_group_rule_map rgr using (revId)
-where 
-  cg.collectionId =  @collectionId
-  and a.assetId IN (select assetId from cteAsset)
-  and rgr.ruleId IN (select ruleId from cteRule)
-  and cg.userId = @userId 
-  and (CASE WHEN cg.accessLevel = 1 THEN usa.userId = cg.userId ELSE TRUE END)`
-  
-  return `cteGrant AS (${cte})`
-}
-
-function cteCollectionSettingGen () {
-  const cte = `SELECT 
-  c.settings->>"$.fields.detail.required" as detailRequired,
-  c.settings->>"$.fields.comment.required" as commentRequired,
-  c.settings->>"$.status.canAccept" as canAccept,
-  c.settings->>"$.status.resetCriteria" as resetCriteria,
-  c.settings->>"$.status.minAcceptGrant" as minAcceptGrant
-FROM
-  collection c
-where
-  collectionId = @collectionId`
-  return `cteCollectionSetting AS (${cte})`
-}
-
-const mergeFilterOperators = {
-  contains: 'LIKE',
-  beginsWith: 'LIKE',
-  endsWith: 'LIKE',
-  equals: '=',
-  notequal: '!=',
-  greaterThan: '>',
-  lessThan: '<',
-}
-
-function genFilter(filter) {
-  let {field, condition = 'equals', value} = filter
-  if (field === 'result') {
-    field = 'resultId'
-    value = dbUtils.REVIEW_RESULT_API[value]
-  }
-  if (field === 'status' || field === 'statusLabel') {
-    field = 'statusId'
-    value = dbUtils.REVIEW_STATUS_API[value]
-  }
-
-  value = field === 'userId' || field === 'statusUserId' ? parseInt(value) : value
-
-  const sqlOperator = mergeFilterOperators[condition]
-  const isDateValue =  (field === 'ts' || field === 'touchTs' || field === 'statusTs')
-  let sqlValue
-  if (isDateValue) {
-    sqlValue = dbUtils.pool.escape(new Date(value))
-  }
-  else if (condition === 'contains') {
-    sqlValue = dbUtils.pool.escape(`%${value}%`)
-  }
-  else if (condition === 'beginsWith') {
-    sqlValue = dbUtils.pool.escape(`${value}%`)
-  }
-  else if (condition === 'endsWith') {
-    sqlValue = dbUtils.pool.escape(`%${value}`)
-  }
-  else {
-    sqlValue = dbUtils.pool.escape(value)
-  }
-  return `review.${field} ${sqlOperator} ${sqlValue}`
-}
-
-function cteCandidateGen ({skipGrantCheck = false, action, updateFilters}) {
-  let sqlFilterPredicates, sqlPredicates
-  if (updateFilters) {
-    sqlFilterPredicates = updateFilters.map( filter => genFilter(filter)).join(' AND ')
-  }
-
-  if (action === 'insert') {
-    sqlPredicates = `review.reviewId is null`
-  }
-  else if (action === 'update') {
-    sqlPredicates = sqlFilterPredicates || 'review.reviewId is not null'
-  }
-  else if (action === 'merge') {
-    sqlPredicates = `${sqlFilterPredicates ? `review.reviewId is null OR (${sqlFilterPredicates})` : ''}`
-  }
-  const cte = `
-select
-  ${!skipGrantCheck ? 'CASE WHEN cteGrant.assetId is not null then 1 else null end' : '1'} as granted,
-  review.reviewId,
-  cteAsset.assetId,
-  cteRule.ruleId,
-  rvcd.version,
-  rvcd.checkDigest,
-  
-  COALESCE(cteReview.resultId, review.resultId) as resultId,
-  COALESCE(cteReview.detail, review.detail, '') as detail,
-  COALESCE(cteReview.comment, review.comment, '') as comment,
-  COALESCE(cteReview.metadata, review.metadata, '{}') as metadata,
-  
-  CASE WHEN cteReview.resultEngine != 0 -- resultEngine present
-    THEN cteReview.resultEngine
-    ELSE
-    CASE WHEN cteReview.resultId is null or cteReview.resultId = review.resultId
-      THEN review.resultEngine
-      ELSE NULL
-    END
-  END as resultEngine,
-    
-  CASE WHEN cteReview.statusId is not null
-    THEN cteReview.statusId
-    ELSE
-      CASE WHEN review.reviewId is null
-          or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
-          or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
-        THEN 0
-        ELSE review.statusId
-      END
-  END as statusId,
-    
-  CASE WHEN cteReview.statusId is not null or review.reviewId is null
-    THEN cteReview.statusText
-    ELSE
-      CASE WHEN (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
-          or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
-        THEN 'Review change triggered status update'
-        ELSE review.statusText
-      END
-  END as statusText,
-    
-  CASE WHEN cteReview.statusId is not null 
-      or review.reviewId is null
-      or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
-      or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
-    THEN UTC_TIMESTAMP()
-    ELSE review.statusTs
-  END as statusTs,
-  
-  CASE WHEN cteReview.statusId is not null 
-      or review.reviewId is null
-      or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
-      or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
-    THEN @userId
-    ELSE review.statusUserId
-  END as statusUserId,
-    
-  CASE WHEN cteReview.resultId is not null
-      or cteReview.detail is not null
-      or cteReview.comment is not null
-      or review.reviewId is null
-    THEN @userId
-    ELSE review.userId
-  END as userId,
-    
-  CASE WHEN cteReview.resultId is not null
-      or cteReview.detail is not null
-      or cteReview.comment is not null
-      or review.reviewId is null
-    THEN UTC_TIMESTAMP()
-    ELSE review.ts
-  END as ts
-
-from
-  cteAsset
-  CROSS JOIN cteRule
-  LEFT JOIN cteReview on true
-  ${!skipGrantCheck ? 'LEFT JOIN cteGrant on (cteAsset.assetId = cteGrant.assetId and cteRule.ruleId = cteGrant.ruleId)' : ''}
-  LEFT JOIN rule_version_check_digest rvcd on cteRule.ruleId = rvcd.ruleId
-  LEFT JOIN review on (cteAsset.assetId = review.assetId and rvcd.version = review.version and rvcd.checkDigest = review.checkDigest)
-  LEFT JOIN cteCollectionSetting on true
-  LEFT JOIN review rChangedResult on (
-    rChangedResult.reviewId = review.reviewId 
-    and rChangedResult.statusId != 0
-    and rChangedResult.resultId != cteReview.resultId
-  )
-  LEFT JOIN review rChangedAny on (
-    rChangedAny.reviewId = review.reviewId 
-    and rChangedAny.statusId != 0
-    and (rChangedAny.resultId != cteReview.resultId or rChangedAny.detail != cteReview.detail or rChangedAny.comment != cteReview.comment)
-  )
-  ${sqlPredicates ? `WHERE ${sqlPredicates}` : ''}
-  `
-  return `cteCandidate AS (${cte})`
-}
-
 exports.postReviewBatch = async function ({
   source, 
   assets, 
@@ -288,10 +16,278 @@ exports.postReviewBatch = async function ({
   historyMaxReviews,
   skipGrantCheck = false
 }) {
-  const { performance } = require('node:perf_hooks');
-
-  // performance.mark('beforeCteGen');
-
+  function cteReviewGen(obj) {
+    const cte = `SELECT
+    jtresult.resultId,
+    TRIM(jt.detail) as detail,
+    TRIM(jt.comment) as comment,
+    jt.resultEngine,
+    jt.metadata,
+    jtstatus.statusId,
+    jt.statusText
+    FROM
+    JSON_TABLE(
+      @review,
+      "$"
+      COLUMNS(
+      result VARCHAR(255) PATH "$.result",
+      detail MEDIUMTEXT PATH "$.detail" NULL ON EMPTY,
+      comment MEDIUMTEXT PATH "$.comment",
+      resultEngine JSON PATH "$.resultEngine" DEFAULT '0' ON EMPTY,
+      metadata JSON PATH "$.metadata",
+      statusLabel VARCHAR(255) PATH "$.status.label",
+      statusText VARCHAR(255) PATH "$.status.text"
+      )
+    ) as jt
+    left join result jtresult on (jtresult.api = jt.result)
+    left join status jtstatus on (jtstatus.api = jt.statusLabel)`
+    return `cteReview AS (${cte})`
+  }
+  
+  function cteAssetGen({assetIds, benchmarkIds, labelIds, labelNames}) {
+    let cte
+    if (assetIds?.length) {
+      const json = JSON.stringify(assetIds)
+      const sql = `select jtAssets.assetId
+    from
+      json_table(
+        ?,
+        '$[*]'
+        COLUMNS (assetId INT PATH '$') 
+      ) as jtAssets`
+      cte = dbUtils.pool.format(sql,[json])
+    }
+    else if (benchmarkIds?.length) {
+      const sql = `select distinct assetId 
+      from
+        asset a
+        left join collection_grant cg on a.collectionId = cg.collectionId
+        left join stig_asset_map sa using (assetId)
+        left join user_stig_asset_map usa on sa.saId = usa.saId
+      where
+        a.collectionId = @collectionId 
+        and a.state = "enabled"
+        and cg.userId = @userId 
+        and (CASE WHEN cg.accessLevel = 1 THEN usa.userId = cg.userId ELSE TRUE END)
+        and sa.benchmarkId IN ?`
+      cte = dbUtils.pool.format(sql,[[benchmarkIds]])
+    }
+    return `cteAsset AS (${cte})`
+  }
+  
+  function cteRuleGen({ruleIds, benchmarkIds, collectionId}) {
+    let cte
+    if (ruleIds?.length) {
+      const json = JSON.stringify(ruleIds)
+      const sql = `select jtRules.ruleId
+    from
+      json_table(
+        ?,
+        '$[*]'
+        COLUMNS (ruleId VARCHAR(255) PATH '$') 
+      ) as jtRules`
+      cte = dbUtils.pool.format(sql,[json])
+    }
+    else if (benchmarkIds?.length) {
+      const sql = `select rgr.ruleId from default_rev dr left join rev_group_rule_map rgr using (revId) where dr.benchmarkId IN ? and dr.collectionId = ?`
+      cte = dbUtils.pool.format(sql,[[benchmarkIds], collectionId])
+    }
+    return `cteRule AS (${cte})`
+  }
+  
+  function cteGrantGen() {
+    const cte = `select
+    distinct a.assetId,
+    rgr.ruleId 
+  from 
+    asset a
+    left join collection_grant cg on a.collectionId = cg.collectionId
+    left join stig_asset_map sa using (assetId)
+    left join user_stig_asset_map usa on sa.saId = usa.saId
+    left join revision rev using (benchmarkId)
+    left join rev_group_rule_map rgr using (revId)
+  where 
+    cg.collectionId =  @collectionId
+    and a.assetId IN (select assetId from cteAsset)
+    and rgr.ruleId IN (select ruleId from cteRule)
+    and cg.userId = @userId 
+    and (CASE WHEN cg.accessLevel = 1 THEN usa.userId = cg.userId ELSE TRUE END)`
+    
+    return `cteGrant AS (${cte})`
+  }
+  
+  function cteCollectionSettingGen () {
+    const cte = `SELECT 
+    c.settings->>"$.fields.detail.required" as detailRequired,
+    c.settings->>"$.fields.comment.required" as commentRequired,
+    c.settings->>"$.status.canAccept" as canAccept,
+    c.settings->>"$.status.resetCriteria" as resetCriteria,
+    c.settings->>"$.status.minAcceptGrant" as minAcceptGrant
+  FROM
+    collection c
+  where
+    collectionId = @collectionId`
+    return `cteCollectionSetting AS (${cte})`
+  }
+  
+  const mergeFilterOperators = {
+    contains: 'LIKE',
+    beginsWith: 'LIKE',
+    endsWith: 'LIKE',
+    equals: '=',
+    notequal: '!=',
+    greaterThan: '>',
+    lessThan: '<',
+  }
+  
+  function genFilter(filter) {
+    let {field, condition = 'equals', value} = filter
+    if (field === 'result') {
+      field = 'resultId'
+      value = dbUtils.REVIEW_RESULT_API[value]
+    }
+    if (field === 'status' || field === 'statusLabel') {
+      field = 'statusId'
+      value = dbUtils.REVIEW_STATUS_API[value]
+    }
+  
+    value = field === 'userId' || field === 'statusUserId' ? parseInt(value) : value
+  
+    const sqlOperator = mergeFilterOperators[condition]
+    const isDateValue =  (field === 'ts' || field === 'touchTs' || field === 'statusTs')
+    let sqlValue
+    if (isDateValue) {
+      sqlValue = dbUtils.pool.escape(new Date(value))
+    }
+    else if (condition === 'contains') {
+      sqlValue = dbUtils.pool.escape(`%${value}%`)
+    }
+    else if (condition === 'beginsWith') {
+      sqlValue = dbUtils.pool.escape(`${value}%`)
+    }
+    else if (condition === 'endsWith') {
+      sqlValue = dbUtils.pool.escape(`%${value}`)
+    }
+    else {
+      sqlValue = dbUtils.pool.escape(value)
+    }
+    return `review.${field} ${sqlOperator} ${sqlValue}`
+  }
+  
+  function cteCandidateGen ({skipGrantCheck = false, action, updateFilters}) {
+    let sqlFilterPredicates, sqlPredicates
+    if (updateFilters) {
+      sqlFilterPredicates = updateFilters.map( filter => genFilter(filter)).join(' AND ')
+    }
+  
+    if (action === 'insert') {
+      sqlPredicates = `review.reviewId is null`
+    }
+    else if (action === 'update') {
+      sqlPredicates = sqlFilterPredicates || 'review.reviewId is not null'
+    }
+    else if (action === 'merge') {
+      sqlPredicates = `${sqlFilterPredicates ? `review.reviewId is null OR (${sqlFilterPredicates})` : ''}`
+    }
+    const cte = `
+  select
+    ${!skipGrantCheck ? 'CASE WHEN cteGrant.assetId is not null then 1 else null end' : '1'} as granted,
+    review.reviewId,
+    cteAsset.assetId,
+    cteRule.ruleId,
+    rvcd.version,
+    rvcd.checkDigest,
+    
+    COALESCE(cteReview.resultId, review.resultId) as resultId,
+    COALESCE(cteReview.detail, review.detail, '') as detail,
+    COALESCE(cteReview.comment, review.comment, '') as comment,
+    COALESCE(cteReview.metadata, review.metadata, '{}') as metadata,
+    
+    CASE WHEN cteReview.resultEngine != 0 -- resultEngine present
+      THEN cteReview.resultEngine
+      ELSE
+      CASE WHEN cteReview.resultId is null or cteReview.resultId = review.resultId
+        THEN review.resultEngine
+        ELSE NULL
+      END
+    END as resultEngine,
+      
+    CASE WHEN cteReview.statusId is not null
+      THEN cteReview.statusId
+      ELSE
+        CASE WHEN review.reviewId is null
+            or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
+            or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
+          THEN 0
+          ELSE review.statusId
+        END
+    END as statusId,
+      
+    CASE WHEN cteReview.statusId is not null or review.reviewId is null
+      THEN cteReview.statusText
+      ELSE
+        CASE WHEN (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
+            or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
+          THEN 'Review change triggered status update'
+          ELSE review.statusText
+        END
+    END as statusText,
+      
+    CASE WHEN cteReview.statusId is not null 
+        or review.reviewId is null
+        or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
+        or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
+      THEN UTC_TIMESTAMP()
+      ELSE review.statusTs
+    END as statusTs,
+    
+    CASE WHEN cteReview.statusId is not null 
+        or review.reviewId is null
+        or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
+        or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
+      THEN @userId
+      ELSE review.statusUserId
+    END as statusUserId,
+      
+    CASE WHEN cteReview.resultId is not null
+        or cteReview.detail is not null
+        or cteReview.comment is not null
+        or review.reviewId is null
+      THEN @userId
+      ELSE review.userId
+    END as userId,
+      
+    CASE WHEN cteReview.resultId is not null
+        or cteReview.detail is not null
+        or cteReview.comment is not null
+        or review.reviewId is null
+      THEN UTC_TIMESTAMP()
+      ELSE review.ts
+    END as ts
+  
+  from
+    cteAsset
+    CROSS JOIN cteRule
+    LEFT JOIN cteReview on true
+    ${!skipGrantCheck ? 'LEFT JOIN cteGrant on (cteAsset.assetId = cteGrant.assetId and cteRule.ruleId = cteGrant.ruleId)' : ''}
+    LEFT JOIN rule_version_check_digest rvcd on cteRule.ruleId = rvcd.ruleId
+    LEFT JOIN review on (cteAsset.assetId = review.assetId and rvcd.version = review.version and rvcd.checkDigest = review.checkDigest)
+    LEFT JOIN cteCollectionSetting on true
+    LEFT JOIN review rChangedResult on (
+      rChangedResult.reviewId = review.reviewId 
+      and rChangedResult.statusId != 0
+      and rChangedResult.resultId != cteReview.resultId
+    )
+    LEFT JOIN review rChangedAny on (
+      rChangedAny.reviewId = review.reviewId 
+      and rChangedAny.statusId != 0
+      and (rChangedAny.resultId != cteReview.resultId or rChangedAny.detail != cteReview.detail or rChangedAny.comment != cteReview.comment)
+    )
+    ${sqlPredicates ? `WHERE ${sqlPredicates}` : ''}
+    `
+    return `cteCandidate AS (${cte})`
+  }
+  
   const cteReview = cteReviewGen()
   const cteAsset = cteAssetGen(assets)
   if (rules.benchmarkIds) {
@@ -486,26 +482,15 @@ from
     r.userId = vr.userId,
     r.ts = vr.ts
   `
-  // performance.mark('afterCteGen');
-
-  // performance.measure('CteGen', 'beforeCteGen', 'afterCteGen')
 
   let connection
   try {
-    // performance.mark('beforeGetConnection')
     connection = await dbUtils.pool.getConnection()
-    // performance.mark('afterGetConnection')
-    // performance.measure('GetConnection', 'beforeGetConnection', 'afterGetConnection')
-
     connection.config.namedPlaceholders = false
 
     const sqlVariables = `set @collectionId = ?, @userId = ?, @review = ?`
     await connection.query(sqlVariables, [parseInt(collectionId), parseInt(userId), JSON.stringify(source.review)])
-    // performance.mark('beforeTempTable')
     await connection.query(sqlTempTable)
-    // performance.mark('afterTempTable')
-    // performance.measure('TempTable', 'beforeTempTable', 'afterTempTable')
-
     
     let validationErrors = []
     let [table] = await connection.query('select * from validated_reviews')
@@ -517,34 +502,17 @@ from
     if (counts[0].failedValidations) {
       ;[validationErrors] = await connection.query('select CAST(assetId AS CHAR) as assetId, ruleId, error from validated_reviews where error is not null LIMIT 50')
     }
-    // performance.mark('afterCounts')
-    // performance.measure('Counts', 'afterTempTable', 'afterCounts')
-
-    // return {inserted: 0, updated: 0, errors:[]}
     async function transaction () {
       await connection.query('START TRANSACTION')
 
       if (counts[0].updates) {
         if (historyMaxReviews !== -1) {
-          // performance.mark('beforeHistoryPrune')
           await connection.query(sqlHistoryPrune, [ historyMaxReviews ])
-          // performance.mark('afterHistoryPrune')
-          // performance.measure('HistoryPrune', 'beforeHistoryPrune', 'afterHistoryPrune')
-
-
         }
         if (historyMaxReviews !== 0) {
-          // performance.mark('beforeHistory')
           await connection.query(sqlHistory)
-          // performance.mark('afterHistory')
-          // performance.measure('History', 'beforeHistory', 'afterHistory')
-
         }
-        // performance.mark('beforeUpdateReviews')
         await connection.query(sqlUpdateReviews) 
-        // performance.mark('afterUpdateReviews')
-        // performance.measure('UpdateReviews', 'beforeUpdateReviews', 'afterUpdateReviews')
-
       }
       if (counts[0].inserts) {
         await connection.query(sqlInsertReviews) 
@@ -564,18 +532,8 @@ from
       else if (rules.benchmarkIds) {
         statsParams.benchmarkIds = rules.benchmarkIds
       }
-      // performance.mark('beforeUpdateStats')
-      dbUtils.updateStatsAssetStig(connection, statsParams)
-      // performance.mark('afterUpdateStats')
-      // performance.measure('UpdateStats', 'beforeUpdateStats', 'afterUpdateStats')
-
-
-      // performance.mark('beforeCommit')
+      await dbUtils.updateStatsAssetStig(connection, statsParams)
       await connection.commit()
-      // performance.mark('afterCommit')
-      // performance.measure('Commit', 'beforeCommit', 'afterCommit')
-
-     
     }
 
     if (!dryRun) {
@@ -600,180 +558,6 @@ from
   }
 }
 
-const writeQueries = {
-  dropIncoming: 'DROP TEMPORARY TABLE IF EXISTS incoming',
-  createIncomingForPost: `
-  CREATE TEMPORARY TABLE IF NOT EXISTS incoming (
-    ruleId varchar(255),
-    \`version\` varchar(45),
-    checkDigest binary(32),
-    resultId int,
-    resultEngine json,
-    detail mediumtext,
-    comment mediumtext,
-    autoResult json,
-    statusId int,
-    statusText varchar(255),
-    PRIMARY KEY (ruleId),
-    UNIQUE KEY (\`version\`, checkDigest)
-  ) 
-    REPLACE SELECT
-      jt.ruleId,
-      jtrvcd.version,
-      jtrvcd.checkDigest,
-      jtresult.resultId,
-      jt.resultEngine,
-      jt.detail,
-      jt.comment,
-      jt.autoResult,
-      jtstatus.statusId,
-      jt.statusText
-    FROM
-      JSON_TABLE(
-        ?,
-        "$[*]"
-        COLUMNS(
-          ruleId VARCHAR(255) PATH "$.ruleId",
-          result VARCHAR(255) PATH "$.result",
-          resultEngine JSON PATH "$.resultEngine",
-          detail MEDIUMTEXT PATH "$.detail" NULL ON EMPTY,
-          comment MEDIUMTEXT PATH "$.comment",
-          autoResult JSON PATH "$.autoResult",
-          statusLabel VARCHAR(255) PATH "$.status.label",
-          statusText VARCHAR(255) PATH "$.status.text"
-        )
-      ) as jt
-      left join rule_version_check_digest jtrvcd on jtrvcd.ruleId = jt.ruleId
-      left join result jtresult on (jtresult.api = jt.result)
-      left join status jtstatus on (jtstatus.api = jt.statusLabel)
-  `,
-  insertReviews: `
-  insert into review (
-    assetId,
-      ruleId,
-      \`version\`,
-      checkDigest,
-      resultId,
-      resultEngine,
-      detail,
-      comment,
-      autoResult,
-      ts,
-      userId,
-      statusId,
-      statusText,
-      statusUserId,
-      statusTs
-  )
-  select
-    :assetId,
-    i.ruleId,
-    i.version,
-    i.checkDigest,
-    i.resultId,
-    CASE WHEN i.resultEngine = 0 THEN NULL ELSE i.resultEngine END,
-    COALESCE(i.detail,''),
-    COALESCE(i.comment,''),
-    CASE WHEN i.autoResult THEN 1 ELSE 0 END,
-    UTC_TIMESTAMP(),
-    :userId,
-    CASE WHEN i.statusId is not null THEN i.statusId ELSE 0 END,
-    i.statusText,
-    :userId,
-    UTC_TIMESTAMP()
-    from
-      incoming i
-      left join review r on (r.assetId = :assetId and r.version = i.version and r.checkDigest = i.checkDigest)
-    where
-      r.reviewId is null  
-  `,
-  updateReviews: (resetCriteria = 'result') => `
-  update 
-    incoming i
-    inner join review r on (r.assetId = :assetId and r.version = i.version and r.checkDigest = i.checkDigest)
-    left join review rChanged on (
-      rChanged.assetId = :assetId 
-      and rChanged.version = i.version
-      and rChanged.checkDigest = i.checkDigest 
-      and rChanged.statusId != 0 
-      and (
-        rChanged.resultId != i.resultId
-        ${resetCriteria === 'any' ? 'or rChanged.detail != i.detail or rChanged.comment != i.comment' : ''}
-      )
-    )
-  SET
-    r.assetId = :assetId,
-
-    r.ruleId = i.ruleId,
-
-    r.version = i.version,
-
-    r.checkDigest = i.checkDigest,
-
-    r.resultId = COALESCE(i.resultId, r.resultId),
-
-    r.detail = COALESCE(i.detail, r.detail),
-
-    r.comment = COALESCE(i.comment, r.comment),
-
-    r.autoResult = CASE WHEN i.autoResult IS NOT NULL
-      THEN CASE WHEN i.autoResult THEN 1 ELSE 0 END
-      ELSE r.autoResult
-    END,
-
-    r.resultEngine = CASE WHEN i.resultEngine = 0 THEN NULL ELSE COALESCE(i.resultEngine, r.resultEngine) END,
-
-    r.ts = CASE WHEN i.resultId IS NOT NULL 
-    OR i.detail IS NOT NULL 
-    OR i.comment IS NOT NULL
-    OR i.autoResult IS NOT NULL
-      THEN UTC_TIMESTAMP()
-      ELSE r.ts
-    END,
-
-    r.userId = CASE WHEN i.resultId IS NOT NULL 
-    OR i.detail IS NOT NULL 
-    OR i.comment IS NOT NULL
-    OR i.autoResult IS NOT NULL
-      THEN :userId
-      ELSE r.userId
-    END,
-
-    r.statusId = CASE WHEN i.statusId IS NOT NULL 
-      THEN i.statusId 
-      ELSE CASE WHEN rChanged.reviewId IS NOT NULL
-        THEN 0
-        ELSE r.statusId
-      END
-    END,
-
-    r.statusText = CASE WHEN i.statusId IS NOT NULL 
-      THEN i.statusText 
-        ELSE CASE WHEN rChanged.reviewId IS NOT NULL
-          THEN 'Review change triggered status update'
-          ELSE CASE WHEN r.statusId = 0
-            THEN NULL
-            ELSE r.statusText
-        END
-      END
-    END,
-
-    r.statusUserId = CASE WHEN i.statusId IS NOT NULL
-    OR rChanged.reviewId IS NOT NULL
-    OR r.statusId = 0
-      THEN :userId 
-      ELSE r.statusUserId
-    END,
-
-    r.statusTs = CASE WHEN i.statusId IS NOT NULL 
-    OR rChanged.reviewId IS NOT NULL
-    OR r.statusId = 0
-      THEN UTC_TIMESTAMP()
-      ELSE r.statusTs
-    END
-  `
-}
-
 /**
 Generalized queries for review(s).
 **/
@@ -793,7 +577,6 @@ exports.getReviews = async function (inProjection = [], inPredicates = {}, userO
       json_array()
     ) as assetLabelIds`,
     'r.ruleId',
-    // line below is commented so newman tests pass 2023-04-15
     `cast(concat('[', group_concat(distinct concat('"',rvcd2.ruleId,'"')), ']') as json) as ruleIds`,
     'result.api as "result"',
     'CASE WHEN r.resultEngine = 0 THEN NULL ELSE r.resultEngine END as resultEngine',
@@ -846,7 +629,6 @@ exports.getReviews = async function (inProjection = [], inPredicates = {}, userO
     groupBy.push(`r.metadata`)
   }
   if (inProjection.includes('stigs')) {
-    // columns.push(`coalesce(cast( concat( '[', group_concat(distinct concat('"',sa.benchmarkId,'"')), ']' ) as json ),JSON_ARRAY()) as "stigs"`)
     columns.push(`cast(
       concat('[', 
         coalesce (
@@ -1151,119 +933,391 @@ exports.deleteReviewByAssetRule = async function(assetId, ruleId, projection, us
 }
 
 exports.putReviewsByAsset = async function ({
-    assetId, 
-    reviews, 
-    userObject, 
-    resetCriteria, 
-    tryInsert = true, 
-    svcStatus = {},
-    maxHistory = 5
+  collectionId, 
+  assetId,
+  reviews,
+  userId,
+  svcStatus
   }) {
   let connection
+  const sqlCreateTableValidatedReview = `
+CREATE TEMPORARY TABLE IF NOT EXISTS tt_validated_review (
+  INDEX idx_reviewId (reviewId),
+  INDEX idx_error (error),
+  PRIMARY KEY (ruleId),
+  UNIQUE KEY (\`version\`, checkDigest)
+)
+REPLACE WITH
+cteCollectionSetting AS (
+SELECT 
+  c.settings->>"$.fields.detail.required" AS detailRequired,
+  c.settings->>"$.fields.comment.required" AS commentRequired,
+  c.settings->>"$.status.canAccept" AS collectionCanAccept,
+  CASE WHEN c.settings->>"$.status.canAccept" = 'true' AND c.settings->>"$.status.minAcceptGrant" <= cg.accessLevel
+    THEN 'true'
+    ELSE 'false'
+  END AS userCanAccept,
+  c.settings->>"$.status.resetCriteria" AS resetCriteria,
+  c.settings->>"$.history.maxReviews" AS maxReviews
+FROM
+  collection c
+  LEFT JOIN collection_grant cg ON (c.collectionId = cg.collectionId)
+WHERE
+  c.collectionId = @collectionId
+  and cg.userId = @userId
+),
+cteIncoming AS (
+SELECT
+  jt.ruleId,
+  result.resultId,
+  TRIM(jt.detail) as detail,
+  TRIM(jt.comment) as comment,
+  jt.resultEngine,
+  jt.metadata,
+  coalesce(statuslabel.statusId, statusraw.statusId) as statusId,
+  jt.statusText
+FROM
+  JSON_TABLE(
+    @reviews,
+    "$[*]"
+    COLUMNS(
+    ruleId VARCHAR(45) PATH "$.ruleId",
+    result VARCHAR(255) PATH "$.result",
+    detail MEDIUMTEXT PATH "$.detail" NULL ON EMPTY,
+    comment MEDIUMTEXT PATH "$.comment",
+    resultEngine JSON PATH "$.resultEngine",
+    metadata JSON PATH "$.metadata",
+    statusRaw VARCHAR(255) PATH "$.status",
+    statusLabel VARCHAR(255) PATH "$.status.label",
+    statusText VARCHAR(255) PATH "$.status.text"
+    )
+  ) AS jt
+  left join result on (jt.result = result.api)
+  left join \`status\` statusraw on (jt.statusRaw = statusraw.api)
+  left join \`status\` statuslabel on (jt.statusLabel = statuslabel.api)
+),
+cteGrant AS (
+select
+  distinct rgr.ruleId 
+from 
+  asset a
+  left join collection_grant cg on a.collectionId = cg.collectionId
+  left join stig_asset_map sa using (assetId)
+  left join user_stig_asset_map usa on sa.saId = usa.saId
+  left join revision rev using (benchmarkId)
+  left join rev_group_rule_map rgr using (revId)
+where 
+  cg.collectionId =  @collectionId
+  and a.assetId = @assetId
+  and cg.userId = @userId 
+  and (CASE WHEN cg.accessLevel = 1 THEN usa.userId = cg.userId ELSE TRUE END)
+),
+cteCandidate AS (
+select
+  CASE WHEN cteGrant.ruleId is not null then 1 else null end as granted,
+  review.reviewId,
+  @assetId as assetId,
+  cteIncoming.ruleId,
+  rvcd.version,
+  rvcd.checkDigest,
+  
+  COALESCE(cteIncoming.resultId, review.resultId) as resultId,
+  COALESCE(cteIncoming.detail, review.detail, '') as detail,
+  COALESCE(cteIncoming.comment, review.comment, '') as comment,
+  COALESCE(cteIncoming.metadata, review.metadata, '{}') as metadata,
+  
+  CASE WHEN cteIncoming.resultEngine != 0 -- resultEngine present
+    THEN cteIncoming.resultEngine
+    ELSE
+      NULL
+  END as resultEngine,
+  
+  CASE WHEN cteIncoming.statusId is not null
+    THEN cteIncoming.statusId
+    ELSE
+      CASE WHEN review.reviewId is null
+          or (rChangedResult.reviewId is not null and cteCollectionSetting.resetCriteria = 'result')
+          or (rChangedAny.reviewId is not null and cteCollectionSetting.resetCriteria = 'any')
+        THEN 0
+        ELSE review.statusId
+      END
+  END as statusId,
+  
+  CASE WHEN cteIncoming.statusId is not null or review.reviewId is null
+    THEN cteIncoming.statusText
+    ELSE
+      CASE WHEN (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null)
+          or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null)
+        THEN 'Review change triggered status update'
+        ELSE review.statusText
+      END
+  END as statusText,
+  
+  CASE WHEN cteIncoming.statusId is not null -- request contains a status
+      or review.reviewId is null -- no existing review
+      or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null) -- status meets criteria for resetting
+      or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null) -- status meets criteria for resetting
+    THEN UTC_TIMESTAMP() -- now
+    ELSE review.statusTs -- saved time
+  END as statusTs,
+  
+  CASE WHEN cteIncoming.statusId is not null -- request contains a status
+      or review.reviewId is null -- no existing review
+      or (cteCollectionSetting.resetCriteria = 'result' and rChangedResult.reviewId is not null) -- status meets criteria for resetting
+      or (cteCollectionSetting.resetCriteria = 'any' and rChangedAny.reviewId is not null) -- status meets criteria for resetting
+    THEN @userId -- this user
+    ELSE review.statusUserId -- saved user
+  END as statusUserId,
+  
+  @userId as userId,
+  UTC_TIMESTAMP() as ts
+from
+  cteIncoming
+  LEFT JOIN cteGrant on cteIncoming.ruleId = cteGrant.ruleId
+  LEFT JOIN rule_version_check_digest rvcd on cteGrant.ruleId = rvcd.ruleId
+  LEFT JOIN review on (@assetId = review.assetId and rvcd.version = review.version and rvcd.checkDigest = review.checkDigest)
+  LEFT JOIN cteCollectionSetting on true
+  LEFT JOIN review rChangedResult on (
+  review.reviewId = rChangedResult.reviewId
+    and rChangedResult.statusId != 0
+    and cteIncoming.resultId != rChangedResult.resultId
+  )
+  LEFT JOIN review rChangedAny on (
+    review.reviewId = rChangedAny.reviewId
+    and rChangedAny.statusId != 0
+    and (rChangedAny.resultId != cteIncoming.resultId or rChangedAny.detail != cteIncoming.detail or rChangedAny.comment != cteIncoming.comment)
+  )
+)
+select
+  CASE WHEN cteCandidate.granted IS NULL
+    THEN 
+      'no grant for this asset/ruleId'
+    ELSE
+      CASE WHEN cteCandidate.statusId > 0 -- submitted, rejected, accepted
+        THEN
+          CASE WHEN (cteCollectionSetting.collectionCanAccept = 'false' and cteCandidate.statusId IN (2,3))
+            THEN
+              'status = accepted, rejected not allowed for this Collection'
+            ELSE
+              CASE WHEN (cteCollectionSetting.userCanAccept = 'false' and cteCandidate.statusId IN (2,3))
+                THEN
+                  'status = accepted, rejected not allowed for this User'
+                ELSE
+                  CASE WHEN (cteCandidate.resultId NOT IN (2,3,4))
+                    THEN
+                      'status is not allowed for the result'
+                    ELSE
+                      CASE WHEN (cteCollectionSetting.detailRequired = 'always' AND cteCandidate.detail = '')
+                        THEN 
+                          'empty detail is not allowed for status = submitted, accepted, rejected'
+                        ELSE
+                          CASE WHEN (cteCollectionSetting.commentRequired = 'always' AND cteCandidate.comment = '')
+                            THEN 
+                              'empty comment is not allowed for status = submitted, accepted, rejected'
+                            ELSE
+                              CASE WHEN cteCandidate.resultId = 4 -- fail
+                                THEN
+                                  CASE WHEN (cteCollectionSetting.detailRequired = 'findings' AND cteCandidate.detail = '')
+                                    THEN 
+                                      'result = fail and empty detail not allowed for status = submitted, accepted, rejected'
+                                    ELSE
+                                      CASE WHEN (cteCollectionSetting.commentRequired = 'findings' AND cteCandidate.comment = '')
+                                        THEN 
+                                          'result = fail and empty comment not allowed for status = submitted, accepted, rejected'
+                                      END
+                                  END
+                              END
+                          END
+                      END
+                  END
+              END
+          END
+      END
+  END as error,
+  cteCandidate.reviewId, 
+  cteCandidate.assetId, 
+  cteCandidate.ruleId, 
+  cteCandidate.version,
+  cteCandidate.checkDigest,
+  cteCandidate.resultId, 
+  cteCandidate.detail, 
+  cteCandidate.comment, 
+  cteCandidate.resultEngine, 
+  cteCandidate.metadata, 
+  cteCandidate.statusId, 
+  cteCandidate.statusText,
+  cteCandidate.statusUserId,
+  cteCandidate.statusTs,
+  cteCandidate.userId,
+  cteCandidate.ts
+from
+  cteCandidate
+  LEFT JOIN cteCollectionSetting on true`
+  const sqlHistoryPrune = `
+with historyRecs AS (
+  select
+    rh.historyId,
+    ROW_NUMBER() OVER (PARTITION BY r.assetId, r.version, r.checkDigest ORDER BY rh.historyId DESC) as rowNum
+  from
+    review_history rh
+    left join review r using (reviewId)
+  where
+    reviewId IN (SELECT reviewId from tt_validated_review where error is null and reviewId is not null)
+)
+delete review_history
+FROM 
+   review_history
+   left join historyRecs on review_history.historyId = historyRecs.historyId 
+WHERE 
+   historyRecs.rowNum > (select c.settings->>"$.history.maxReviews" FROM collection c where collectionId = @collectionId) - 1
+`
+  const sqlHistory = `  
+INSERT INTO review_history (
+  reviewId,
+  ruleId,
+  resultId,
+  detail,
+  comment,
+  autoResult,
+  ts,
+  userId,
+  statusText,
+  statusUserId,
+  statusTs,
+  statusId,
+  touchTs,
+  resultEngine
+) SELECT 
+    reviewId,
+    ruleId,
+    resultId,
+    LEFT(detail,32767) as detail,
+    LEFT(comment,32767) as comment,
+    autoResult,
+    ts,
+    userId,
+    statusText,
+    statusUserId,
+    statusTs,
+    statusId,
+    touchTs,
+    CASE WHEN resultEngine = 0 THEN NULL ELSE resultEngine END
+  FROM
+    review 
+  WHERE
+    reviewId IN (SELECT reviewId from tt_validated_review where error is null and reviewId is not null)
+  FOR UPDATE
+`
+  const sqlUpdateReviews = `
+update
+  review r
+  inner join tt_validated_review vr on (r.reviewId = vr.reviewId and vr.error is null)
+set
+  r.ruleId = vr.ruleId,
+  r.resultId = vr.resultId,
+  r.resultEngine = vr.resultEngine,
+  r.detail = vr.detail,
+  r.comment = vr.comment,
+  r.metadata = vr.metadata,
+  r.statusId = vr.statusId,
+  r.statusText = vr.statusText,
+  r.statusUserId = vr.statusUserId,
+  r.statusTs = vr.statusTs,
+  r.userId = vr.userId,
+  r.ts = vr.ts
+`
+  const sqlInsertReviews = `
+insert into review (
+  assetId,
+  ruleId,
+  \`version\`,
+  checkDigest,
+  resultId,
+  resultEngine,
+  detail,
+  comment,
+  metadata,
+  statusId,
+  statusText,
+  statusUserId,
+  statusTs,
+  userId,
+  ts)
+select 
+  assetId,
+  ruleId,
+  \`version\`,
+  checkDigest,
+  resultId,
+  resultEngine,
+  detail,
+  comment,
+  metadata,
+  statusId,
+  statusText,
+  statusUserId,
+  statusTs,
+  userId,
+  ts
+from
+  tt_validated_review vr
+where
+  error is null and reviewId is null 
+`
   try {
     connection = await dbUtils.pool.getConnection()
-    await connection.query(writeQueries.dropIncoming)
-    await connection.query(writeQueries.createIncomingForPost, [ JSON.stringify(reviews) ])
+    
+    const sqlSetVariables = `set @collectionId = ?, @assetId = ?, @userId = ?, @reviews = ?`
+    await connection.query(sqlSetVariables, [parseInt(collectionId), parseInt(assetId), parseInt(userId), JSON.stringify(reviews)])
+    const [settings] = await connection.query(`select c.settings->>"$.history.maxReviews" as maxReviews FROM collection c where collectionId = @collectionId`)
+    const historyMaxReviews = settings[0].maxReviews
+    await connection.query(sqlCreateTableValidatedReview)
+    let [counts] = await connection.query(`select
+    coalesce(sum(case when error is not null then 1 else 0 end),0) as failedValidations,
+    coalesce(sum(case when error is null and reviewId is null then 1 else 0 end),0) as inserts,
+    coalesce(sum(case when error is null and reviewId is not null then 1 else 0 end),0) as updates
+    from tt_validated_review`)
+    let validationErrors = []
+    if (counts[0].failedValidations) {
+      ;[validationErrors] = await connection.query('select ruleId, error as reason from tt_validated_review where error is not null LIMIT 50')
+    }
 
     async function transaction () {
-      const affected = {
-        updated: 0,
-        inserted: 0
-      }
-      const sqlHistoryPrune = `
-      with historyRecs AS (
-        select
-          rh.historyId,
-          ROW_NUMBER() OVER (PARTITION BY r.assetId, r.version, r.checkDigest ORDER BY rh.historyId DESC) as rowNum
-        from
-          review_history rh
-          left join review r using (reviewId)
-          left join rule_version_check_digest rvcd on r.version = rvcd.version and r.checkDigest = rvcd.checkDigest
-        where
-          r.assetId = ?
-          and rvcd.ruleId IN ?)
-      delete review_history
-      FROM 
-         review_history
-         left join historyRecs on review_history.historyId = historyRecs.historyId 
-      WHERE 
-         historyRecs.rowNum > ? - 1
-      `
-      const sqlHistory = `  
-      INSERT INTO review_history (
-        reviewId,
-        ruleId,
-        resultId,
-        detail,
-        comment,
-        autoResult,
-        ts,
-        userId,
-        statusText,
-        statusUserId,
-        statusTs,
-        statusId,
-        touchTs,
-        resultEngine
-      ) SELECT 
-          r.reviewId,
-          r.ruleId,
-          r.resultId,
-          LEFT(r.detail,32767) as detail,
-          LEFT(r.comment,32767) as comment,
-          r.autoResult,
-          r.ts,
-          r.userId,
-          r.statusText,
-          r.statusUserId,
-          r.statusTs,
-          r.statusId,
-          r.touchTs,
-          CASE WHEN r.resultEngine = 0 THEN NULL ELSE r.resultEngine END
-        FROM
-          review r
-          left join rule_version_check_digest rvcd on r.version=rvcd.version and r.checkDigest=rvcd.checkDigest
-        WHERE
-          r.assetId = ?
-          and rvcd.ruleId IN ?
-          and r.reviewId IS NOT NULL
-        FOR UPDATE    
-      `
       await connection.query('START TRANSACTION')
-      const historyRules = reviews.map( r => r.ruleId )
-      if (maxHistory !== -1) {
-        await connection.query(sqlHistoryPrune, [ assetId, [historyRules], maxHistory ])
+      if (counts[0].updates) {
+        if (historyMaxReviews !== -1) {
+          await connection.query(sqlHistoryPrune, [ historyMaxReviews ])
+        }
+        if (historyMaxReviews !== 0) {
+          await connection.query(sqlHistory)
+        }
+        await connection.query(sqlUpdateReviews) 
       }
-      if (maxHistory !== 0) {
-        await connection.query(sqlHistory, [ assetId, [historyRules] ])
+      if (counts[0].inserts) {
+        await connection.query(sqlInsertReviews) 
       }
-      const [resultUpdate] = await connection.query(writeQueries.updateReviews(resetCriteria), {userId: userObject.userId, assetId})
-      affected.updated = resultUpdate.affectedRows
-      if (tryInsert) {
-        const [resultInsert] = await connection.query(writeQueries.insertReviews, {userId: userObject.userId, assetId})
-        affected.inserted = resultInsert.affectedRows
-      }
-      await dbUtils.updateStatsAssetStig(connection, {
-        assetId: assetId,
-        rules: historyRules
-      })
+      await dbUtils.updateStatsAssetStig(connection, {assetId})
       await connection.commit()
-      return affected
     }
-    return await dbUtils.retryOnDeadlock(transaction, svcStatus)
+    await dbUtils.retryOnDeadlock(transaction, svcStatus)
+
+    return {
+      rejected: validationErrors,
+      affected: {
+        updated: counts[0].updates,
+        inserted: counts[0].inserts
+      }
+    }
   }
-  catch(err) {
+  catch (err) {
     if (typeof connection !== 'undefined') {
       await connection.rollback()
-    }
-    if (err.code === 'ER_DUP_ENTRY') {
-      throw({status: 400, message: err.message})
-    }
-    throw ( err )
+    }    
+    throw ( {status: 500, message: err.message, stack: err.stack} ) ;
   }
   finally {
     if (typeof connection !== 'undefined') {
-      await connection.query(writeQueries.dropIncoming)
+      await connection.query('DROP TEMPORARY TABLE IF EXISTS tt_validated_review')
       await connection.release()
     }
   }

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -62181,6 +62181,425 @@
 							"response": []
 						}
 					]
+				},
+				{
+					"name": "review status reset check",
+					"item": [
+						{
+							"name": "Import and overwrite application data (as elevated Admin) Copy 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let user = pm.environment.get(\"user\");\r",
+											"console.log(\"user: \" + user);\r",
+											"\r",
+											"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+											"    user = \"elevated\";\r",
+											"    console.log(\"setting user to 'elevated'\");\r",
+											"}\r",
+											"\r",
+											"if (user == \"elevated\") { //placeholder for \"users\" that should fail\r",
+											"    pm.test(\"Status should be is 200 for elevated stigmanadmin user\", function () {\r",
+											"        pm.response.to.have.status(200);\r",
+											"    });\r",
+											"}\r",
+											"else {\r",
+											"    pm.test(\"Status code is 403\", function () {\r",
+											"        pm.response.to.have.status(403);\r",
+											"    });\r",
+											"}\r",
+											"if (pm.response.code !== 200) {\r",
+											"    return;\r",
+											"}\r",
+											"\r",
+											"\r",
+											"let response = pm.response.text();\r",
+											"console.log(response)\r",
+											"\r",
+											"pm.test(\"Body contains string\",() => {\r",
+											"  pm.expect(response).to.include(\"Commit successful\");\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "oauth2",
+									"oauth2": [
+										{
+											"key": "accessToken",
+											"value": "{{token.stigmanadmin}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "multipart/form-data"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "importFile",
+											"type": "file",
+											"src": "./{{formDataFiles}}/{{appDataFile}}"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{baseUrl}}/op/appdata?elevate=true",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"op",
+										"appdata"
+									],
+									"query": [
+										{
+											"key": "elevate",
+											"value": "true",
+											"description": "Elevate the user context for this request if user is permitted (canAdmin)"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "PATCH Review with new details, expect status to remain",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let user = pm.environment.get('user');\r",
+											"\r",
+											"console.log('user: ' + user)\r",
+											"\r",
+											"let jsonData = pm.response.json();\r",
+											"\r",
+											"pm.test('Status is 200', () => pm.response.to.have.status(200))\r",
+											"\r",
+											"pm.test(\"Status is still submitted\", () => {\r",
+											"    pm.expect(jsonData.status).to.have.property('label').that.eqls('submitted');\r",
+											"});\r",
+											"\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{token.stigmanadmin}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"detail\": \"these details have changed, but the status remains\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/collections/:collectionId/reviews/:assetId/:ruleId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"collections",
+										":collectionId",
+										"reviews",
+										":assetId",
+										":ruleId"
+									],
+									"variable": [
+										{
+											"key": "collectionId",
+											"value": "{{testCollection}}",
+											"description": "(Required) A path parameter that indentifies a Collection"
+										},
+										{
+											"key": "assetId",
+											"value": "{{testAsset}}",
+											"description": "(Required) A path parameter that indentifies an Asset"
+										},
+										{
+											"key": "ruleId",
+											"value": "SV-106181r1_rule",
+											"description": "(Required) A path parameter that indentifies a Rule"
+										}
+									]
+								},
+								"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+							},
+							"response": []
+						},
+						{
+							"name": "PATCH Review with new result, expect status to reset to saved",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let user = pm.environment.get(\"user\")\r",
+											"console.log(\"user: \" + user)\r",
+											"\r",
+											"let jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"Status is 200\", () => pm.response.to.have.status(200))\r",
+											"\r",
+											"pm.test(\"Result was set to pass\", () => {\r",
+											"     pm.expect(jsonData.result).to.eql(\"pass\")\r",
+											"})\r",
+											"pm.test(\"Status is now saved\", () => {\r",
+											"    pm.expect(jsonData.status.label).to.eql(\"saved\")\r",
+											"})\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{token.stigmanadmin}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"result\": \"pass\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/collections/:collectionId/reviews/:assetId/:ruleId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"collections",
+										":collectionId",
+										"reviews",
+										":assetId",
+										":ruleId"
+									],
+									"variable": [
+										{
+											"key": "collectionId",
+											"value": "{{testCollection}}",
+											"description": "(Required) A path parameter that indentifies a Collection"
+										},
+										{
+											"key": "assetId",
+											"value": "{{testAsset}}",
+											"description": "(Required) A path parameter that indentifies an Asset"
+										},
+										{
+											"key": "ruleId",
+											"value": "SV-106181r1_rule",
+											"description": "(Required) A path parameter that indentifies a Rule"
+										}
+									]
+								},
+								"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+							},
+							"response": []
+						},
+						{
+							"name": "PATCH Review to submitted status",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let user = pm.environment.get(\"user\")\r",
+											"console.log(\"user: \" + user)\r",
+											"\r",
+											"let jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"Status is 200\", () => pm.response.to.have.status(200))\r",
+											"\r",
+											"\r",
+											"pm.test(\"Status is now submitted\", () => {\r",
+											"    pm.expect(jsonData.status.label).to.eql(\"submitted\")\r",
+											"})\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{token.stigmanadmin}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"status\": \"submitted\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/collections/:collectionId/reviews/:assetId/:ruleId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"collections",
+										":collectionId",
+										"reviews",
+										":assetId",
+										":ruleId"
+									],
+									"variable": [
+										{
+											"key": "collectionId",
+											"value": "{{testCollection}}",
+											"description": "(Required) A path parameter that indentifies a Collection"
+										},
+										{
+											"key": "assetId",
+											"value": "{{testAsset}}",
+											"description": "(Required) A path parameter that indentifies an Asset"
+										},
+										{
+											"key": "ruleId",
+											"value": "SV-106181r1_rule",
+											"description": "(Required) A path parameter that indentifies a Rule"
+										}
+									]
+								},
+								"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+							},
+							"response": []
+						},
+						{
+							"name": "PATCH Review patched and no longer meets Collection Requirements",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let user = pm.environment.get(\"user\")\r",
+											"console.log(\"user: \" + user)\r",
+											"\r",
+											"let jsonData = pm.response.json()\r",
+											"\r",
+											"pm.test(\"Status is 200\", () => pm.response.to.have.status(200))\r",
+											"\r",
+											"pm.test(\"Result was set to fail\", () => {\r",
+											"     pm.expect(jsonData.result).to.eql(\"fail\")\r",
+											"})\r",
+											"pm.test(\"Status is now saved\", () => {\r",
+											"    pm.expect(jsonData.status.label).to.eql(\"saved\")\r",
+											"})\r",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{token.stigmanadmin}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"result\": \"fail\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/collections/:collectionId/reviews/:assetId/:ruleId",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"collections",
+										":collectionId",
+										"reviews",
+										":assetId",
+										":ruleId"
+									],
+									"variable": [
+										{
+											"key": "collectionId",
+											"value": "{{testCollection}}",
+											"description": "(Required) A path parameter that indentifies a Collection"
+										},
+										{
+											"key": "assetId",
+											"value": "{{testAsset}}",
+											"description": "(Required) A path parameter that indentifies an Asset"
+										},
+										{
+											"key": "ruleId",
+											"value": "SV-106181r1_rule",
+											"description": "(Required) A path parameter that indentifies a Rule"
+										}
+									]
+								},
+								"description": "Create a new Review, or update all properties of an existing Review, setting missing properties to null"
+							},
+							"response": []
+						}
+					]
 				}
 			],
 			"description": "These tests should be self contained, provide their own authorization, and repopulate test data if required.",


### PR DESCRIPTION
Resolves #1098 
Resolves #985

Refactors the controller and MySQL service methods for Asset Review POST, PUT, and PATCH endpoints:

`POST /collections/{collectionId}/reviews/{assetId}`
`PATCH /collections/{collectionId}/reviews/{assetId}/{ruleId}`
`PUT /collections/{collectionId}/reviews/{assetId}/{ruleId}`

The revised approach performs most request validation logic in the MySQL service.