### PR TITLE
fix: remove DEFINER statements from output of `generateSchema.sh`

### DIFF
--- a/api/source/service/migrations/sql/current/10-stigman-tables.sql
+++ b/api/source/service/migrations/sql/current/10-stigman-tables.sql
@@ -618,7 +618,6 @@ DROP TABLE IF EXISTS `v_latest_rev`;
 /*!50001 SET @saved_col_connection     = @@collation_connection */;
 /*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`stigman`@`%` SQL SECURITY DEFINER */
 /*!50001 VIEW `v_current_rev` AS select `rr`.`revId` AS `revId`,`rr`.`benchmarkId` AS `benchmarkId`,`rr`.`version` AS `version`,`rr`.`release` AS `release`,`rr`.`benchmarkDate` AS `benchmarkDate`,`rr`.`benchmarkDateSql` AS `benchmarkDateSql`,`rr`.`status` AS `status`,`rr`.`statusDate` AS `statusDate`,`rr`.`description` AS `description`,`rr`.`active` AS `active`,`rr`.`groupCount` AS `groupCount`,`rr`.`ruleCount` AS `ruleCount`,`rr`.`lowCount` AS `lowCount`,`rr`.`mediumCount` AS `mediumCount`,`rr`.`highCount` AS `highCount`,`rr`.`checkCount` AS `checkCount`,`rr`.`fixCount` AS `fixCount` from (select `r`.`revId` AS `revId`,`r`.`benchmarkId` AS `benchmarkId`,`r`.`version` AS `version`,`r`.`release` AS `release`,`r`.`benchmarkDate` AS `benchmarkDate`,`r`.`benchmarkDateSql` AS `benchmarkDateSql`,`r`.`status` AS `status`,`r`.`statusDate` AS `statusDate`,`r`.`description` AS `description`,`r`.`active` AS `active`,`r`.`groupCount` AS `groupCount`,`r`.`ruleCount` AS `ruleCount`,`r`.`lowCount` AS `lowCount`,`r`.`mediumCount` AS `mediumCount`,`r`.`highCount` AS `highCount`,`r`.`checkCount` AS `checkCount`,`r`.`fixCount` AS `fixCount`,row_number() OVER (PARTITION BY `r`.`benchmarkId` ORDER BY field(`r`.`status`,'draft','accepted') desc,(`r`.`version` + 0) desc,(`r`.`release` + 0) desc )  AS `rn` from `revision` `r`) `rr` where (`rr`.`rn` = 1) */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
 
@@ -630,7 +629,6 @@ DROP TABLE IF EXISTS `v_latest_rev`;
 /*!50001 SET @saved_col_connection     = @@collation_connection */;
 /*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`stigman`@`%` SQL SECURITY DEFINER */
 /*!50001 VIEW `v_default_rev` AS select distinct `a`.`collectionId` AS `collectionId`,`sa`.`benchmarkId` AS `benchmarkId`,(case when (`crm`.`revId` is not null) then `crm`.`revId` else `cr`.`revId` end) AS `revId`,(case when (`crm`.`revId` is not null) then 1 else 0 end) AS `revisionPinned` from (((`asset` `a` join `stig_asset_map` `sa` on((`a`.`assetId` = `sa`.`assetId`))) left join `current_rev` `cr` on((`sa`.`benchmarkId` = `cr`.`benchmarkId`))) left join `collection_rev_map` `crm` on(((`sa`.`benchmarkId` = `crm`.`benchmarkId`) and (`a`.`collectionId` = `crm`.`collectionId`)))) */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
 
@@ -642,7 +640,6 @@ DROP TABLE IF EXISTS `v_latest_rev`;
 /*!50001 SET @saved_col_connection     = @@collation_connection */;
 /*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`stigman`@`%` SQL SECURITY DEFINER */
 /*!50001 VIEW `v_latest_rev` AS select `rr`.`revId` AS `revId`,`rr`.`benchmarkId` AS `benchmarkId`,concat('V',`rr`.`version`,'R',`rr`.`release`) AS `revisionStr` from (select `r`.`revId` AS `revId`,`r`.`benchmarkId` AS `benchmarkId`,`r`.`version` AS `version`,`r`.`release` AS `release`,row_number() OVER (PARTITION BY `r`.`benchmarkId` ORDER BY field(`r`.`status`,'draft','accepted') desc,(`r`.`version` + 0) desc,(`r`.`release` + 0) desc )  AS `rn` from `revision` `r`) `rr` where (`rr`.`rn` = 1) */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/api/source/service/migrations/sql/generateSchema.sh
+++ b/api/source/service/migrations/sql/generateSchema.sh
@@ -19,11 +19,11 @@ static_data_tables="result status _migrations"
 # and removing statements that trigger a mysql2 bug when changing client character set
 # The '--no-data' flag means no table row data will be dumped, only the schema.
 # The '--no-create-db' flag prevents the inclusion of CREATE DATABASE statements in the dump.
-mysqldump -h 127.0.0.1 -P 50001 -u root -prootpw --no-data --no-create-db stigman |
-  sed --expression='s/ AUTO_INCREMENT=[0-9]\+//' |
+mysqldump -h 127.0.0.1 -P 3306 -u root -prootpw --no-data --no-create-db stigman |
+  sed --expression='s/ AUTO_INCREMENT=[0-9]\+//'  --expression='/\/\*!50013 DEFINER=`stigman`@`%` SQL SECURITY DEFINER \*\//d' |
   awk 'tolower($0) !~ /character_set|set names/' > 10-stigman-tables.sql
 
 # Export only the data from specific tables listed in $static_data_tables into a separate SQL file. 
 # '--no-create-info' flag ensures that table creation statements are not included, just the row insertions.
-mysqldump -h 127.0.0.1 -P 50001 -u root -prootpw --no-create-info stigman $static_data_tables |
+mysqldump -h 127.0.0.1 -P 3306 -u root -prootpw --no-create-info stigman $static_data_tables |
   awk 'tolower($0) !~ /character_set|set names/' > 20-stigman-static.sql

--- a/api/source/service/migrations/sql/generateSchema.sh
+++ b/api/source/service/migrations/sql/generateSchema.sh
@@ -20,7 +20,7 @@ static_data_tables="result status _migrations"
 # The '--no-data' flag means no table row data will be dumped, only the schema.
 # The '--no-create-db' flag prevents the inclusion of CREATE DATABASE statements in the dump.
 mysqldump -h 127.0.0.1 -P 3306 -u root -prootpw --no-data --no-create-db stigman |
-  sed --expression='s/ AUTO_INCREMENT=[0-9]\+//'  --expression='/\/\*!50013 DEFINER=`stigman`@`%` SQL SECURITY DEFINER \*\//d' |
+  sed --expression='s/ AUTO_INCREMENT=[0-9]\+//'  --expression='/DEFINER=/d' |
   awk 'tolower($0) !~ /character_set|set names/' > 10-stigman-tables.sql
 
 # Export only the data from specific tables listed in $static_data_tables into a separate SQL file. 


### PR DESCRIPTION
Removed `DEFINER=....` lines from 10-stigman-tables.sql
Added sed expression to generateSchema to remove definer lines when generating the file

resolves: #1317 