### PR TITLE
feat: add import results to collection dashboard

### DIFF
--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -2011,6 +2011,16 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   src: local(''),
        url('../fonts/ubuntu-mono-v15-latin-regular.woff2') format('woff2'), /* Chrome 26+, Opera 23+, Firefox 39+ */
 }
+.x-tool.x-tool-import {
+  background-image: url(../img/upload.svg);
+  background-repeat: no-repeat;
+  background-size: 12px 16px;
+  color: grey;
+  width: auto;
+  padding-left: 15px;
+  font-size: 10px;
+  line-height: 16px;
+}
 .x-tool.x-tool-label {
   background-image: url(../img/label.svg);
   background-repeat: no-repeat;

--- a/client/src/js/SM/CollectionAsset.js
+++ b/client/src/js/SM/CollectionAsset.js
@@ -413,6 +413,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                     {
                         iconCls: 'sm-import-icon',
                         text: 'Import CKL(B) or XCCDF...',
+                        tooltip: SM.TipContent.ImportFromCollectionManager,
                         handler: function() {
                             showImportResultFiles(me.collectionId);            
                         }

--- a/client/src/js/SM/CollectionAsset.js
+++ b/client/src/js/SM/CollectionAsset.js
@@ -414,7 +414,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                         iconCls: 'sm-import-icon',
                         text: 'Import CKL(B) or XCCDF...',
                         handler: function() {
-                            showImportResultFiles( me.collectionId, me.apiFieldSettings );            
+                            showImportResultFiles(me.collectionId);            
                         }
                     },
                     '-',

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -1741,6 +1741,7 @@ SM.CollectionPanel.showCollectionTab = async function (options) {
         {
           id: 'import',
           text: 'Import CKL(B) or SCAP...',
+          qtip: SM.TipContent.ImportFromCollectionPanel,
           handler: () => {
             showImportResultFiles(collectionId, false)         
           }

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -1742,7 +1742,7 @@ SM.CollectionPanel.showCollectionTab = async function (options) {
           id: 'import',
           text: 'Import CKL(B) or SCAP...',
           handler: () => {
-            showImportResultFiles(collectionId)         
+            showImportResultFiles(collectionId, false)         
           }
         }
       ],

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -954,7 +954,7 @@ SM.CollectionPanel.ProgressPanel = Ext.extend(Ext.Panel, {
       }
     }
     Ext.apply(this, Ext.apply(this.initialConfig, config))
-    SM.CollectionPanel.ProgressPanel.superclass.initComponent.call(this)
+    this.superclass().initComponent.call(this)
   }
 })
 
@@ -1231,6 +1231,7 @@ SM.CollectionPanel.OverviewPanel = Ext.extend(Ext.Panel, {
       bodyStyle: 'padding: 10px;',
       title: 'Progress',
       tools: this.progressPanelTools || undefined,
+      toolTemplate,
       border: true
     })
     this.agesPanel = new SM.CollectionPanel.AgesPanel({
@@ -1733,6 +1734,15 @@ SM.CollectionPanel.showCollectionTab = async function (options) {
               collectionName,
               treePath
             })
+          }
+        }
+      ],
+      progressPanelTools: [
+        {
+          id: 'import',
+          text: 'Import CKL(B) or SCAP...',
+          handler: () => {
+            showImportResultFiles(collectionId)         
           }
         }
       ],

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -1992,7 +1992,7 @@ SM.ReviewsImport.ImportProgressPanel = Ext.extend(Ext.Panel, {
     }
 })
 
-async function showImportResultFiles(collectionId) {
+async function showImportResultFiles(collectionId, createObjects = true) {
     try {
         const cachedCollection = SM.Cache.CollectionMap.get(collectionId)
         const userGrant = curUser.collectionGrants.find( i => i.collection.collectionId === cachedCollection.collectionId )?.accessLevel
@@ -2219,7 +2219,7 @@ async function showImportResultFiles(collectionId) {
 
             const taskConfig = {
                 collectionId,
-                createObjects: userGrant >= 3,
+                createObjects,
                 strictRevisionCheck: false
             } 
             const tasks = new STIGMAN.ClientModules.TaskObject({ apiAssets, apiStigs, parsedResults: parseResults.success, options: taskConfig })

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -2219,16 +2219,17 @@ async function showImportResultFiles(collectionId) {
 
             const taskConfig = {
                 collectionId,
-                createObjects: true,
+                createObjects: userGrant >= 3,
                 strictRevisionCheck: false
             } 
             const tasks = new STIGMAN.ClientModules.TaskObject({ apiAssets, apiStigs, parsedResults: parseResults.success, options: taskConfig })
+            const taskErrors = tasks.errors.map( e => ({file: e.sourceRef, error: e.message}))
             // Transform into data for SM.ReviewsImport.Grid
             const results = {
                 taskAssets: tasks.taskAssets,
                 rows: [],
                 dupedRows: [],
-                errors: parseResults.fail,
+                errors: [...parseResults.fail, ...taskErrors],
                 hasDuplicates: false
             }
             // Collate multiple checklists into duplicates and the single checklist for POSTing.

--- a/client/src/js/SM/TipContent.js
+++ b/client/src/js/SM/TipContent.js
@@ -95,3 +95,7 @@ The user must have a "Manage" or "Owner" grant in the destination Collection.<br
 <b>Exporting results to another Collection is limited to a maximum of {maxItems} Assets at a time.</b>`
 
 SM.TipContent.ExportOptions.ZipArchive = `Export a .zip archive of checklists for selected Assets/STIGs in the desired format.`
+
+SM.TipContent.ImportFromCollectionPanel = `Will not create new Assets or STIG assignments.<br><br>To create new Assets or STIG assignments, import from the Collection Management workspace.`
+
+SM.TipContent.ImportFromCollectionManager = `Will create new Assets and STIG assignments if they do not exist in this Collection.`


### PR DESCRIPTION
Resolves #1045 

Adds a button to the Collection-level dashboard that exposes the CKL(B)/SCAP import feature to all users. This description of the feature may be modified as the PR is refined.