### PR TITLE
feat: display touchTs in grids for checklist, other assets, and reviews

### DIFF
--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -496,7 +496,10 @@ exports.queryChecklist = async function (inProjection, inPredicates, elevate, us
       `result.api as "result"`,
       `CASE WHEN review.resultEngine = 0 THEN NULL ELSE review.resultEngine END as resultEngine`,
       `review.autoResult`,
-      `status.api as "status"`
+      `status.api as "status"`,
+      `review.statusTs`,
+      `review.ts`,
+      `review.touchTs`
     ]
     const joins = [
       'current_rev rev',

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -4300,11 +4300,11 @@ components:
           status:
             $ref: '#/components/schemas/ChecklistStatus'
           statusTs:
-            $ref: '#/components/schemas/StringDateTime'
+            $ref: '#/components/schemas/StringDateTimeNullable'
           ts:
-            $ref: '#/components/schemas/StringDateTime'
+            $ref: '#/components/schemas/StringDateTimeNullable'
           touchTs:
-            $ref: '#/components/schemas/StringDateTime'
+            $ref: '#/components/schemas/StringDateTimeNullable'
     ChecklistCkl:
       type: object
       description: The CKL format generated and read by DISA STIG VIewer

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -4299,6 +4299,12 @@ components:
             type: boolean
           status:
             $ref: '#/components/schemas/ChecklistStatus'
+          statusTs:
+            $ref: '#/components/schemas/StringDateTime'
+          ts:
+            $ref: '#/components/schemas/StringDateTime'
+          touchTs:
+            $ref: '#/components/schemas/StringDateTime'
     ChecklistCkl:
       type: object
       description: The CKL format generated and read by DISA STIG VIewer

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -238,7 +238,8 @@
 }
 .sm-engine-result-icon {
   background-image: url(../img/bot2.svg);
-  background-repeat: no-repeat
+  background-repeat: no-repeat;
+  width: 12px;
 }
 .sm-engine-override-icon {
   background-image: url(../img/override2.svg);
@@ -258,6 +259,17 @@
   height: 14px;
   width: 14px
 }
+.x-menu-item-text .sm-engine-result-icon,  .x-menu-item-text .sm-history-icon{
+  background-size: 12px 12px;
+  height: 12px
+}
+
+.x-grid3-cell.x-grid3-hd .sm-history-icon {
+  background-size: 12px 12px;
+  background-position: center;
+  height: 12px
+}
+
 .x-menu-check-item .x-menu-item-icon {
   background-image: url(../img/checkboxes.svg);
   background-position: 1px 0;

--- a/client/src/js/SM/Review.js
+++ b/client/src/js/SM/Review.js
@@ -269,7 +269,7 @@ SM.Review.Form.Panel = Ext.extend(Ext.form.FormPanel, {
     })
     const mdf = new Ext.form.DisplayField({
       // anchor: '100% 2%',
-      fieldLabel: 'Modified',
+      fieldLabel: 'Evaluated',
       hideLabel: false,
       allowBlank: true,
       name: 'editStr',
@@ -281,14 +281,14 @@ SM.Review.Form.Panel = Ext.extend(Ext.form.FormPanel, {
       }
     })
     const sdf = new Ext.form.DisplayField({
-      fieldLabel: 'Status',
+      fieldLabel: 'Statused',
       hideLabel: false,
       allowBlank: true,
       name: 'status',
       formatValue: function (v) {
-        this.setValue(`<span class="sm-review-sprite sm-review-sprite-${v.label}"></span>
-        <span class="sm-review-sprite sm-review-sprite-date">${new Date(v.ts).format('Y-m-d H:i T')}</span>
-        <span class="sm-review-sprite sm-review-sprite-user">${v.user.username}<span>`)
+        this.setValue(`<span class="sm-review-sprite sm-review-sprite-date">${new Date(v.ts).format('Y-m-d H:i T')}</span>
+        <span class="sm-review-sprite sm-review-sprite-user">${v.user.username}</span>
+        <span class="sm-review-sprite sm-review-sprite-${v.label}"></span>`)
       }
     })
     const btn1 = new SM.Review.Form.Button({

--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -749,6 +749,7 @@ async function addCollectionReview ( params ) {
 				type: 'string'
 			},
 	    'resultEngine',
+		'touchTs',
 			{
 				name: 'engineResult',
 				convert: engineResultConverter
@@ -1044,7 +1045,18 @@ async function addCollectionReview ( params ) {
 					filter: {
 						type: 'values'
 					}
-				}
+				},
+				{
+					id: 'touchTs' + idAppend,
+					header: '<div exportvalue="touchTs" class="sm-history-icon" ext:qtip="Last action"></div>',
+					fixed: true,
+					width: 48,
+					align: 'center',
+					dataIndex: 'touchTs',
+					sortable: true,
+					renderer: renderDurationToNow
+				  }
+			
 			],
 			isCellEditable: function(col, row) {
 				var record = reviewsStore.getAt(row);

--- a/client/src/js/review.js
+++ b/client/src/js/review.js
@@ -86,10 +86,7 @@ async function addReview( params ) {
       name: 'engineResult',
       convert: engineResultConverter
     },
-    {
-      name: 'reviewComplete',
-      type: 'boolean'
-    }
+    'touchTs'
   ]);
 
 
@@ -625,8 +622,17 @@ async function addReview( params ) {
           type: 'values',
           renderer: SM.ColumnFilters.Renderers.status
         } 
+      },
+      {
+        id: 'touchTs' + idAppend,
+        header: '<div exportvalue="touchTs" class="sm-history-icon" ext:qtip="Last action"></div>',
+        fixed: true,
+        width: 44,
+        align: 'center',
+        dataIndex: 'touchTs',
+        sortable: true,
+        renderer: renderDurationToNow
       }
-
     ],
     autoExpandColumn: 'ruleTitle' + idAppend,
     loadMask: {msg: ''},
