### PR TITLE
fix: remove `with (Math)` block in `Exports.js`

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -7,6 +7,7 @@
 #
 # Build artifacts will created in ./dist
 
+set -e
 echo "Client build starting"
 
 # Change to this script directory

--- a/client/src/js/SM/Exports.js
+++ b/client/src/js/SM/Exports.js
@@ -704,10 +704,8 @@ SM.Exports.showExportTree = async function (collectionId, collectionName, treeba
 SM.Exports.exportArchiveStreaming = async function ({collectionId, checklists, format = 'ckl-mono'}) {
 
   function formatBytes(a, b = 2, k = 1024) { 
-    with (Math) { 
-      let d = floor(log(a) / log(k));
-      return 0 == a ? "0 Bytes" : (a / pow(k, d)).toFixed(b) + " " + ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d] 
-    }
+    const d = Math.floor(Math.log(a) / Math.log(k));
+    return 0 == a ? "0 Bytes" : (a / Math.pow(k, d)).toFixed(b) + " " + ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"][d] 
   }
 
   const url = {
@@ -734,6 +732,7 @@ SM.Exports.exportArchiveStreaming = async function ({collectionId, checklists, f
       return
     }
 
+    // The fallback code below only executes if the service worker is broken, which probably means we have bigger issues
     let response = await fetch(url[format], fetchInit)
     const contentDisposition = response.headers.get("content-disposition")
     if (!response.ok) {


### PR DESCRIPTION
Resolves #1310 

This PR refactors `client/src/js/SM/Exports.js` and removes a `with (Math)` block because that is now forbidden in strict mode. This block is causing the most recent version of `uglify.js` to throw during the client build stage of the Docker publish action. Which results in an incomplete client directory in our images.

This error during client build is not aborting the build script, which would have aborted the publish action. So I've added `set -e` to the top of the build script to remedy this.