### PR TITLE
Hotfix: Correct path to eer-stigman-wide.svg in the rst.

### DIFF
--- a/docs/installation-and-setup/data-and-permissions.rst
+++ b/docs/installation-and-setup/data-and-permissions.rst
@@ -176,9 +176,9 @@ Database Entity Relationship Diagrams
 The following diagram may not always be up to date. Always refer to the implemented db structure as the authoritative source for this information. 
 
 
-.. thumbnail:: /assets/images/eer-stig-wide.svg
+.. thumbnail:: /assets/images/eer-stigman-wide.svg
       :width: 75% 
       :show_caption: True
       :title: Entity Relationship Diagram representation of STIG Manager's MySQL data. 
 
-`View the enlarged ERD Document here. <../_images/eer-stig-wide1.svg>`_
+`View the enlarged ERD Document here. <../_images/eer-stigman-wide1.svg>`_


### PR DESCRIPTION
This fix corrects the path to an image which points to our ERD diagram 'eer-stigman-wide.svg'.