### PR TITLE
CI/CD: Enhance workflow with automatic MySQL version testing

### DIFF
--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Fetch MySQL Versions
         id: fetch-versions
         run: |
-          VERSIONS=$(echo $(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.0\\.\\d+$"))' | sort -V | tail -n3; echo "8.0.21") | tr ' ' '\n' | sort -Vr | jq -Rsc 'split("\n")[:-1]')
+          VERSIONS=$(echo $(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.0\\.\\d+$"))' | sort -V | tail -n3 | cat <(echo "8.0.21") - | jq -Rnc '[inputs]'))
           echo "version_array=$VERSIONS" >> $GITHUB_OUTPUT
 
   test_api:

--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -20,8 +20,8 @@ jobs:
         id: fetch-versions
         run: |
           VERSIONS=$(echo $(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.0\\.\\d+$"))' | sort -V | tail -n3; echo "8.0.21") | tr ' ' '\n' | sort -Vr | jq -Rsc 'split("\n")[:-1]')
-        
           echo "version_array=$VERSIONS" >> $GITHUB_OUTPUT
+
   test_api:
     needs: fetch-mysql-versions
     name: Postman tests with ${{ matrix.container.name }} and MySQL ${{ matrix.mysql_version }}
@@ -36,7 +36,6 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-
       - name: Build image for ${{ matrix.container.name }}
         id: image-build
         run: |

--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -11,18 +11,32 @@ on:
       - ".github/workflows/api-container-tests.yml"
 
 jobs:
+  fetch-mysql-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      MYSQL_VERSIONS: ${{ steps.fetch-versions.outputs.version_array }}
+    steps:
+      - name: Fetch MySQL Versions
+        id: fetch-versions
+        run: |
+          VERSIONS=$(echo $(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.0\\.\\d+$"))' | sort -V | tail -n3; echo "8.0.21") | tr ' ' '\n' | sort -Vr | jq -Rsc 'split("\n")[:-1]')
+        
+          echo "version_array=$VERSIONS" >> $GITHUB_OUTPUT
   test_api:
+    needs: fetch-mysql-versions
     name: Postman tests with ${{ matrix.container.name }} and MySQL ${{ matrix.mysql_version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
         container:
-          - name: "stig-manager-alpine"
-            build_arg: "node:lts-alpine"
-        mysql_version: ["8.0.34", "8.0.35", "8.0.36"]
+            - name: "stig-manager-alpine"
+              build_arg: "node:lts-alpine"
+        mysql_version: ${{fromJson(needs.fetch-mysql-versions.outputs.MYSQL_VERSIONS)}}
+        
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
+
       - name: Build image for ${{ matrix.container.name }}
         id: image-build
         run: |


### PR DESCRIPTION
This PR adds a new job to dynamically fetch the three latest MySQL version tags from Docker Hub and utilize them for container testing. This PR also incorporates our project's minimum required MySQL version, 8.0.21, into the testing matrix.