### PR TITLE
feat: time string appended to attachment filenames

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -227,6 +227,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
     const benchmarkId = req.params.benchmarkId
     const revisionStr = req.params.revisionStr
     const format = req.query.format || 'json'
+    const started = new Date().toISOString()
     if (await dbUtils.userHasAssetStigs(assetId, [benchmarkId], false, req.userObject)) {
       const response = await AssetService.getChecklistByAssetStig(assetId, benchmarkId, revisionStr, format, false, req.userObject )
       if (format === 'json') {
@@ -234,7 +235,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
       }
       else if (format === 'cklb') {
         response.cklb.title = `${response.assetName}-${benchmarkId}-${response.revisionStrResolved}`
-        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}.cklb`)
+        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-${started.replace(/:|\d{2}\.\d{3}/g,'')}.cklb`)
         writer.writeInlineFile(res, JSON.stringify(response.cklb), filename, 'application/json')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
       }
       else if (format === 'ckl') {
@@ -251,7 +252,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
         })
         let xml = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- STIG Manager ${config.version} -->\n<!-- Classification: ${config.settings.setClassification} -->\n`
         xml += builder.build(response.xmlJs)
-        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}.ckl`)
+        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-${started.replace(/:|\d{2}\.\d{3}/g,'')}.ckl`)
         writer.writeInlineFile(res, xml, filename, 'application/xml')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
       }
       else if (format === 'xccdf') {
@@ -270,7 +271,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
         })
         let xml = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- STIG Manager ${config.version} -->\n<!-- Classification: ${config.settings.setClassification} -->\n`
         xml += builder.build(response.xmlJs)
-        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-xccdf.xml`)
+        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-${started.replace(/:|\d{2}\.\d{3}/g,'')}-xccdf.xml`)
         writer.writeInlineFile(res, xml, filename, 'application/xml')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
       }
     }

--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -227,16 +227,18 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
     const benchmarkId = req.params.benchmarkId
     const revisionStr = req.params.revisionStr
     const format = req.query.format || 'json'
