### PR TITLE
chore: readTheDocs changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,13 @@
 # Required
 version: 2
 
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+    
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ import sphinx_rtd_theme
 # -- Project information -----------------------------------------------------
 
 project = 'STIG Manager'
-copyright = '2023 U.S. Federal Government (in countries where recognized)'
+copyright = '2024 U.S. Federal Government (in countries where recognized)'
 author = 'cd-rite'
 
 


### PR DESCRIPTION
readTheDocs build now fails if build.os is not specified