### PR TITLE
refactor: remove web app request for labels projection

### DIFF
--- a/client/src/js/SM/Cache.js
+++ b/client/src/js/SM/Cache.js
@@ -6,10 +6,7 @@ SM.Cache.getCollections = async function () {
   const apiCollections = await Ext.Ajax.requestPromise({
     responseType: 'json',
     url: `${STIGMAN.Env.apiBase}/collections`,
-    method: 'GET',
-    params: {
-      projection: 'labels'
-    }
+    method: 'GET'
   })
   return SM.Cache.seedCollections(apiCollections)
 }
@@ -69,9 +66,6 @@ SM.Cache.updateCollection = function (apiCollection) {
 SM.Cache.seedCollections = function (apiCollections) {
   for (const collection of apiCollections) {
     const labelMap = new Map()
-    for (const label of collection.labels) {
-      labelMap.set(label.labelId, label)
-    }
     SM.Cache.CollectionMap.set(collection.collectionId, { labelMap, ...collection })
   }
   return SM.Cache.CollectionMap

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -1675,6 +1675,8 @@ SM.CollectionPanel.showCollectionTab = async function (options) {
       return
     }
 
+    SM.Cache.updateCollectionLabels(collectionId)
+
     const gState = {}
 
     gState.labelIds = initialLabelIds
@@ -1819,7 +1821,7 @@ SM.CollectionPanel.showCollectionTab = async function (options) {
       ],
       listeners: {
         tabchange: function (tp) {
-          updateData({event: 'tabchange'})
+          if (!tp.firstShow) updateData({ event: 'tabchange' })
           tp.firstShow = false
         }
       }

--- a/client/src/js/collectionAdmin.js
+++ b/client/src/js/collectionAdmin.js
@@ -331,6 +331,7 @@ async function showCollectionProps(collectionId) {
         },
         method: 'GET'
       })
+      SM.Cache.updateCollection(apiCollection)
 
       fp.setFieldValues(apiCollection)
     }

--- a/client/src/js/collectionManager.js
+++ b/client/src/js/collectionManager.js
@@ -17,6 +17,8 @@ async function addCollectionManager( params ) {
 			},
 			method: 'GET'
 		})
+		SM.Cache.updateCollection(apiCollection)
+
 		let apiFieldSettings = apiCollection.settings.fields
 
 		function onFieldSettingsChanged (collectionId, fieldSettings) {


### PR DESCRIPTION
Resolves #1326 

This PR refactors the web app to eliminate the unneeded and non-performant `projection=labels` parameter from the initial request for all Collections. In individual Collection workspaces, calls have been inserted that refresh that Collection's label cache from the just retrieved data.

Also, added logic to the Collection dashboard that suppresses three repetitive requests to the Metrics endpoints when the dashboard is first loaded. There was no issue for this, but the behavior was noted during other development efforts.
