### PR TITLE
chore: update MySQL recent versions in api-container-tests.yml

### DIFF
--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -19,7 +19,7 @@ jobs:
         container:
           - name: "stig-manager-alpine"
             build_arg: "node:lts-alpine"
-        mysql_version: ["8.0.33", "8.0.34", "8.0.35"]
+        mysql_version: ["8.0.34", "8.0.35", "8.0.36"]
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
MySQL released version 8.0.36 on 2024-01-16

We could automate the lookup of the last three 8.0.x releases. A possible command is:
```
docker run --rm quay.io/skopeo/stable list-tags docker://docker.io/library/mysql | \
jq -r '.Tags[]|select(test("^8\\.0\\.\\d+$"))' | \
sort -V | \
tail -n3 | \
jq -Rnc '[inputs]'
```