### PR TITLE
fix: dragged review sets engine value

### DIFF
--- a/client/src/js/SM/Review.js
+++ b/client/src/js/SM/Review.js
@@ -310,7 +310,7 @@ SM.Review.Form.Panel = Ext.extend(Ext.form.FormPanel, {
     }
 
     this.resultChanged = function () {
-      return ack.lastSavedData != ack.getValue()
+      return rcb.lastSavedData != rcb.value
     }
 
     function loadValues (values) {
@@ -684,6 +684,7 @@ SM.Review.Form.Panel = Ext.extend(Ext.form.FormPanel, {
                 // Load the record into the form
                 if (!rcb.disabled) {
                   rcb.setValue(selectedRecord.data.result);
+                  rcb.fireEvent('select')
                 }
                 dta.setValue(selectedRecord.data.detail);
                 if (rcb.getValue() === 'fail') {


### PR DESCRIPTION
This PR corrects the way `resultEngine` values are handled in the Asset/STIG Review workspace when dragging a Review from Other Assets into the Review Form. 

Existing code did not trigger the Result combobox `select()` handler, which updates the resultEngine sprite  when `result` is changed. The fixed code explicitly fires the `select` event.

Also, the `resultChanged()` function was updated to check for a change of `result` instead of a change of `resultEngine`.