### PR TITLE
Refactor: Removes manually creating sql query, uses makeQueryString() function.

### DIFF
--- a/api/source/service/ReviewService.js
+++ b/api/source/service/ReviewService.js
@@ -784,17 +784,8 @@ exports.getReviews = async function (inProjection = [], inPredicates = {}, userO
     }
   }
 
-
-  // CONSTRUCT MAIN QUERY
-  let sql = 'SELECT '
-  sql+= columns.join(",\n")
-  sql += ' FROM '
-  sql+= joins.join(" \n")
-  if (predicates.statements.length > 0) {
-    sql += "\nWHERE " + predicates.statements.join(" and ")
-  }
-  sql += ` GROUP BY ${groupBy.join(', ')}`
-
+  // // CONSTRUCT MAIN QUERY
+  const sql = dbUtils.makeQueryString({columns, joins, predicates, groupBy})
   let [rows] = await dbUtils.pool.query(sql, predicates.binds)
 
   return (rows)
@@ -878,12 +869,7 @@ exports.exportReviews = async function (includeHistory = false) {
     ]
   }
 
-  const sql = `SELECT
-  ${columns.join(',\n')}
-  FROM
-  ${joins.join(" \n")}
-  ${includeHistory ? ` GROUP BY ${groupBy.join(', ')}` : ''}
-  `
+  const sql = dbUtils.makeQueryString({columns, joins, groupBy})
   let [rows] = await dbUtils.pool.query(sql)
   return (rows)
 }

--- a/api/source/service/UserService.js
+++ b/api/source/service/UserService.js
@@ -29,6 +29,8 @@ exports.queryUsers = async function (inProjection, inPredicates, elevate, userOb
       'ud.username'
     ]
 
+    const orderBy = ['ud.username']
+
     // PROJECTIONS
     if (inProjection?.includes('collectionGrants')) {
       joins.push('left join collection c on cg.collectionId = c.collectionId')
@@ -90,15 +92,7 @@ exports.queryUsers = async function (inProjection, inPredicates, elevate, userOb
     }
 
     // CONSTRUCT MAIN QUERY
-    let sql = 'SELECT '
-    sql+= columns.join(',\n')
-    sql += ' FROM '
-    sql+= joins.join(' \n')
-    if (predicates.statements.length > 0) {
-      sql += '\nWHERE ' + predicates.statements.join(' and ')
-    }
-    sql += '\nGROUP BY ' + groupBy.join(',\n')
-    sql += ' order by ud.username'
+    const sql = dbUtils.makeQueryString({columns, joins, predicates, groupBy, orderBy})
   
     connection = await dbUtils.pool.getConnection()
     connection.config.namedPlaceholders = true


### PR DESCRIPTION
This PR removes all instances in the API where the SQL query is manually constructed. Instead the dbUtils.makeQueryString function will now be used to construct the query. Many functions were refactored so that this function could be used. This gives a more normalized approach throughout the API.