### PR TITLE
fix: metadata query param parsing

### DIFF
--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -207,7 +207,7 @@ exports.queryAssets = async function (inProjection = [], inPredicates = {}, elev
   }
   if ( inPredicates.metadata ) {
     for (const pair of inPredicates.metadata) {
-      const [key, value] = pair.split(':')
+      const [key, value] = pair.split(/:(.*)/s)
       predicates.statements.push('JSON_CONTAINS(a.metadata, ?, ?)')
       predicates.binds.push( `"${value}"`,  `$.${key}`)
     }

--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -162,7 +162,7 @@ exports.queryCollections = async function (inProjection = [], inPredicates = {},
     }
     if ( inPredicates.metadata ) {
       for (const pair of inPredicates.metadata) {
-        const [key, value] = pair.split(':')
+        const [key, value] = pair.split(/:(.*)/s)
         predicates.statements.push('JSON_CONTAINS(c.metadata, ?, ?)')
         predicates.binds.push( `"${value}"`,  `$.${key}`)
       }

--- a/api/source/service/ReviewService.js
+++ b/api/source/service/ReviewService.js
@@ -776,7 +776,7 @@ exports.getReviews = async function (inProjection = [], inPredicates = {}, userO
   }
   if ( inPredicates.metadata ) {
     for (const pair of inPredicates.metadata) {
-      const [key, value] = pair.split(':')
+      const [key, value] = pair.split(/:(.*)/s)
       predicates.statements.push('JSON_CONTAINS(r.metadata, ?, ?)')
       predicates.binds.push( `"${value}"`,  `$.${key}`)
     }


### PR DESCRIPTION
Resolves #1357 

The PR changes the argument passed to `pair.split()` as recommended in the issue. 

```javascript
const [key, value] = pair.split(/:(.*)/s)
````
