### PR TITLE
fix: pass collectionId to getCollectionLabels() when known

### DIFF
--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -106,14 +106,8 @@ exports.queryCollections = async function (inProjection = [], inPredicates = {},
       ) as "owners"`)
     }
     if (inProjection.includes('labels')) {
-      if ( inPredicates.collectionId ) {
-        // get labels for specified collectionId
-        queries.push(_this.getCollectionLabels(inPredicates.collectionId, userObject))
-      }
-      else {
-        // no collectionId specified, get "all" labels
-        queries.push(_this.getCollectionLabels('all', userObject))
-      }
+      // get labels for specified collectionId. If no collectionId specified, get "all" labels
+      queries.push(_this.getCollectionLabels(inPredicates.collectionId ? inPredicates.collectionId : 'all', userObject));
     }
     if (inProjection.includes('statistics')) {
       if (context == dbUtils.CONTEXT_USER) {

--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -187,7 +187,7 @@ exports.queryCollections = async function (inProjection = [], inPredicates = {},
       const labelResults = results[0]
       const collectionResults = results[1][0]
       
-      if (inPredicates.collectionId){
+      if (inPredicates.collectionId && collectionResults[0]){
         // collectionId predicate specified, add labels array to first (and only) item in collectionResults
         collectionResults[0].labels = labelResults
       }
@@ -1304,6 +1304,7 @@ exports.getCollectionLabels = async function (collectionId, userObject) {
   ]
   const joins = [
     'collection_label cl', 
+    'right join collection c on c.collectionId = cl.collectionId and c.state = "enabled"',
     'left join collection_grant cg_l on cl.collectionId = cg_l.collectionId',
     'left join asset a_l on cl.collectionId = a_l.collectionId',
     'left join stig_asset_map sa_l on a_l.assetId = sa_l.assetId',

--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -1304,7 +1304,7 @@ exports.getCollectionLabels = async function (collectionId, userObject) {
   ]
   const joins = [
     'collection_label cl', 
-    'right join collection c on c.collectionId = cl.collectionId and c.state = "enabled"',
+    'inner join collection c on c.collectionId = cl.collectionId and c.state = "enabled"',
     'left join collection_grant cg_l on cl.collectionId = cg_l.collectionId',
     'left join asset a_l on cl.collectionId = a_l.collectionId',
     'left join stig_asset_map sa_l on a_l.assetId = sa_l.assetId',


### PR DESCRIPTION
When calling queryCollections w/ a collectionId, pass it to getCollectionLabels (instead of "all") to limit label query
resolves: #1361 