### PR TITLE
fix: getAssetMetadataKeys now envokes NotFoundError() when asset does not have metadata.

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -601,7 +601,7 @@ module.exports.getAssetMetadataKeys = async function (req, res, next) {
   try {
     let { assetId } = await getAssetInfoAndVerifyAccess(req, Security.ACCESS_LEVEL.Restricted)
     let result = await AssetService.getAssetMetadataKeys(assetId, req.userObject)
-    if (!result) {
+    if (!result.length) {
       throw new SmError.NotFoundError('metadata keys not found')
     }
     res.json(result)


### PR DESCRIPTION
This PR corrects dead logic surrounding error handling in getAssetMetadataKeys where the API would return an empty array (200) instead of an error when no metadata keys were found. It now correctly checks if the result array is empty and throws a NotFoundError. 

This is just fixing what the code was attempting to do. Not sure if we WANT to return 404 anyway! We also have the pattern of getCollectionMetadata which will just return an empty object/array and a 200. 

After looking further the same pattern of dead code is in getCollectionMetadataKeys and getReviewMetadataKeys. 