### PR TITLE
fix: get lastSavedData from dom

### DIFF
--- a/client/src/js/SM/Review.js
+++ b/client/src/js/SM/Review.js
@@ -334,10 +334,10 @@ SM.Review.Form.Panel = Ext.extend(Ext.form.FormPanel, {
 
     function initLastSavedData () {
       if ( rcb.value === null ) { rcb.value = '' }
-      ack.lastSavedData = ack.value
+      ack.lastSavedData = ack.getValue()
       rcb.lastSavedData = rcb.value
-      dta.lastSavedData = dta.value === null ? '' : dta.value
-      cta.lastSavedData = cta.value === null ? '' : cta.value
+      dta.lastSavedData = dta.getValue()
+      cta.lastSavedData = cta.getValue()
     }
 
     function isReviewSubmittable () {


### PR DESCRIPTION
This PR fixes a bug that was triggered when review evaluation fields contained Windows line endings. The `lastSavedData` for these fields was being initialized from the field component's `[Component].value` property, but the `reviewChanged()` function implemented [here](https://github.com/NUWCDIVNPT/stig-manager/blob/a106046491f0b75df294672e883f7d451fb1bdf5/client/src/js/SM/Review.js#L303-L310) was comparing that data to the DOM-normalized values returned by `[Component].getValue()`.

The corrected code initializes `lastSavedData` by calling `[Component].getValue()` on these fields.