### PR TITLE
Refactor: gets to asset metadata  no longer require grant >= manage

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -562,7 +562,7 @@ module.exports.updateAsset = async function updateAsset (req, res, next) {
 
 module.exports.getAssetMetadata = async function (req, res, next) {
   try {
-    let { assetId } = await getAssetInfoAndVerifyAccess(req)
+    let { assetId } = await getAssetInfoAndVerifyAccess(req, Security.ACCESS_LEVEL.Restricted)
     let result = await AssetService.getAssetMetadata(assetId, req.userObject)
     res.json(result)
   }
@@ -599,7 +599,7 @@ module.exports.putAssetMetadata = async function (req, res, next) {
 
 module.exports.getAssetMetadataKeys = async function (req, res, next) {
   try {
-    let { assetId } = await getAssetInfoAndVerifyAccess(req)
+    let { assetId } = await getAssetInfoAndVerifyAccess(req, Security.ACCESS_LEVEL.Restricted)
     let result = await AssetService.getAssetMetadataKeys(assetId, req.userObject)
     if (!result) {
       throw new SmError.NotFoundError('metadata keys not found')
@@ -613,7 +613,7 @@ module.exports.getAssetMetadataKeys = async function (req, res, next) {
 
 module.exports.getAssetMetadataValue = async function (req, res, next) {
   try {
-    let { assetId } = await getAssetInfoAndVerifyAccess(req)
+    let { assetId } = await getAssetInfoAndVerifyAccess(req, Security.ACCESS_LEVEL.Restricted)
     let key = req.params.key
     let result = await AssetService.getAssetMetadataValue(assetId, key, req.userObject)
     if (!result) { 
@@ -690,7 +690,7 @@ function getCollectionIdAndVerifyAccess(request, minimumAccessLevel = Security.A
  * @returns {Promise<Object>} - A promise that resolves to an object containing the assetId and a collectionGrant.
  * @throws {SmError.PrivilegeError} - user does not have sufficient access level or the asset does not exist.
  */
-async function getAssetInfoAndVerifyAccess(request) {
+async function getAssetInfoAndVerifyAccess(request, accessLevel = Security.ACCESS_LEVEL.Manage) {
   let assetId = request.params.assetId
 
   // fetch the Asset for access control checks and the response
@@ -701,7 +701,7 @@ async function getAssetInfoAndVerifyAccess(request) {
   }
   const collectionGrant = request.userObject.collectionGrants.find( g => g.collection.collectionId === assetToAffect.collection.collectionId )
   // check if user has sufficient access level
-  if (collectionGrant?.accessLevel < Security.ACCESS_LEVEL.Manage) {
+  if (collectionGrant?.accessLevel < accessLevel) {
     throw new SmError.PrivilegeError("Insufficient access level.")
   }
   return {assetId, collectionGrant}

--- a/test/api/form-data-files/appdata.json
+++ b/test/api/form-data-files/appdata.json
@@ -704,7 +704,9 @@
       ],
       "mac": null,
       "noncomputing": true,
-      "metadata": {},
+      "metadata": {
+        "testkey": "testvalue"
+      },
       "stigGrants": [
         {
           "benchmarkId": "VPN_SRG_TEST",

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -2,7 +2,7 @@
 	"info": {
 		"_postman_id": "fcb1e3fc-7e68-4709-baae-eb5bec83df44",
 		"name": "STIGMan OSS",
-		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:\n Name: Carl Smigielski\n Email: carl.a.smigielski@saic.com",
+		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:  \nName: Carl Smigielski  \nEmail: [carl.a.smigielski@saic.com](https://mailto:carl.a.smigielski@saic.com)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "28917726"
 	},
@@ -7645,19 +7645,21 @@
 															"\r",
 															"\r",
 															"//&& user != \"collectioncreator\"\r",
-															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
-															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated), collectioncreator, or >= level 3\", function () {\r",
-															"        pm.response.to.have.status(403);\r",
-															"    });\r",
-															"    return;\r",
+															"// if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
+															"//     pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated), collectioncreator, or >= level 3\", function () {\r",
+															"//         pm.response.to.have.status(403);\r",
+															"//     });\r",
+															"//     return;\r",
+															"// }\r",
+															"if (user == \"collectioncreator\"){\r",
+															"     pm.response.to.have.status(403);\r",
+															"     return;\r",
 															"}\r",
 															"else {\r",
 															"    pm.test(\"Status code is 200 for \" + user, function () {\r",
 															"        pm.response.to.have.status(200);\r",
 															"    });\r",
 															"}\r",
-															"\r",
-															"\r",
 															"if (pm.response.code !== 200) {\r",
 															"    return;\r",
 															"}\r",
@@ -7669,15 +7671,15 @@
 															"});\r",
 															"\r",
 															"\r",
-															"\r",
-															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
-															"    let testMetadataKey = pm.environment.get(\"pocEmail\");\r",
-															"    let testMetadataValue = pm.environment.get(\"pocEmail@email.com\");\r",
-															"    pm.expect(jsonData[testMetadataKey]).to.eql(testMetadataValue);\r",
-															"});\r",
+															"// pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
+															"//     let testMetadataKey = pm.environment.get(\"pocEmail\");\r",
+															"//     let testMetadataValue = pm.environment.get(\"pocEmail@email.com\");\r",
+															"//     pm.expect(jsonData[testMetadataKey]).to.eql(testMetadataValue);\r",
+															"// });\r",
 															""
 														],
-														"type": "text/javascript"
+														"type": "text/javascript",
+														"packages": {}
 													}
 												}
 											],
@@ -7714,18 +7716,14 @@
 															"let user = pm.environment.get(\"user\");\r",
 															"console.log(\"user: \" + user);\r",
 															"\r",
-															"\r",
-															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
-															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
-															"        pm.response.to.have.status(403);\r",
-															"    });\r",
-															"    return;\r",
+															"if (user == \"collectioncreator\"){\r",
+															"     pm.response.to.have.status(403);\r",
+															"     return;\r",
 															"}\r",
-															"else {\r",
-															"    pm.test(\"Status code is 200\", function () {\r",
-															"        pm.response.to.have.status(200);\r",
-															"    });\r",
-															"}\r",
+															"pm.test(\"Status code is 200\", function () {\r",
+															"    pm.response.to.have.status(200);\r",
+															"});\r",
+															"//}\r",
 															"if (pm.response.code !== 200) {\r",
 															"    return;\r",
 															"}\r",
@@ -7738,13 +7736,14 @@
 															"});\r",
 															"\r",
 															"\r",
-															"/*\r",
-															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
-															"    pm.expect(jsonData).to.include(\"pocEmail\");\r",
+															"\r",
+															"pm.test(\"Check if asset metadata object contains proper metadata\", function () {\r",
+															"    pm.expect(jsonData).to.include(\"testkey\");\r",
 															"});\r",
-															"*/"
+															""
 														],
-														"type": "text/javascript"
+														"type": "text/javascript",
+														"packages": {}
 													}
 												}
 											],
@@ -7782,12 +7781,9 @@
 															"let user = pm.environment.get(\"user\");\r",
 															"console.log(\"user: \" + user);\r",
 															"\r",
-															"/*\r",
-															"if (user != \"stigmanadmin\" && user != \"elevated\" && user != \"lvl3\" && user != \"lvl4\" && user != \"lvl5\") {\r",
-															"    pm.test(\"Status should be 403 for all users except stigmanAdmin(elevated) or >= level 3\", function () {\r",
-															"        pm.response.to.have.status(403);\r",
-															"    });\r",
-															"    return;\r",
+															"if (user == \"collectioncreator\"){\r",
+															"     pm.response.to.have.status(403);\r",
+															"     return;\r",
 															"}\r",
 															"else {\r",
 															"    pm.test(\"Status code is 200 for \" + user, function () {\r",
@@ -7804,14 +7800,13 @@
 															"    pm.expect(jsonData).to.be.an('string');\r",
 															"});\r",
 															"\r",
-															"\r",
-															"\r",
 															"pm.test(\"Check if collection metadata object contains proper metadata\", function () {\r",
-															"    pm.expect(jsonData).to.eql(\"poc2Patched\");\r",
+															"    pm.expect(jsonData).to.eql(\"testvalue\");\r",
 															"});\r",
-															"*/"
+															""
 														],
-														"type": "text/javascript"
+														"type": "text/javascript",
+														"packages": {}
 													}
 												}
 											],
@@ -7837,7 +7832,7 @@
 														},
 														{
 															"key": "key",
-															"value": "{{metadataKey}}"
+															"value": "{{testMetadataKey}}"
 														}
 													]
 												}


### PR DESCRIPTION
This PR extends on PR #1270 

The following functions no longer require an access level >= manage in order to retrieve asset metadata. They now will only require an access level of restricted. 

- getAssetMetadata
- getAssetMetadataKeys
- getAssetMetadataValue

Tests under postman collection `STIGMan OSS / GETs / Asset GET / {asset Id} / metadata` were altered to account for these new access level rules. Some of the test data and assertions were altered also. 