### PR TITLE
Chore: Update to node 20 based workflow actions

### DIFF
--- a/.github/workflows/api-audit-test-coverage-response.yml
+++ b/.github/workflows/api-audit-test-coverage-response.yml
@@ -39,7 +39,7 @@ jobs:
     name: npm audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install dependencies
         run: npm ci
         working-directory: ./api/source/
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: coverage directory
@@ -145,21 +145,21 @@ jobs:
         run: c8 report -r lcov -r text
       - name: Upload Newman artifact
         id: artifact-upload-newman
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: newman-htmlextra
           path: ./test/api/newman
       - name: Upload coverage artifact
         id: artifact-upload-coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: coverage-report
           path: ./api/source/coverage
       - name: Upload API logs
         id: artifact-upload-api-logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: api-log
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download API log artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: api-log
           path: ./logs
@@ -182,7 +182,7 @@ jobs:
           exit $(jq '. | length' response-validation.json)
       - name: Upload response validation artifact
         if: ${{ failure() }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: response-validation
           path: ./logs/response-validation.json
@@ -192,11 +192,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important to fetch all history for accurate blame information
       - name: Download lcov artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report
       - name: Move lcov.info to api/source

--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -22,7 +22,7 @@ jobs:
         mysql_version: ["8.0.33", "8.0.34", "8.0.35"]
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build image for ${{ matrix.container.name }}
         id: image-build
         run: |
@@ -104,7 +104,7 @@ jobs:
           newman run postman_collection.json -e postman_environment.json -d collectionRunnerData.json -n 1 --folder "Additional sundry tests" -r cli,htmlextra --reporter-cli-no-assertions --reporter-cli-no-console --reporter-htmlextra-showEnvironmentData --reporter-htmlextra-export ./newman/AdditionalSundryReport-${{ matrix.container.name }}-${{ matrix.mysql_version }}-${{ github.run_id }}.html | grep -A18 '┌─────'
       - name: Upload Newman artifact
         id: artifact-upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: newman-htmlextra-${{ matrix.container.name }}-${{ matrix.mysql_version }}-${{ github.run_id }}
@@ -116,7 +116,7 @@ jobs:
         run: |
           docker logs stig-manager-api > api-log-${{ matrix.container.name }}-${{ matrix.mysql_version }}-${{ github.run_id }}.json
       - name: Upload API log artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         id: api-log-upload
         if: ${{ always() }}
         with:
@@ -132,7 +132,7 @@ jobs:
         run: tar cvzf ./logs-${{ matrix.container.name }}-${{ matrix.mysql_version }}.tgz ./logs-${{ matrix.container.name }}-${{ matrix.mysql_version }}
       - name: Upload container logs artifact
         if: ${{ cancelled() || failure() }}
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v4
         with:
           name: logs-${{ matrix.container.name }}-${{ matrix.mysql_version }}.tgz
           path: ./logs-${{ matrix.container.name }}-${{ matrix.mysql_version }}.tgz

--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
       - name: Get repository metadata
         id: repo
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const repo = await github.rest.repos.get(context.repo)
@@ -85,7 +85,7 @@ jobs:
    
       - name: Upload builds
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binary-artifacts
           path: ./api/bin/
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload archives
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binary-archives
           path: ./api/dist/

--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - name: Install uglify-js
@@ -17,7 +17,7 @@ jobs:
         working-directory: ./client
         run: ./build.sh
       - name: Upload distribution
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: client-dist
           path: ./client/dist

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,14 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
       - name: run image, generating docs
         working-directory: ./docs
         run: ./build.sh
       - name: Upload docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-build
           path: ./docs/_build/html

--- a/.github/workflows/client-sonarcloud.yml
+++ b/.github/workflows/client-sonarcloud.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       #checkout the repo
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important to fetch all history for accurate blame information
       - name: Analyze client with SonarCloud

--- a/.github/workflows/pub-docker.yml
+++ b/.github/workflows/pub-docker.yml
@@ -29,23 +29,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
       - name: Download client distribution
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: client-dist
           path: ./client/dist
       - name: Download documentation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs-build
           path: ./docs/_build/html
       - name: Get repository metadata
         id: repo
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const repo = await github.rest.repos.get(context.repo)
@@ -115,23 +115,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
       - name: Download client distribution
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: client-dist
           path: ./client/dist
       - name: Download documentation
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: docs-build
           path: ./docs/_build/html
       - name: Get repository metadata
         id: repo
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const repo = await github.rest.repos.get(context.repo)


### PR DESCRIPTION
This pull request upgrades the Node.js version for actions within this repository to use Node.js 20.

The following actions were changed to version 4:

actions/checkout
actions/upload-artifact
actions/setup-node
actions/download-artifact
actions/github-script