### PR TITLE
fix: elevate handling for stig import

### DIFF
--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -6,10 +6,8 @@ const parsers = require('../utils/parsers.js')
 const STIGService = require(`../service/STIGService`)
 
 module.exports.importBenchmark = async function importManualBenchmark (req, res, next) {
-  if ( !req.query.elevate ) {
-    next(new SmError.PrivilegeError())
-  }
   try {
+    if (!req.query.elevate) throw new SmError.PrivilegeError()
     const extension = req.file.originalname.substring(req.file.originalname.lastIndexOf(".")+1)
     const clobber = req.query.clobber ?? false
     if (extension.toLowerCase() != 'xml') {

--- a/client/src/js/SM/StigRevision.js
+++ b/client/src/js/SM/StigRevision.js
@@ -470,7 +470,7 @@ SM.StigRevision.ImportStigs = function ( grid ) {
             updateStatusText (file.name)
     
             await window.oidcProvider.updateToken(10)
-            let response = await fetch(`${STIGMAN.Env.apiBase}/stigs?clobber=${clobber ? 'true':'false'}`, {
+            let response = await fetch(`${STIGMAN.Env.apiBase}/stigs?elevate=true&clobber=${clobber ? 'true':'false'}`, {
               method: 'POST',
               headers: new Headers({
                 'Authorization': `Bearer ${window.oidcProvider.token}`
@@ -516,7 +516,7 @@ SM.StigRevision.ImportStigs = function ( grid ) {
               fd.append('importFile', data, xml)
 
               await window.oidcProvider.updateToken(10)
-              let response = await fetch(`${STIGMAN.Env.apiBase}/stigs?clobber=${clobber ? 'true':'false'}`, {
+              let response = await fetch(`${STIGMAN.Env.apiBase}/stigs?elevate=true&clobber=${clobber ? 'true':'false'}`, {
                 method: 'POST',
                 params: { clobber },
                 headers: new Headers({


### PR DESCRIPTION
Resolves #1342 by adding `elevate=true` to the web app code for importing new benchmarks.

This PR also refactors the STIG import handler code in the API so it does not continue execution after detecting an unelevated request.