### PR TITLE
fix: getStigById/getUserByUserId now return 404 when querying a resource that does not exist.

### DIFF
--- a/api/source/controllers/STIG.js
+++ b/api/source/controllers/STIG.js
@@ -221,6 +221,9 @@ module.exports.getStigById = async function getStigById (req, res, next) {
   const elevate = req.query.elevate
   try {
     let response = await STIGService.getStigById(benchmarkId, req.userObject, elevate)
+    if(!response) {
+      throw new SmError.NotFoundError()
+    }
     res.json(response)
   }
   catch(err) {

--- a/api/source/controllers/User.js
+++ b/api/source/controllers/User.js
@@ -93,6 +93,9 @@ module.exports.getUserByUserId = async function getUserByUserId (req, res, next)
       let userId = req.params.userId
       let projection = req.query.projection
       let response = await UserService.getUserByUserId(userId, projection, elevate, req.userObject)
+      if(!response) {
+        throw new SmError.NotFoundError()
+      }
       res.json(response)
     }
     else {


### PR DESCRIPTION
getStigById/getUserByUserId were returning a empty 200 response body when querying a resource that does not exist. This was found through the validation response workflow. This PR alters these endpoints to now return a 404.