### PR TITLE
chore: updates for 1.4.5

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "MIT",
       "dependencies": {
         "archiver": "^5.3.1",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,16 @@
+1.4.5
+-----
+
+Changes:
+
+  - (UI/API) feat: Status text field expanded to 511 characters.
+  - (UI) bugfix: Review `resultEngine` no longer keeps old value when using drag & drop from Other Assets. 
+  - (API/DB) chore: Remove unused current_group_rule table and view. 
+  - (API) bugfix: Review `resultEngine` now only set to null when PATCH'd with a `result` and no `resultEngine`.
+  - (API) feat: DB bootstrap improvements, build script, static data.
+  - (API) chore: Update dependency in response to CVE-2022-25881
+  - **Includes database migration**
+
 1.4.4
 -----
 
@@ -11,7 +24,7 @@ Changes:
   - (API) bugfix: Timestamp update misbehavior in some circumstances
   - (API) Dependency updates in response to CVE-2024-28849; CVE-2024-28176
   - (Docs) Guidance for updating deployments
-  - (Docs) Database schemas and diagram updates
+  - (Docs) Database schemas and diagram updates  
 
 1.4.3
 -----


### PR DESCRIPTION
1.4.5
-----

Changes:

  - (UI/API) feat: Status text field expanded to 511 characters.
  - (UI) bugfix: Review `resultEngine` no longer keeps old value when using drag & drop from Other Assets. 
  - (API/DB) chore: Remove unused current_group_rule table and view. 
  - (API) bugfix: Review `resultEngine` now only set to null when PATCH'd with a `result` and no `resultEngine`.
  - (API) feat: DB bootstrap improvements, build script, static data.
  - (API) chore: Update dependency in response to CVE-2022-25881
  - **Includes database migration**