@@ -762,6 +768,7 @@ async function addReview( params ) {
       type: 'string'
     },
     'resultEngine',
+    'touchTs',
     {
       name: 'engineResult',
       convert: engineResultConverter
@@ -909,7 +916,7 @@ async function addReview( params ) {
       },
       { 	
 				header: "Status", 
-				width: 50,
+				width: 44,
 				fixed: true,
         align: 'center',
 				dataIndex: 'status',
@@ -922,6 +929,16 @@ async function addReview( params ) {
           renderer: SM.ColumnFilters.Renderers.status
         }
 			},
+      {
+        id: 'touchTs' + idAppend,
+        header: '<div exportvalue="touchTs" class="sm-history-icon" ext:qtip="Last action"></div>',
+        fixed: true,
+        width: 44,
+        align: 'center',
+        dataIndex: 'touchTs',
+        sortable: true,
+        renderer: renderDurationToNow
+      },
 			{ 	
 				header: "User", 
 				width: 50,
@@ -1385,8 +1402,8 @@ async function addReview( params ) {
 
       // Update group grid
       fp.groupGridRecord.data.result = reviewFromApi.result
-      fp.groupGridRecord.data.reviewComplete = reviewFromApi.reviewComplete
       fp.groupGridRecord.data.status = reviewFromApi.status.label
+      fp.groupGridRecord.data.touchTs = reviewFromApi.touchTs
       fp.groupGridRecord.data.resultEngine = reviewFromApi.resultEngine
       fp.groupGridRecord.data.engineResult = engineResultConverter('', reviewFromApi)
       fp.groupGridRecord.commit()


### PR DESCRIPTION
- Adds timestamp values (`ts`, `statusTs` and `touchTs`) to the response body of `GET /assets/{assetId}/checklists/{benchmarkId}/{revisionStr}` when the `format` query parameter is `json`
- Adds a grid column that displays `touchTs` in the Asset/STIG workspace for
  - the Checklist grid
  - the Other Assets grid
 - Adds a grid column that displays `touchTs` in the Collection/STIG workspace's Reviews grid
 - The grid columns are sortable but not filterable
