### PR TITLE
feat: multi-asset patch with delete support

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -5,6 +5,7 @@ const config = require('../utils/config')
 const escape = require('../utils/escape')
 const AssetService = require(`../service/AssetService`);
 const CollectionService = require(`../service/CollectionService`);
+const Security = require('../utils/accessLevels')
 const dbUtils = require(`../service/utils`)
 const {XMLBuilder} = require("fast-xml-parser")
 const SmError = require('../utils/error')
@@ -785,47 +786,33 @@ module.exports.deleteAssetMetadataKey = async function (req, res, next) {
   }  
 }
 
-module.exports.getAssetLabels = async function (req, res, next) {
+module.exports.patchAssets = async function (req, res, next) {
   try {
-    res.json({})
+    const collectionId = getCollectionIdAndCheckPermission(req, Security.ACCESS_LEVEL.Manage)
+    const patchRequest = req.body
+    const collection = await CollectionService.getCollection( collectionId, ['assets'], false, req.userObject)
+    const collectionAssets = collection.assets.map( a => a.assetId)
+    if (!patchRequest.assetIds.every( a => collectionAssets.includes(a))) {
+      throw new SmError.PrivilegeError('One or more assetId is not a Collection member.')
+    }
+    await AssetService.deleteAssets(patchRequest.assetIds, req.userObject)
+    res.json({
+      operation: 'deleted',
+      assetIds: patchRequest.assetIds
+    })
   }
   catch (err) {
     next(err)
   }
 }
 
-module.exports.addAssetLabels = async function (req, res, next) {
-  try {
-    res.json({})
+function getCollectionIdAndCheckPermission(request, minimumAccessLevel = Security.ACCESS_LEVEL.Manage) {
+  let collectionId = request.query.collectionId
+  const collectionGrant = request.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
+  if (collectionGrant?.accessLevel < minimumAccessLevel) {
+    throw new SmError.PrivilegeError()
   }
-  catch (err) {
-    next(err)
-  }
+  return collectionId
 }
 
-module.exports.replaceAssetLabels = async function (req, res, next) {
-  try {
-    res.json({})
-  }
-  catch (err) {
-    next(err)
-  }
-}
 
-module.exports.deleteAssetLabels = async function (req, res, next) {
-  try {
-    res.json({})
-  }
-  catch (err) {
-    next(err)
-  }
-}
-
-module.exports.deleteAssetLabelById = async function (req, res, next) {
-  try {
-    res.json({})
-  }
-  catch (err) {
-    next(err)
-  }
-}

--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -809,7 +809,7 @@ module.exports.patchAssets = async function (req, res, next) {
 function getCollectionIdAndCheckPermission(request, minimumAccessLevel = Security.ACCESS_LEVEL.Manage) {
   let collectionId = request.query.collectionId
   const collectionGrant = request.userObject.collectionGrants.find( g => g.collection.collectionId === collectionId )
-  if (collectionGrant?.accessLevel < minimumAccessLevel) {
+  if (collectionGrant?.accessLevel < minimumAccessLevel || !collectionGrant) {
     throw new SmError.PrivilegeError()
   }
   return collectionId

--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -1333,6 +1333,13 @@ exports.deleteAsset = async function(assetId, projection, elevate, userObject) {
   return (rows[0])
 }
 
+exports.deleteAssets = async function(assetIds, userObject) {
+  const sqlDelete = `UPDATE asset SET state = "disabled", stateDate = NOW(), stateUserId = ? where assetId IN ?`
+  await dbUtils.pool.query(sqlDelete, [userObject.userId, [assetIds]])
+  // changes above might have affected need for records in collection_rev_map 
+  await dbUtils.pruneCollectionRevMap()
+  await dbUtils.updateDefaultRev(null, {})
+}
 
 exports.attachStigToAsset = async function( {assetId, benchmarkId, collectionId, elevate, userObject, svcStatus = {}} ) {
 

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -10,8 +10,6 @@ servers:
   - url: 'http://localhost:64001/api'
 paths:
   /assets:
-    parameters:
-      - $ref: '#/components/parameters/AssetProjectionQuery'
     get:
       tags:
         - Asset
@@ -26,6 +24,7 @@ paths:
         - $ref: '#/components/parameters/NameMatchQuery'
         - $ref: '#/components/parameters/MetadataQuery'
         - $ref: '#/components/parameters/BenchmarkIdQuery'
+        - $ref: '#/components/parameters/AssetProjectionQuery'
       responses:
         '200':
           description: AssetProjected array response
@@ -49,6 +48,8 @@ paths:
         - Asset
       summary: Create an Asset
       operationId: createAsset
+      parameters:
+        - $ref: '#/components/parameters/AssetProjectionQuery'
       requestBody:
         required: true
         content:
@@ -77,6 +78,42 @@ paths:
       security:
         - oauth:
             - 'stig-manager:collection'
+    patch:
+      tags:
+        - Asset
+      summary: Delete one or more Assets
+      operationId: patchAssets
+      parameters:
+        - $ref: '#/components/parameters/CollectionIdQuery'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetsPatchRequest'
+      responses:
+        '200':
+          description: AssetsPatch response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetsPatchResponse'
+        '400':
+          description: Client Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorDuplicateAsset'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      security:
+        - oauth:
+            - 'stig-manager:collection'
+
   '/assets/{assetId}':
     parameters:
       - $ref: '#/components/parameters/AssetIdPath'
@@ -4031,6 +4068,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StigUserBasic'
+    AssetsPatchRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        operation:
+          type: string
+          enum:
+            - delete
+        assetIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetId'
+    AssetsPatchResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        operation:
+          type: string
+          enum:
+            - deleted
+        assetIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetId'
     AssetStigResponse:
       type: object
       additionalProperties: false

--- a/client/src/js/SM/CollectionAsset.js
+++ b/client/src/js/SM/CollectionAsset.js
@@ -265,24 +265,26 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                 try {
                     let assetRecords = me.getSelectionModel().getSelections()
                     const multiDelete = assetRecords.length > 1
-                    var confirmStr=`Deleting ${multiDelete ? '<b>multiple assets</b>' : 'this asset'} will <b>permanently remove</b> all data associated with the asset${multiDelete ? 's' : ''}. This includes all the corresponding STIG assessments. The deleted data <b>cannot be recovered</b>.<br><br>Do you wish to continue?`;
+                    const confirmStr=`Deleting ${multiDelete ? '<b>multiple assets</b>' : 'this asset'} will <b>permanently remove</b> all data associated with the asset${multiDelete ? 's' : ''}. This includes all the corresponding STIG assessments. The deleted data <b>cannot be recovered</b>.<br><br>Do you wish to continue?`;
                     let btn = await SM.confirmPromise("Confirm Delete", confirmStr)
                     if (btn == 'yes') {
-                        const l = assetRecords.length
-                        let apiAsset
-                        for (let i=0; i < l; i++) {
-                            Ext.getBody().mask(`Deleting ${i+1}/${l} Assets`)
-                            // Edge case to handle when the selected record was changed (e.g., stats updated) 
-                            // while still selected, then is deleted
-                            const thisRecord = me.store.getById(assetRecords[i].id)
-                            apiAsset = await Ext.Ajax.requestPromise({
-                                responseType: 'json',
-                                url: `${STIGMAN.Env.apiBase}/assets/${thisRecord.data.assetId}`,
-                                method: 'DELETE'
-                            })
-                            me.store.remove(thisRecord)
-                        }
-                        SM.Dispatcher.fireEvent('assetdeleted', apiAsset) //only need the last deleted asset
+                        const assetIds = assetRecords.map( r => r.data.assetId)
+                        Ext.getBody().mask(`Deleting ${assetRecords.length} Assets`)
+                        await Ext.Ajax.requestPromise({
+                            responseType: 'json',
+                            url: `${STIGMAN.Env.apiBase}/assets?collectionId=${me.collectionId}`,
+                            method: 'PATCH',
+                            jsonData: {
+                                operation: 'delete',
+                                assetIds
+                            }
+                        })
+                        me.store.suspendEvents(false)
+                        // Might need to handle edge case when the selected record was changed (e.g., stats updated) while still selected, then is deleted
+                        me.store.remove(assetRecords)
+                        me.store.resumeEvents()
+
+                        SM.Dispatcher.fireEvent('assetdeleted', {collection: {collectionId: me.collectionId}}) // mock an Asset for collectionManager.onAssetEvent
                     }
                 }
                 catch (e) {

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -35925,6 +35925,304 @@
 							]
 						},
 						{
+							"name": "Assets-batch-delete",
+							"item": [
+								{
+									"name": "Import and overwrite application data (as elevated Admin) Copy",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"let user = pm.environment.get(\"user\");\r",
+													"console.log(\"user: \" + user);\r",
+													"\r",
+													"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+													"    user = \"elevated\";\r",
+													"    console.log(\"setting user to 'elevated'\");\r",
+													"}\r",
+													"\r",
+													"if (user == \"elevated\") { //placeholder for \"users\" that should fail\r",
+													"    pm.test(\"Status should be is 200 for elevated stigmanadmin user\", function () {\r",
+													"        pm.response.to.have.status(200);\r",
+													"    });\r",
+													"}\r",
+													"else {\r",
+													"    pm.test(\"Status code is 403\", function () {\r",
+													"        pm.response.to.have.status(403);\r",
+													"    });\r",
+													"}\r",
+													"if (pm.response.code !== 200) {\r",
+													"    return;\r",
+													"}\r",
+													"\r",
+													"\r",
+													"let response = pm.response.text();\r",
+													"console.log(response)\r",
+													"\r",
+													"pm.test(\"Body contains string\",() => {\r",
+													"  pm.expect(response).to.include(\"Commit successful\");\r",
+													"});"
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"auth": {
+											"type": "oauth2",
+											"oauth2": [
+												{
+													"key": "accessToken",
+													"value": "{{token.stigmanadmin}}",
+													"type": "string"
+												}
+											]
+										},
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"value": "multipart/form-data"
+											}
+										],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "importFile",
+													"type": "file",
+													"src": "./{{formDataFiles}}/{{appDataFile}}"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{baseUrl}}/op/appdata?elevate=true",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"op",
+												"appdata"
+											],
+											"query": [
+												{
+													"key": "elevate",
+													"value": "true",
+													"description": "Elevate the user context for this request if user is permitted (canAdmin)"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Assets - expect success for valid users",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"let user = pm.environment.get(\"user\");\r",
+													"console.log(\"user: \" + user);\r",
+													"\r",
+													"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+													"    user = \"elevated\";\r",
+													"    console.log(\"setting user to 'elevated'\");\r",
+													"}\r",
+													"\r",
+													"if (user == \"lvl1\" || user == \"lvl2\" || user == \"collectioncreator\" || user == \"globular\") { //placeholder for \"users\" that should fail\r",
+													"    pm.test(\"Status should be is 403 for all users except stigmanAdmin(elevated), lvl3 and lvl4\", function () {\r",
+													"        pm.response.to.have.status(403);\r",
+													"    });\r",
+													"    return;\r",
+													"}\r",
+													"else {\r",
+													"    pm.test(\"Status code is 200\", function () {\r",
+													"        pm.response.to.have.status(200);\r",
+													"    });\r",
+													"}\r",
+													"if (pm.response.code !== 200) {\r",
+													"    return;\r",
+													"}\r",
+													"\r",
+													"\r",
+													"let jsonData = pm.response.json();\r",
+													"\r",
+													"let jsonDataExpected =\r",
+													"{\r",
+													"    \"operation\": \"deleted\",\r",
+													"    \"assetIds\": [\r",
+													"        \"29\",\r",
+													"        \"42\"\r",
+													"    ]\r",
+													"}\r",
+													"\r",
+													"\r",
+													"pm.test(\"Response JSON is an object\", function () {\r",
+													"    pm.expect(jsonData).to.be.an('object');\r",
+													"\r",
+													"});\r",
+													"\r",
+													"pm.test(\"operation = deleted and AssetIs are accurate\", function () {\r",
+													"    pm.expect(jsonData).to.eql(jsonDataExpected);\r",
+													"\r",
+													"});\r",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"operation\":\"delete\",\r\n    \"assetIds\":\r\n        [\"29\",\"42\"]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"assets"
+											],
+											"query": [
+												{
+													"key": "collectionId",
+													"value": "{{testCollection}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Assets - assets not in collection",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"let user = pm.environment.get(\"user\");\r",
+													"console.log(\"user: \" + user);\r",
+													"\r",
+													"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+													"    user = \"elevated\";\r",
+													"    console.log(\"setting user to 'elevated'\");\r",
+													"}\r",
+													"\r",
+													"\r",
+													"    pm.test(\"Status code is 403\", function () {\r",
+													"        pm.response.to.have.status(403);\r",
+													"    });\r",
+													"if (pm.response.code !== 403) {\r",
+													"    return;\r",
+													"}\r",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"operation\":\"delete\",\r\n    \"assetIds\":\r\n        [\"258\",\"260\"]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/assets?collectionId={{testCollection}}",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"assets"
+											],
+											"query": [
+												{
+													"key": "collectionId",
+													"value": "{{testCollection}}"
+												}
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "Delete Assets - collection does not exist",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"let user = pm.environment.get(\"user\");\r",
+													"console.log(\"user: \" + user);\r",
+													"\r",
+													"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+													"    user = \"elevated\";\r",
+													"    console.log(\"setting user to 'elevated'\");\r",
+													"}\r",
+													"\r",
+													"\r",
+													"    pm.test(\"Status code is 403\", function () {\r",
+													"        pm.response.to.have.status(403);\r",
+													"    });\r",
+													"if (pm.response.code !== 403) {\r",
+													"    return;\r",
+													"}\r",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "PATCH",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"operation\":\"delete\",\r\n    \"assetIds\":\r\n        [\"258\",\"260\"]\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseUrl}}/assets?collectionId=65465",
+											"host": [
+												"{{baseUrl}}"
+											],
+											"path": [
+												"assets"
+											],
+											"query": [
+												{
+													"key": "collectionId",
+													"value": "65465"
+												}
+											]
+										}
+									},
+									"response": []
+								}
+							]
+						},
+						{
 							"name": "Create an Asset",
 							"event": [
 								{
@@ -36018,6 +36316,95 @@
 											"key": "projection",
 											"value": "stigs",
 											"description": "Additional properties to include in the response.\n"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Import and overwrite application data (as elevated Admin) Copy 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"let user = pm.environment.get(\"user\");\r",
+											"console.log(\"user: \" + user);\r",
+											"\r",
+											"if (pm.request.url.getQueryString().match(/elevate=true/)) {\r",
+											"    user = \"elevated\";\r",
+											"    console.log(\"setting user to 'elevated'\");\r",
+											"}\r",
+											"\r",
+											"if (user == \"elevated\") { //placeholder for \"users\" that should fail\r",
+											"    pm.test(\"Status should be is 200 for elevated stigmanadmin user\", function () {\r",
+											"        pm.response.to.have.status(200);\r",
+											"    });\r",
+											"}\r",
+											"else {\r",
+											"    pm.test(\"Status code is 403\", function () {\r",
+											"        pm.response.to.have.status(403);\r",
+											"    });\r",
+											"}\r",
+											"if (pm.response.code !== 200) {\r",
+											"    return;\r",
+											"}\r",
+											"\r",
+											"\r",
+											"let response = pm.response.text();\r",
+											"console.log(response)\r",
+											"\r",
+											"pm.test(\"Body contains string\",() => {\r",
+											"  pm.expect(response).to.include(\"Commit successful\");\r",
+											"});"
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "oauth2",
+									"oauth2": [
+										{
+											"key": "accessToken",
+											"value": "{{token.stigmanadmin}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "multipart/form-data"
+									}
+								],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "importFile",
+											"type": "file",
+											"src": "./{{formDataFiles}}/{{appDataFile}}"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{baseUrl}}/op/appdata?elevate=true",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"op",
+										"appdata"
+									],
+									"query": [
+										{
+											"key": "elevate",
+											"value": "true",
+											"description": "Elevate the user context for this request if user is permitted (canAdmin)"
 										}
 									]
 								}


### PR DESCRIPTION
Resolves #1209 

- In the API, introduces the endpoint `PATCH /assets` to support batch operations on Assets. This initial implementation supports batch deletes only.
- In the web app, calls this new endpoint when deleting Assets from the Collection Manage workspace.

Benchmarks, delete 2000 Assets:
Legacy approach: 2000 API calls @ ~125ms each (250s) with 3 database writes each (6000)
New approach: 1 API call @ ~175ms with 3 database writes total