### PR TITLE
fix: Change STIGMAN_JWT_SERVICENAME_CLAIM to conform w/ standard. Don't create null user if no username claim found.

### DIFF
--- a/api/source/utils/auth.js
+++ b/api/source/utils/auth.js
@@ -26,6 +26,9 @@ const verifyRequest = async function (req, requiredScopes, securityDefinition) {
         const decoded = await verifyAndDecodeToken (token, getKey, options)
         req.access_token = decoded
         req.bearer = token
+        req.userObject = {
+            email: decoded[config.oauth.claims.email] ||  'None Provided'
+        }        
         // Get username from configured claim in token, or fall back through precedence list
         const usernamePrecedence = [config.oauth.claims.username, config.oauth.claims.servicename, "azp", "client_id", "clientId"]
         for (const precedence of usernamePrecedence) {

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -75,7 +75,7 @@ let config = {
         authority: process.env.STIGMAN_OIDC_PROVIDER || process.env.STIGMAN_API_AUTHORITY || "http://localhost:8080/auth/realms/stigman",
         claims: {
             scope: process.env.STIGMAN_JWT_SCOPE_CLAIM || "scope",
-            username: process.env.STIGMAN_JWT_USERNAME_CLAIM || "preferred_username",
+            username: process.env.STIGMAN_JWT_USERNAME_CLAIM,
             servicename: process.env.STIGMAN_JWT_SERVICENAME_CLAIM,
             name: process.env.STIGMAN_JWT_NAME_CLAIM || process.env.STIGMAN_JWT_USERNAME_CLAIM || "name",
             privileges: formatChain(process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || "realm_access.roles"),

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -76,7 +76,7 @@ let config = {
         claims: {
             scope: process.env.STIGMAN_JWT_SCOPE_CLAIM || "scope",
             username: process.env.STIGMAN_JWT_USERNAME_CLAIM || "preferred_username",
-            servicename: process.env.STIGMAN_JWT_SERVICENAME_CLAIM || "clientId",
+            servicename: process.env.STIGMAN_JWT_SERVICENAME_CLAIM,
             name: process.env.STIGMAN_JWT_NAME_CLAIM || process.env.STIGMAN_JWT_USERNAME_CLAIM || "name",
             privileges: formatChain(process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || "realm_access.roles"),
             email: process.env.STIGMAN_JWT_EMAIL_CLAIM || "email"

--- a/api/source/utils/error.js
+++ b/api/source/utils/error.js
@@ -11,13 +11,6 @@ class SmError extends Error {
   }
 }
 
-class PrivilegeError extends SmError {
-  constructor(detail) {
-    super('User has insufficient privilege to complete this request.')
-    this.status = 403
-    this.detail = detail
-  }
-}
 
 class ClientError extends SmError {
   constructor(detail) {
@@ -27,6 +20,21 @@ class ClientError extends SmError {
   }
 }
 
+class AuthorizeError extends SmError {
+  constructor(detail) {
+    super('Request not authorized.')
+    this.status = 401
+    this.detail = detail
+  }
+}
+
+class PrivilegeError extends SmError {
+  constructor(detail) {
+    super('User has insufficient privilege to complete this request.')
+    this.status = 403
+    this.detail = detail
+  }
+}
 class NotFoundError extends SmError {
   constructor(detail) {
     super('Resource not found.')
@@ -52,6 +60,7 @@ class InternalError extends SmError {
 
 module.exports = {
   SmError,
+  AuthorizeError,  
   PrivilegeError,
   NotFoundError,
   ClientError,


### PR DESCRIPTION
Keycloak was previously using `clientId` but now uses `client_id` which conforms w/ oidc spec. This caused our fallback service name to fail with new versions of Keycloak. When service name is not specified, app will now fall back through azp, client_id, and clientId claims. 
Changed processing to throw a privilege error If no username can be resolved from token claims. 
Added an "Authorize Error" object to SmError that returns status 401.