### PR TITLE
Enhancement: skips sonarcloud actions when PR form fork

### DIFF
--- a/.github/workflows/api-audit-test-coverage-response.yml
+++ b/.github/workflows/api-audit-test-coverage-response.yml
@@ -191,18 +191,29 @@ jobs:
     needs: test_api
     runs-on: ubuntu-latest
     steps:
+      - name: Check if PR is from a fork
+        id: check_fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "This is a PR from a fork, skipping sonarcloud analysis."
+            echo "SKIP_STEP=true" >> $GITHUB_ENV
+          fi
       - name: Checkout repository
+        if: env.SKIP_STEP != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important to fetch all history for accurate blame information
       - name: Download lcov artifact
+        if: env.SKIP_STEP != 'true'
         uses: actions/download-artifact@v4
         with:
           name: coverage-report
       - name: Move lcov.info to api/source
+        if: env.SKIP_STEP != 'true'
         run: mv lcov.info ./api/source/
 
       - name: Analyze API with SonarCloud
+        if: env.SKIP_STEP != 'true'
         uses: SonarSource/sonarcloud-github-action@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information

--- a/.github/workflows/client-sonarcloud.yml
+++ b/.github/workflows/client-sonarcloud.yml
@@ -27,12 +27,22 @@ jobs:
     name: SonarCloud Analysis client
     runs-on: ubuntu-latest
     steps:
+      - name: Check if PR is from a fork
+        id: check_fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "This is a PR from a fork, skipping sonarcloud analysis."
+            echo "SKIP_STEP=true" >> $GITHUB_ENV
+          fi
       #checkout the repo
       - name: Checkout repository
+        if: env.SKIP_STEP != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important to fetch all history for accurate blame information
+      
       - name: Analyze client with SonarCloud
+        if: env.SKIP_STEP != 'true'
         uses: SonarSource/sonarcloud-github-action@v2.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information


### PR DESCRIPTION
This pull request implements a condition to skip  SonarCloud analysis when a pull request is opened from a forked repository. This will avoid "failed" workflows in the future. 
