### PR TITLE
Enhancement: Setting Reject status will now require text before rejecting. 

### DIFF
--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -1648,7 +1648,8 @@ async function addCollectionReview ( params ) {
 						keyup: (field) => {
 							if (field.isValid() && field.getValue().trim().length > 0) {
 								submitBtn.enable()
-							} else {
+							} 
+							else {
 								submitBtn.disable()
 							}
 						}
@@ -1668,10 +1669,11 @@ async function addCollectionReview ( params ) {
 				})
 				function handler (btn) {
 					const value = textArea.getValue()
-					if (btn.action === 'reject' && value.trim().length > 0){
+					if (btn.action === 'reject'){
 						fpwindow.close()
 						resolve(value)
-					}else{
+					}
+					else{
 						fpwindow.close()
 						reject()
 					}

--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -1647,9 +1647,9 @@ async function addCollectionReview ( params ) {
 					listeners: {
 						keyup: (field) => {
 							if (field.isValid() && field.getValue().trim().length > 0) {
-								submitBtn.enable();
+								submitBtn.enable()
 							} else {
-								submitBtn.disable();
+								submitBtn.disable()
 							}
 						}
 					}

--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -1643,12 +1643,14 @@ async function addCollectionReview ( params ) {
 				const textArea = new Ext.form.TextArea({
 					emptyText: 'Provide feedback explaining this rejection.',
 					maxLength: 255,
+					enableKeyEvents: true,
 					listeners: {
-						valid: () => {
-							submitBtn.enable()
-						},
-						invalid: () => {
-							submitBtn.disable()
+						keyup: (field) => {
+							if (field.isValid() && field.getValue().trim().length > 0) {
+								submitBtn.enable();
+							} else {
+								submitBtn.disable();
+							}
 						}
 					}
 				})
@@ -1656,16 +1658,23 @@ async function addCollectionReview ( params ) {
 					text: 'Reject with this feedback',
 					action: 'reject',
 					iconCls: 'sm-rejected-icon',
+					disabled: true,
+					handler
+				})
+				const cancelBtn = new Ext.Button(	{
+					text: 'Cancel',
+					action: 'cancel',
 					handler
 				})
 				function handler (btn) {
-					if (btn.action === 'reject') {
-						const value = textArea.getValue()
+					const value = textArea.getValue()
+					if (btn.action === 'reject' && value.trim().length > 0){
 						fpwindow.close()
 						resolve(value)
+					}else{
+						fpwindow.close()
+						reject()
 					}
-					fpwindow.close()
-					reject()
 				}
 				const fpwindow = new Ext.Window({
 					title: `Reject Reviews`,
@@ -1678,22 +1687,11 @@ async function addCollectionReview ( params ) {
 					plain: true,
 					bodyStyle: 'padding:5px;',
 					buttonAlign: 'right',
-					items: [
-						textArea
-					],
-					buttons: [
-						{
-							text: 'Cancel',
-							action: 'cancel',
-							handler
-						},
-						submitBtn
-					]
+					items: [textArea],
+					buttons: [cancelBtn,submitBtn]
 				})
 				fpwindow.show()
-	
 			})
-
 		}
 		
 		async function handleStatusChange (grid, sm, status) {


### PR DESCRIPTION
resolves #1111 

This PR introduces enhancements to the feedback logic when setting reject status. The component now only allows a rejection to be submitted when the text area contains > 0 characters. 