### PR TITLE
Refactor: Remove unused current_group_rule table and view

### DIFF
--- a/api/source/service/STIGService.js
+++ b/api/source/service/STIGService.js
@@ -573,24 +573,6 @@ exports.insertManualBenchmark = async function (b, clobber, svcStatus = {}) {
       hrend = process.hrtime(hrstart)
       stats.current_rev = `${hrend[0]}s  ${hrend[1] / 1000000}ms`
 
-
-      // update current_group_rule
-      hrstart = process.hrtime()
-      let sqlDeleteCurrentGroupRule = 'DELETE FROM current_group_rule WHERE benchmarkId = ?'
-      let sqlInsertCurrentGroupRule = `INSERT INTO current_group_rule (groupId, ruleId, benchmarkId)
-        SELECT rgr.groupId,
-          rgr.ruleId,
-          cr.benchmarkId
-        from
-          current_rev cr
-          left join rev_group_rule_map rgr on cr.revId = rgr.revId
-        where
-          cr.benchmarkId = ?`
-      ;[result] = await connection.query(sqlDeleteCurrentGroupRule, [dml.stig.binds.benchmarkId])
-      ;[result] = await connection.query(sqlInsertCurrentGroupRule, [dml.stig.binds.benchmarkId])
-      hrend = process.hrtime(hrstart)
-      stats.current_rev = `${hrend[0]}s  ${hrend[1] / 1000000}ms`
-
       // Stats
       hrstart = process.hrtime()
       await dbUtils.updateDefaultRev(connection, {
@@ -928,7 +910,7 @@ exports.deleteRevisionByString = async function(benchmarkId, revisionStr, svcSta
       const [drRows] = await connection.query('SELECT collectionId FROM default_rev WHERE benchmarkId = :benchmarkId and revId = :revId', binds)
       const wasDefaultRev = !!drRows.length
 
-      // re-materialize current_rev and current_group_rule if we're deleteing the current revision
+      // re-materialize current_rev if we're deleteing the current revision
       if (wasCurrentRev) {
         dmls = dmls.concat(currentRevDmls)
       }

--- a/api/source/service/migrations/0029.js
+++ b/api/source/service/migrations/0029.js
@@ -1,0 +1,23 @@
+const MigrationHandler = require('./lib/MigrationHandler')
+
+const upMigration = [
+  // table: review
+  `DROP VIEW IF EXISTS v_current_group_rule`,
+
+  // table: review_history
+  `DROP TABLE IF EXISTS current_group_rule`
+]
+
+const downMigration = [
+]
+
+const migrationHandler = new MigrationHandler(upMigration, downMigration)
+module.exports = {
+  up: async (pool) => {
+    await migrationHandler.up(pool, __filename)
+  },
+  down: async (pool) => {
+    await migrationHandler.down(pool, __filename)
+  }
+}
+


### PR DESCRIPTION
resolves: #1108 

This PR addresses the removal of the unused current_group_rule table and its associated view v_current_group_rule from the database and code. 