### PR TITLE
refactor: label rendering

### DIFF
--- a/client/src/js/SM/AssetSelection.js
+++ b/client/src/js/SM/AssetSelection.js
@@ -44,7 +44,7 @@ SM.AssetSelection.GridPanel = Ext.extend(Ext.grid.GridPanel, {
         renderer: function (value) {
           const labels = []
           for (const labelId of value) {
-            const label = SM.Cache.CollectionMap.get(_this.collectionId).labelMap.get(labelId)
+            const label = SM.Cache.getCollectionLabel(_this.collectionId, labelId)
             if (label) labels.push(label)
           }
           labels.sort((a, b) => a.name.localeCompare(b.name))

--- a/client/src/js/SM/Cache.js
+++ b/client/src/js/SM/Cache.js
@@ -77,6 +77,16 @@ SM.Cache.seedCollections = function (apiCollections) {
   return SM.Cache.CollectionMap
 }
 
+SM.Cache.getCollectionLabel = function (collectionId, labelId) {
+  if (!labelId || !collectionId) return undefined
+  return SM.Cache.CollectionMap.get(collectionId).labelMap.get(labelId) || {
+    labelId,
+    color: 'FF0000',
+    description: 'cross-collection label error',
+    name: 'ERROR'
+  }
+}
+
 SM.Dispatcher.addListener('collectioncreated', function( apiCollection, options) {
   SM.Cache.seedCollections([apiCollection])
 })

--- a/client/src/js/SM/CollectionAsset.js
+++ b/client/src/js/SM/CollectionAsset.js
@@ -151,7 +151,7 @@ SM.CollectionAssetGrid = Ext.extend(Ext.grid.GridPanel, {
                 renderer: function (value, metadata) {
                     const labels = []
                     for (const labelId of value) {
-                        const label = SM.Cache.CollectionMap.get(me.collectionId).labelMap.get(labelId)
+                        const label = SM.Cache.getCollectionLabel(me.collectionId, labelId)
                         if (label) labels.push(label)
                     }
                     labels.sort((a,b) => a.name.localeCompare(b.name))

--- a/client/src/js/SM/CollectionForm.js
+++ b/client/src/js/SM/CollectionForm.js
@@ -1765,7 +1765,7 @@ SM.Collection.LabelSpritesByCollectionLabelId = function (collectionId, labelIds
         if (labelId === null) {
             includeUnlabeled = true
         }
-        const label = SM.Cache.CollectionMap.get(collectionId).labelMap.get(labelId)
+        const label = SM.Cache.getCollectionLabel(collectionId, labelId)
         if (label) labels.push(label)
     }
     labels.sort((a, b) => a.name.localeCompare(b.name))
@@ -2256,7 +2256,7 @@ SM.Collection.LabelsMenu = Ext.extend(Ext.menu.Menu, {
     },
     setLabelsChecked: function (labelIds, checked) {
         for (const labelId of labelIds) {
-            this.find('labelId', labelId)[0].setChecked(checked, true) //suppressEvent = true
+            this.find('labelId', labelId)[0]?.setChecked(checked, true) //suppressEvent = true
         }
     },
     updateLabel: function (label) {
@@ -2341,7 +2341,7 @@ SM.Collection.LabelAssetsForm = Ext.extend(Ext.form.FormPanel, {
             isFormField: true,
             selectionsGridTitle: 'Tagged'
         })
-        const labelData = {...SM.Cache.CollectionMap.get(this.collectionId).labelMap.get(this.labelId)}
+        const labelData = {...SM.Cache.getCollectionLabel(this.collectionId, this.labelId)}
         labelData.extraCls = 'sm-jumbo-sprite'
         const labelSpan = SM.Collection.LabelTpl.apply(labelData)
         const labelField = new Ext.form.DisplayField({

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -268,7 +268,7 @@ SM.CollectionPanel.AggGrid = Ext.extend(Ext.grid.GridPanel, {
             renderer: function (value, metadata) {
               const labels = []
               for (const labelId of value) {
-                const label = SM.Cache.CollectionMap.get(_this.collectionId).labelMap.get(labelId)
+                const label = SM.Cache.getCollectionLabel(_this.collectionId, labelId)
                 if (label) labels.push(label)
               }
               labels.sort((a, b) => a.name.localeCompare(b.name))
@@ -343,7 +343,7 @@ SM.CollectionPanel.AggGrid = Ext.extend(Ext.grid.GridPanel, {
             renderer: function (value, metadata) {
               const labels = []
               const labelId = value
-              const label = SM.Cache.CollectionMap.get(_this.collectionId).labelMap.get(labelId)
+              const label = SM.Cache.getCollectionLabel(_this.collectionId, labelId)
               if (label) labels.push(label)
               labels.sort((a, b) => a.name.localeCompare(b.name))
               metadata.attr = 'style="white-space:normal;"'
@@ -575,7 +575,7 @@ SM.CollectionPanel.UnaggGrid = Ext.extend(Ext.grid.GridPanel, {
             renderer: function (value, metadata) {
               const labels = []
               for (const labelId of value) {
-                const label = SM.Cache.CollectionMap.get(_this.collectionId).labelMap.get(labelId)
+                const label = SM.Cache.getCollectionLabel(_this.collectionId, labelId)
                 if (label) labels.push(label)
               }
               labels.sort((a, b) => a.name.localeCompare(b.name))

--- a/client/src/js/SM/ColumnFilters.js
+++ b/client/src/js/SM/ColumnFilters.js
@@ -191,7 +191,7 @@ SM.ColumnFilters.extend = function extend (extended = Ext.grid.GridView) {
           const cValue = cVals[col.dataIndex]
           for ( const value of uniqueArray ) {
             itemConfigs.push({
-              text: col.filter.renderer ? col.filter.renderer(value, col.filter.collectionId) : value ? value : '<i>(No value)</i>',
+              text: col.filter.renderer ? col.filter.renderer(value, col.filter.collectionId) : value ,
               xtype: 'menucheckitem',
               column: col,
               hideOnClick: false,
@@ -407,7 +407,7 @@ SM.ColumnFilters.Renderers = {
   },
   labels: function (labelId, collectionId) {
     if (!labelId) return '<i>(No value)</i>'
-    const labelObj = SM.Cache.CollectionMap.get(collectionId).labelMap.get(labelId)
+    const labelObj = SM.Cache.getCollectionLabel(collectionId, labelId)
     return SM.Collection.LabelTpl.apply(labelObj)
   }
 }

--- a/client/src/js/SM/FindingsPanel.js
+++ b/client/src/js/SM/FindingsPanel.js
@@ -482,7 +482,7 @@ SM.FindingsChildGrid = Ext.extend(Ext.grid.GridPanel, {
 				renderer: function (value, metadata) {
 					const labels = []
 					for (const labelId of value) {
-						const label = SM.Cache.CollectionMap.get(me.panel.collectionId).labelMap.get(labelId)
+						const label = SM.Cache.getCollectionLabel(me.panel.collectionId, labelId)
 						if (label) labels.push(label)
 					}
 					labels.sort((a, b) => a.name.localeCompare(b.name))

--- a/client/src/js/SM/MetaPanel.js
+++ b/client/src/js/SM/MetaPanel.js
@@ -176,7 +176,7 @@ SM.MetaPanel.AggGrid = Ext.extend(Ext.grid.GridPanel, {
             renderer: function (value, metadata) {
               const labels = []
               for (const labelId of value) {
-                const label = SM.Cache.CollectionMap.get(_this.collectionId).labelMap.get(labelId)
+                const label = SM.Cache.getCollectionLabel(_this.collectionId, labelId)
                 if (label) labels.push(label)
               }
               labels.sort((a, b) => a.name.localeCompare(b.name))
@@ -506,7 +506,7 @@ SM.MetaPanel.UnaggGrid = Ext.extend(Ext.grid.GridPanel, {
             renderer: function (value, metadata) {
               const labels = []
               for (const labelId of value) {
-                const label = SM.Cache.CollectionMap.get(_this.collectionId).labelMap.get(labelId)
+                const label = SM.Cache.getCollectionLabel(_this.collectionId, labelId)
                 if (label) labels.push(label)
               }
               labels.sort((a, b) => a.name.localeCompare(b.name))

--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -942,8 +942,8 @@ async function addCollectionReview ( params ) {
 					renderer: function (value, metadata) {
 							const labels = []
 							for (const labelId of value) {
-									const label = SM.Cache.CollectionMap.get(apiCollection.collectionId).labelMap.get(labelId)
-									if (label) labels.push(label)
+								const label = SM.Cache.getCollectionLabel(apiCollection.collectionId, labelId)
+								if (label) labels.push(label)
 							}
 							labels.sort((a,b) => a.name.localeCompare(b.name))
 							metadata.attr = 'style="white-space:nowrap;text-overflow:clip;"'

--- a/client/src/js/completionStatus.js
+++ b/client/src/js/completionStatus.js
@@ -72,7 +72,7 @@ function addCompletionStatus( params) {
 				renderer: function (value, metadata) {
 						const labels = []
 						for (const labelId of value) {
-								const label = SM.Cache.CollectionMap.get(collectionId).labelMap.get(labelId)
+								const label = SM.Cache.getCollectionLabel(collectionId, labelId)
 								if (label) labels.push(label)
 						}
 						labels.sort((a,b) => a.name.localeCompare(b.name))

--- a/client/src/js/review.js
+++ b/client/src/js/review.js
@@ -884,7 +884,7 @@ async function addReview( params ) {
         renderer: function (value, metadata) {
             const labels = []
             for (const labelId of value) {
-                const label = SM.Cache.CollectionMap.get(apiCollection.collectionId).labelMap.get(labelId)
+                const label = SM.Cache.getCollectionLabel(apiCollection.collectionId, labelId)
                 if (label) labels.push(label)
             }
             labels.sort((a,b) => a.name.localeCompare(b.name))
@@ -1086,10 +1086,9 @@ async function addReview( params ) {
     labelSpans = SM.Collection.LabelArrayTpl.apply(leaf.assetLabels)
   }
   else {
-    const labelMap = SM.Cache.CollectionMap.get(apiCollection.collectionId).labelMap
     const labels = []
     for (const labelId of leaf.assetLabelIds) {
-        const label = labelMap.get(labelId)
+        const label = SM.Cache.getCollectionLabel(apiCollection.collectionId, labelId)
         if (label) labels.push(label)
     }
     labels.sort((a,b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
This PR surfaces inconsistent label data in all grids that display assets with labels, which may help us track down the root cause of #1329. 

A utility function replaces the following chained statement used throughout the web app:
```
SM.Cache.CollectionMap.get(collectionId).labelMap.get(labelId)```
which becomes
```
SM.Cache.getCollectionLabel(collectionId, labelId)
```
If the given labelId is not present in the given collection, the utility function returns a label object that clearly indicates an error situation exists.