-    const started = new Date().toISOString()
     if (await dbUtils.userHasAssetStigs(assetId, [benchmarkId], false, req.userObject)) {
       const response = await AssetService.getChecklistByAssetStig(assetId, benchmarkId, revisionStr, format, false, req.userObject )
       if (format === 'json') {
         res.json(response)
+        return
       }
-      else if (format === 'cklb') {
-        response.cklb.title = `${response.assetName}-${benchmarkId}-${response.revisionStrResolved}`
-        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-${started.replace(/:|\d{2}\.\d{3}/g,'')}.cklb`)
-        writer.writeInlineFile(res, JSON.stringify(response.cklb), filename, 'application/json')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
+      
+      const dateString = escape.filenameComponentFromDate()
+      const fileBasename = `${response.assetName}-${benchmarkId}-${response.revisionStrResolved}`
+      if (format === 'cklb') {
+        response.cklb.title = fileBasename
+        writer.writeInlineFile(res, JSON.stringify(response.cklb), `${fileBasename}_${dateString}.cklb`, 'application/json')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
       }
       else if (format === 'ckl') {
         const builder = new XMLBuilder({
@@ -252,8 +254,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
         })
         let xml = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- STIG Manager ${config.version} -->\n<!-- Classification: ${config.settings.setClassification} -->\n`
         xml += builder.build(response.xmlJs)
-        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-${started.replace(/:|\d{2}\.\d{3}/g,'')}.ckl`)
-        writer.writeInlineFile(res, xml, filename, 'application/xml')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
+        writer.writeInlineFile(res, xml, `${fileBasename}_${dateString}.ckl`, 'application/xml')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
       }
       else if (format === 'xccdf') {
         const builder = new XMLBuilder({
@@ -271,8 +272,7 @@ module.exports.getChecklistByAssetStig = async function getChecklistByAssetStig 
         })
         let xml = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- STIG Manager ${config.version} -->\n<!-- Classification: ${config.settings.setClassification} -->\n`
         xml += builder.build(response.xmlJs)
-        let filename = escape.escapeFilename(`${response.assetName}-${benchmarkId}-${response.revisionStrResolved}-${started.replace(/:|\d{2}\.\d{3}/g,'')}-xccdf.xml`)
-        writer.writeInlineFile(res, xml, filename, 'application/xml')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
+        writer.writeInlineFile(res, xml, `${fileBasename}-xccdf_${dateString}.xml`, 'application/xml')  // revisionStrResolved provides specific rev string, if "latest" was asked for.
       }
     }
     else {
@@ -311,9 +311,9 @@ module.exports.getChecklistByAsset = async function getChecklistByAssetStig (req
 
     const response = await AssetService.getChecklistByAsset(assetId, stigs, format, false, req.userObject )
 
+    const dateString = escape.filenameComponentFromDate()
     if (format === 'cklb') {
-      let filename = escape.escapeFilename(`${response.assetName}.cklb`)
-      writer.writeInlineFile(res, JSON.stringify(response.cklb), filename, 'application/json') 
+      writer.writeInlineFile(res, JSON.stringify(response.cklb), `${response.assetName}_${dateString}.cklb`, 'application/json') 
     }
     else if (format === 'ckl') {
       const builder = new XMLBuilder({
@@ -329,8 +329,7 @@ module.exports.getChecklistByAsset = async function getChecklistByAssetStig (req
       })
       let xml = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- STIG Manager ${config.version} -->\n`
       xml += builder.build(response.xmlJs)
-      let filename = escape.escapeFilename(`${response.assetName}.ckl`)
-      writer.writeInlineFile(res, xml, filename, 'application/xml')
+      writer.writeInlineFile(res, xml, `${response.assetName}_${dateString}.ckl`, 'application/xml')
     }
   }
   catch (err) {

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -652,12 +652,13 @@ async function postArchiveByCollection ({format = 'ckl-mono', req, res, parsedRe
     attrValueProcessor: escapeForXml
 })
   const zip = Archiver('zip', {zlib: {level: 9}})
+  const started = new Date().toISOString()
   const attachmentName = escape.escapeFilename(`${parsedRequest.collection.name}-${format.startsWith('ckl-') ? 
-    'CKL' : format.startsWith('cklb-') ? 'CKLB' : 'XCCDF'}.zip`)
+    'CKL' : format.startsWith('cklb-') ? 'CKLB' : 'XCCDF'}_${started.replace(/:|\d{2}\.\d{3}/g,'')}.zip`)
   res.attachment(attachmentName)
   zip.pipe(res)
   const manifest = {
-    started: new Date().toISOString(),
+    started,
     finished: '',
     errorCount: 0,
     errors: [],

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -173,7 +173,7 @@ module.exports.getPoamByCollection = async function getFindingsByCollection (req
     const po = Serialize.poamObjectFromFindings(response, defaults)
     const xlsx = await Serialize.xlsxFromPoamObject(po)
     let collectionName = collectionGrant.collection.name
-    writer.writeInlineFile( res, xlsx, `POAM-${collectionName}.xlsx`, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+    writer.writeInlineFile( res, xlsx, `POAM-${collectionName}_${escape.filenameComponentFromDate()}.xlsx`, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
   }
   catch (err) {
     next(err)
@@ -652,13 +652,14 @@ async function postArchiveByCollection ({format = 'ckl-mono', req, res, parsedRe
     attrValueProcessor: escapeForXml
 })
   const zip = Archiver('zip', {zlib: {level: 9}})
-  const started = new Date().toISOString()
+  const started = new Date()
+  const dateString = escape.filenameComponentFromDate(started)
   const attachmentName = escape.escapeFilename(`${parsedRequest.collection.name}-${format.startsWith('ckl-') ? 
-    'CKL' : format.startsWith('cklb-') ? 'CKLB' : 'XCCDF'}_${started.replace(/:|\d{2}\.\d{3}/g,'')}.zip`)
+    'CKL' : format.startsWith('cklb-') ? 'CKLB' : 'XCCDF'}_${dateString}.zip`)
   res.attachment(attachmentName)
   zip.pipe(res)
   const manifest = {
-    started,
+    started: started.toISOString(),
     finished: '',
     errorCount: 0,
     errors: [],

--- a/api/source/utils/escape.js
+++ b/api/source/utils/escape.js
@@ -38,7 +38,7 @@ module.exports.escapeFilename = function (value) {
    * Regexes match characters that need to be escaped in filenames.
    * @type {RegExp}
    */
-  const osReserved = /[\/\\:\*"\?<>\|]/g
+  const osReserved = /[/\\:*"?<>|]/g
   const controlChars = /[\x00-\x1f]/g
 
     /**
@@ -61,5 +61,9 @@ module.exports.escapeFilename = function (value) {
   .replace(osReserved, (match) => osReserveReplace[match])
   .replace(controlChars, (match) => `&#x${match.charCodeAt(0).toString().padStart(2,'0')};`)
   .substring(0, 255)
+}
+
+module.exports.filenameComponentFromDate = function (dateObject = new Date()) {
+  return dateObject.toISOString().replace(/:|\d{2}\.\d{3}/g,'')
 }
 

--- a/api/source/utils/writer.js
+++ b/api/source/utils/writer.js
@@ -1,3 +1,4 @@
+const escape = require ('./escape.js')
 let ResponsePayload = function(code, payload) {
   this.code = code;
   this.payload = payload;
@@ -52,15 +53,10 @@ let writeJson = exports.writeJson = function(response, arg1, arg2) {
   response.end(payload);
 }
 
-const charToHexStr = (c) => `%${c.charCodeAt(0).toString(16).padStart(2, '0')}`
-
-const goodFilename = (string) =>
-  string.replace(/[<>:"/\\|?*\x00-\x1F]| +$/g, charToHexStr)
-
 exports.writeInlineFile = function(response, payload, filename, contentType) {
   response.writeHead(200, {
     'Content-Type': contentType,
-    'Content-Disposition': `inline; filename="${goodFilename(filename)}"`,
+    'Content-Disposition': `inline; filename="${escape.escapeFilename(filename)}"`,
     'Access-Control-Expose-Headers': 'Content-Disposition'
   })
   response.write(payload)
@@ -78,4 +74,6 @@ exports.writeNoContent = function (response) {
   response.writeHead(204)
   response.end()
 }
+
+
 

--- a/client/src/js/ExportButton.js
+++ b/client/src/js/ExportButton.js
@@ -66,10 +66,10 @@ Ext.ux.ExportButton = Ext.extend(Ext.Button, {
 		if (btn.exportFormat == 'csv'){
 			if (btn.exportType == 'grid') {
 				csv += this.gridToCsv(this.gridSource);
-				filename = this.gridBasename + '.csv';
+				filename = `${this.gridBasename}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.csv`;
 			} else if (btn.exportType == 'store') {
 				csv += this.storeToCsv(this.storeSource);
-				filename = this.storeBasename + '.csv';
+				filename = `${this.storeBasename}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.csv`;
 			}
 		}
 		let blob = new Blob([csv],{type:"text/csv;charset=utf-8"});

--- a/client/src/js/ExportButton.js
+++ b/client/src/js/ExportButton.js
@@ -66,10 +66,10 @@ Ext.ux.ExportButton = Ext.extend(Ext.Button, {
 		if (btn.exportFormat == 'csv'){
 			if (btn.exportType == 'grid') {
 				csv += this.gridToCsv(this.gridSource);
-				filename = `${this.gridBasename}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.csv`;
+				filename = SM.Global.filenameEscaped(`${this.gridBasename}_${SM.Global.filenameComponentFromDate()}.csv`);
 			} else if (btn.exportType == 'store') {
 				csv += this.storeToCsv(this.storeSource);
-				filename = `${this.storeBasename}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.csv`;
+				filename = SM.Global.filenameEscaped(`${this.storeBasename}_${SM.Global.filenameComponentFromDate()}.csv`);
 			}
 		}
 		let blob = new Blob([csv],{type:"text/csv;charset=utf-8"});

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -1126,7 +1126,7 @@ SM.CollectionPanel.ExportPanel = Ext.extend(Ext.Panel, {
         const agg = aggComboBox.getValue()
         const url = `${STIGMAN.Env.apiBase}/collections/${collectionId}/metrics/${style}${agg === 'unagg' ? '' : `/${agg}`}?${queryParamsStr}`
 
-        const attachment = `${agg}-${style}.${format}`
+        const attachment = `${agg}-${style}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.${format}`
         await window.oidcProvider.updateToken(10)
         const fetchInit = {
           method: 'GET',

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -1126,7 +1126,7 @@ SM.CollectionPanel.ExportPanel = Ext.extend(Ext.Panel, {
         const agg = aggComboBox.getValue()
         const url = `${STIGMAN.Env.apiBase}/collections/${collectionId}/metrics/${style}${agg === 'unagg' ? '' : `/${agg}`}?${queryParamsStr}`
 
-        const attachment = `${agg}-${style}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.${format}`
+        const attachment = SM.Global.filenameEscaped(`${SM.Cache.CollectionMap.get(_this.collectionId)?.name}-${agg}-${style}_${SM.Global.filenameComponentFromDate()}.${format}`)
         await window.oidcProvider.updateToken(10)
         const fetchInit = {
           method: 'GET',

--- a/client/src/js/SM/Global.js
+++ b/client/src/js/SM/Global.js
@@ -533,3 +533,37 @@ Ext.override(Ext.grid.GridPanel, {
     }
 })
 
+SM.Global.filenameComponentFromDate = function (dateObject = new Date()) {
+    return dateObject.toISOString().replace(/:|\d{2}\.\d{3}/g,'')
+}
+
+SM.Global.filenameEscaped = function (value) {
+    /**
+     * Regexes match characters that need to be escaped in filenames.
+     * @type {RegExp}
+     */
+    const osReserved = /[/\\:*"?<>|]/g
+    const controlChars = /[\x00-\x1f]/g
+  
+      /**
+     * Map of characters to their corresponding named HTML entities.
+     * @type {Object.<string, string>}
+     */
+    const osReserveReplace = {
+      '/': '&sol;',
+      '\\': '&bsol;',
+      ':': '&colon;',
+      '*': '&ast;',
+      '"': '&quot;',
+      '?': '&quest;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '|': '&vert;',
+    }
+  
+    return value.toString()
+    .replace(osReserved, (match) => osReserveReplace[match])
+    .replace(controlChars, (match) => `&#x${match.charCodeAt(0).toString().padStart(2,'0')};`)
+    .substring(0, 255)
+  }
+

--- a/client/src/js/SM/MetaPanel.js
+++ b/client/src/js/SM/MetaPanel.js
@@ -942,7 +942,7 @@ SM.MetaPanel.ExportPanel = Ext.extend(Ext.Panel, {
         const agg = aggComboBox.getValue()
         const url = `${STIGMAN.Env.apiBase}/collections/meta/metrics/${style}${agg === 'unagg' ? '' : `/${agg}`}?${queryParamsStr}`
 
-        const attachment = `${agg}-${style}.${format}`
+        const attachment = `${agg}-${style}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.${format}`
         await window.oidcProvider.updateToken(10)
         const fetchInit = {
           method: 'GET',

--- a/client/src/js/SM/MetaPanel.js
+++ b/client/src/js/SM/MetaPanel.js
@@ -942,7 +942,8 @@ SM.MetaPanel.ExportPanel = Ext.extend(Ext.Panel, {
         const agg = aggComboBox.getValue()
         const url = `${STIGMAN.Env.apiBase}/collections/meta/metrics/${style}${agg === 'unagg' ? '' : `/${agg}`}?${queryParamsStr}`
 
-        const attachment = `${agg}-${style}_${new Date().toISOString().replace(/:|\d{2}\.\d{3}/g,'')}.${format}`
+        const attachment = SM.Global.filenameEscaped(`Meta-${agg}-${style}_${SM.Global.filenameComponentFromDate()}.${format}`)
+
         await window.oidcProvider.updateToken(10)
         const fetchInit = {
           method: 'GET',

--- a/client/src/js/appDataAdmin.js
+++ b/client/src/js/appDataAdmin.js
@@ -21,7 +21,7 @@ async function addAppDataAdmin( params ) {
           handler: function (btn) {
             if (detailResponseText) {
               const blob = new Blob([detailResponseText], {type: 'application/json'})
-              downloadBlob(blob, 'stig-manager-details.json')
+              downloadBlob(blob, SM.Global.filenameEscaped(`stig-manager-details_${SM.Global.filenameComponentFromDate()}.json`))
             }
           }
         }

--- a/test/api/postman_collection.json
+++ b/test/api/postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "fcb1e3fc-7e68-4709-baae-eb5bec83df44",
+		"_postman_id": "835a145b-c95c-4f10-ad6b-2547ac6840b0",
 		"name": "STIGMan OSS",
 		"description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.\n\nContact Support:  \nName: Carl Smigielski  \nEmail: [carl.a.smigielski@saic.com](https://mailto:carl.a.smigielski@saic.com)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "28917726"
+		"_exporter_id": "9301046"
 	},
 	"item": [
 		{
@@ -71381,12 +71381,20 @@
 											"}\r",
 											"\r",
 											"\r",
+											"const regex = /^inline; filename=\"TxxxxxEST_&bsol;slash&colon;colon\\.\\.x2-VPN_SRG_TEST-V1R1/;\r",
+											"\r",
+											"\r",
 											"pm.test(\"Content-Disposition is set with expected filename\", function () {\r",
-											"    pm.response.to.have.header(\"Content-Disposition\", \"inline; filename=\\\"TxxxxxEST_&bsol;slash&colon;colon..x2-VPN_SRG_TEST-V1R1.ckl\\\"\");\r",
+											"    pm.expect(pm.response.headers.get('Content-Disposition')).to.match(regex)\r",
+											"\r",
+											"\r",
 											"});\r",
+											"\r",
+											"\r",
 											""
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -71477,13 +71485,18 @@
 											"}\r",
 											"\r",
 											"\r",
-											"pm.test(\"Content-Disposition is set with expected filename\", function () {\r",
-											"    pm.response.to.have.header(\"Content-Disposition\", \"inline; filename=\\\"TxxxxxEST_&bsol;slash&colon;colon..x2-VPN_SRG_TEST-V1R1.cklb\\\"\");\r",
-											"});\r",
+											"const regex = /^inline; filename=\"TxxxxxEST_&bsol;slash&colon;colon\\.\\.x2-VPN_SRG_TEST-V1R1/;\r",
 											"\r",
+											"\r",
+											"pm.test(\"Content-Disposition is set with expected filename\", function () {\r",
+											"    pm.expect(pm.response.headers.get('Content-Disposition')).to.match(regex)\r",
+											"\r",
+											"\r",
+											"});\r",
 											""
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],
@@ -71541,7 +71554,7 @@
 							"response": []
 						},
 						{
-							"name": "Return the cklB for Asset with reserved chars Copy",
+							"name": "Return the xccdf for Asset with reserved chars Copy",
 							"event": [
 								{
 									"listen": "test",
@@ -71573,14 +71586,18 @@
 											"    return;\r",
 											"}\r",
 											"\r",
+											"const regex = /^inline; filename=\"TxxxxxEST_&bsol;slash&colon;colon\\.\\.x2-VPN_SRG_TEST-V1R1/;\r",
+											"\r",
 											"\r",
 											"pm.test(\"Content-Disposition is set with expected filename\", function () {\r",
-											"    pm.response.to.have.header(\"Content-Disposition\", \"inline; filename=\\\"TxxxxxEST_&bsol;slash&colon;colon..x2-VPN_SRG_TEST-V1R1-xccdf.xml\\\"\");\r",
-											"});\r",
+											"    pm.expect(pm.response.headers.get('Content-Disposition')).to.match(regex)\r",
 											"\r",
+											"\r",
+											"});\r",
 											""
 										],
-										"type": "text/javascript"
+										"type": "text/javascript",
+										"packages": {}
 									}
 								}
 							],


### PR DESCRIPTION
Resolves #1307 

This PR modifies the API and web app to add a time string to the default filenames presented by a browser when downloading files. The time string value is an ISO8601-like token with the format `YYYY-MM-DDThhmmZ`.

The date string is appended to the following downloads:
- ZIP archives of CKL, CKLB, and XCCDF checklists
- Individual Asset/STIG checklists in CKL, CKLB, or XCCDF formats
- Collection and Meta-collection metrics, JSON and CSV
- Individual grid CSV

In addition, the filename escape routine in the API was ported to the web app.