### PR TITLE
fix: Update functions to use transactions

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -51,7 +51,7 @@ module.exports.deleteAsset = async function deleteAsset (req, res, next) {
     let projection = req.query.projection
     const { assetId } = await getAssetInfoAndVerifyAccess(req)
     const response = await AssetService.getAsset(assetId, projection, elevate, req.userObject)
-    await AssetService.deleteAsset( assetId, projection, elevate, req.userObject )
+    await AssetService.deleteAsset( assetId, projection, elevate, req.userObject, res.svcStatus)
     res.json(response)
   }
   catch (err) {
@@ -64,7 +64,7 @@ module.exports.removeStigFromAsset = async function removeStigFromAsset (req, re
     let benchmarkId = req.params.benchmarkId
     let elevate = req.query.elevate
     const { assetId } = await getAssetInfoAndVerifyAccess(req)
-    let response = await AssetService.removeStigFromAsset(assetId, benchmarkId, elevate, req.userObject )
+    let response = await AssetService.removeStigFromAsset(assetId, benchmarkId, elevate, req.userObject, res.svcStatus)
     res.json(response)
   }
   catch (err) {
@@ -76,7 +76,7 @@ module.exports.removeStigsFromAsset = async function removeStigsFromAsset (req, 
   try {
     let elevate = req.query.elevate
     const { assetId } = await getAssetInfoAndVerifyAccess(req)
-    let response = await AssetService.removeStigsFromAsset(assetId, elevate, req.userObject )
+    let response = await AssetService.removeStigsFromAsset(assetId, elevate, req.userObject, res.svcStatus)
     res.json(response)
   }
   catch (err) {
@@ -663,7 +663,7 @@ module.exports.patchAssets = async function (req, res, next) {
     if (!patchRequest.assetIds.every( a => collectionAssets.includes(a))) {
       throw new SmError.PrivilegeError('One or more assetId is not a Collection member.')
     }
-    await AssetService.deleteAssets(patchRequest.assetIds, req.userObject)
+    await AssetService.deleteAssets(patchRequest.assetIds, req.userObject, res.svcStatus)
     res.json({
       operation: 'deleted',
       assetIds: patchRequest.assetIds

--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -1349,7 +1349,7 @@ exports.deleteAsset = async function(assetId, projection, elevate, userObject, s
     if (typeof connection !== 'undefined') {
       await connection.rollback()
     }
-    throw ( {status: 500, message: err.message, stack: err.stack} )
+    throw err
   }
   finally {
     if (typeof connection !== 'undefined') {
@@ -1378,7 +1378,7 @@ exports.deleteAssets = async function(assetIds, userObject, svcStatus = {}) {
     if (typeof connection !== 'undefined') {
       await connection.rollback()
     }
-    throw ( {status: 500, message: err.message, stack: err.stack} )
+    throw err
   }
   finally {
     if (typeof connection !== 'undefined') {
@@ -1454,7 +1454,7 @@ exports.removeStigFromAsset = async function (assetId, benchmarkId, elevate, use
     if (typeof connection !== 'undefined') {
       await connection.rollback()
     }
-    throw ( {status: 500, message: err.message, stack: err.stack} )
+    throw err
   }
   finally {
     if (typeof connection !== 'undefined') {
@@ -1486,7 +1486,7 @@ exports.removeStigsFromAsset = async function (assetId, elevate, userObject, svc
     if (typeof connection !== 'undefined') {
       await connection.rollback()
     }
-    throw ( {status: 500, message: err.message, stack: err.stack} )
+    throw err
   }
   finally {
     if (typeof connection !== 'undefined') {

--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -1327,22 +1327,64 @@ exports.createAsset = async function({body, projection, elevate, userObject, svc
   })
 }
 
-exports.deleteAsset = async function(assetId, projection, elevate, userObject) {
-  const rows = await _this.queryAssets(projection, {assetId: assetId}, elevate, userObject)
-  const sqlDelete = `UPDATE asset SET state = "disabled", stateDate = NOW(), stateUserId = ? where assetId = ?`
-  await dbUtils.pool.query(sqlDelete, [userObject.userId, assetId])
-  // changes above might have affected need for records in collection_rev_map 
-  await dbUtils.pruneCollectionRevMap()
-  await dbUtils.updateDefaultRev(null, {})
-  return (rows[0])
+exports.deleteAsset = async function(assetId, projection, elevate, userObject, svcStatus = {}) {
+
+  let connection
+  try {
+    connection = await dbUtils.pool.getConnection()
+    async function transaction () {
+      await connection.query('START TRANSACTION')
+      const sqlDelete = `UPDATE asset SET state = "disabled", stateDate = NOW(), stateUserId = ? where assetId = ?`
+      await connection.query(sqlDelete, [userObject.userId, assetId])
+      // changes above might have affected need for records in collection_rev_map
+      await dbUtils.pruneCollectionRevMap(connection)
+      await dbUtils.updateDefaultRev(connection, {})
+      await connection.commit()
+    }
+    const rows = await _this.queryAssets(projection, {assetId: assetId}, elevate, userObject)
+    await dbUtils.retryOnDeadlock(transaction, svcStatus)
+    return (rows[0])
+  }
+  catch (err) {
+    if (typeof connection !== 'undefined') {
+      await connection.rollback()
+    }
+    throw ( {status: 500, message: err.message, stack: err.stack} )
+  }
+  finally {
+    if (typeof connection !== 'undefined') {
+      await connection.release()
+    }
+  }
 }
 
-exports.deleteAssets = async function(assetIds, userObject) {
-  const sqlDelete = `UPDATE asset SET state = "disabled", stateDate = NOW(), stateUserId = ? where assetId IN ?`
-  await dbUtils.pool.query(sqlDelete, [userObject.userId, [assetIds]])
-  // changes above might have affected need for records in collection_rev_map 
-  await dbUtils.pruneCollectionRevMap()
-  await dbUtils.updateDefaultRev(null, {})
+exports.deleteAssets = async function(assetIds, userObject, svcStatus = {}) {
+
+  let connection
+  try{
+    connection = await dbUtils.pool.getConnection()
+    async function transaction () {
+      await connection.query('START TRANSACTION')
+      const sqlDelete = `UPDATE asset SET state = "disabled", stateDate = NOW(), stateUserId = ? where assetId IN ?`
+      await connection.query(sqlDelete, [userObject.userId, [assetIds]])
+      // changes above might have affected need for records in collection_rev_map 
+      await dbUtils.pruneCollectionRevMap(connection)
+      await dbUtils.updateDefaultRev(connection, {})
+      await connection.commit()
+    }
+    await dbUtils.retryOnDeadlock(transaction, svcStatus)
+  }
+  catch (err) {
+    if (typeof connection !== 'undefined') {
+      await connection.rollback()
+    }
+    throw ( {status: 500, message: err.message, stack: err.stack} )
+  }
+  finally {
+    if (typeof connection !== 'undefined') {
+      await connection.release()
+    }
+  }
 }
 
 exports.attachStigToAsset = async function( {assetId, benchmarkId, collectionId, elevate, userObject, svcStatus = {}} ) {
@@ -1388,26 +1430,69 @@ exports.attachStigToAsset = async function( {assetId, benchmarkId, collectionId,
   }
 }
 
-exports.removeStigFromAsset = async function (assetId, benchmarkId, elevate, userObject ) {
-  const sqlDelete = `DELETE FROM stig_asset_map where assetId = ? and benchmarkId = ?`
-  await dbUtils.pool.query(sqlDelete, [assetId, benchmarkId])
-  const rows = await _this.queryStigsByAsset( {
-    assetId: assetId
-  }, elevate, userObject)
-  // changes above might have affected need for records in collection_rev_map 
-  await dbUtils.pruneCollectionRevMap()
-  await dbUtils.updateDefaultRev(null, {})
-  return (rows)
+exports.removeStigFromAsset = async function (assetId, benchmarkId, elevate, userObject, svcStatus = {}) {
+  
+  let connection
+  try{
+    connection = await dbUtils.pool.getConnection()
+    async function transaction () {
+      connection.query('START TRANSACTION')
+      const sqlDelete = `DELETE FROM stig_asset_map where assetId = ? and benchmarkId = ?`
+      await connection.query(sqlDelete, [assetId, benchmarkId])
+      // changes above might have affected need for records in collection_rev_map
+      const rows = await _this.queryStigsByAsset( {
+        assetId: assetId
+      }, elevate, userObject)
+      await dbUtils.pruneCollectionRevMap(connection)
+      await dbUtils.updateDefaultRev(connection, {})
+      await connection.commit()
+      return (rows)
+    }
+    return await dbUtils.retryOnDeadlock(transaction, svcStatus)
+  }
+  catch (err) {
+    if (typeof connection !== 'undefined') {
+      await connection.rollback()
+    }
+    throw ( {status: 500, message: err.message, stack: err.stack} )
+  }
+  finally {
+    if (typeof connection !== 'undefined') {
+      await connection.release()
+    }
+  }
 }
 
-exports.removeStigsFromAsset = async function (assetId, elevate, userObject ) {
-  const sqlDelete = `DELETE FROM stig_asset_map where assetId = ?`
-  await dbUtils.pool.query(sqlDelete, [assetId])
-  const rows = await _this.queryStigsByAsset( {assetId: assetId}, elevate, userObject)
-  // changes above might have affected need for records in collection_rev_map 
-  await dbUtils.pruneCollectionRevMap()
-  await dbUtils.updateDefaultRev(null, {})
-  return (rows)
+exports.removeStigsFromAsset = async function (assetId, elevate, userObject, svcStatus = {}) {
+
+  let connection
+
+  try{
+    connection = await dbUtils.pool.getConnection()
+    async function transaction () {
+      await connection.query('START TRANSACTION')
+      const sqlDelete = `DELETE FROM stig_asset_map where assetId = ?`
+      await connection.query(sqlDelete, [assetId])
+      
+      // changes above might have affected need for records in collection_rev_map
+      await dbUtils.pruneCollectionRevMap(connection)
+      await dbUtils.updateDefaultRev(connection, {})
+      await connection.commit()
+    }
+    await dbUtils.retryOnDeadlock(transaction, svcStatus)
+    return await _this.queryStigsByAsset( {assetId: assetId}, elevate, userObject)
+  }
+  catch (err) {
+    if (typeof connection !== 'undefined') {
+      await connection.rollback()
+    }
+    throw ( {status: 500, message: err.message, stack: err.stack} )
+  }
+  finally {
+    if (typeof connection !== 'undefined') {
+      await connection.release()
+    }
+  }
 }
 
 exports.deleteAssetStigGrant = async function (assetId, benchmarkId, userId, elevate, userObject ) {

--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -1609,6 +1609,9 @@ exports.attachAssetsToStig = async function(collectionId, benchmarkId, assetIds,
         await connection.query(sqlInsertBenchmarks, [ binds ])
       }
 
+      // changes above might have affected need for records in collection_rev_map 
+      await dbUtils.pruneCollectionRevMap(connection)
+
       await dbUtils.updateDefaultRev(connection, {
         collectionId: collectionId,
         benchmarkId: benchmarkId
@@ -1618,8 +1621,7 @@ exports.attachAssetsToStig = async function(collectionId, benchmarkId, assetIds,
         benchmarkId: benchmarkId
       })
 
-      // changes above might have affected need for records in collection_rev_map 
-      await dbUtils.pruneCollectionRevMap(connection)
+  
 
       // Commit the changes
       await connection.commit()

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -4114,16 +4114,16 @@ components:
       properties:
         assetIds:
           type: array
+          minItems: 1
           items:
             $ref: '#/components/schemas/AssetId'
-            minItems: 1
         operation:
           type: string
           enum:
             - delete
-        required:
-          - assetIds
-          - operation
+      required:
+        - assetIds
+        - operation
     AssetsPatchResponse:
       additionalProperties: false
       type: object

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -4116,10 +4116,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AssetId'
+            minItems: 1
         operation:
           type: string
           enum:
             - delete
+        required:
+          - assetIds
+          - operation
     AssetsPatchResponse:
       additionalProperties: false
       type: object


### PR DESCRIPTION
Resolves: #1370 
This PR updates the following functions to implement transaction handling:
- removeStigsFromAsset
- removeStigFromAsset
- deleteAsset
- deleteAssets

Also, attachAssetsToStig was edited to call pruneCollectionRevMap prior to updateDefaultRev.

note: removeStigsFromAsset will never return data as it is. If we want to return the stigs deleted the call to queryStigsByAsset should be made before stig_asset_map deleting occurs. 