### PR TITLE
feat: handle duplicate CCI reference elements in benchmark rules

### DIFF
--- a/api/source/service/STIGService.js
+++ b/api/source/service/STIGService.js
@@ -654,7 +654,7 @@ exports.insertManualBenchmark = async function (b, clobber, svcStatus = {}) {
         binds: []
       },
       revGroupRuleCciMap: {
-        sql: `INSERT INTO rev_group_rule_cci_map (rgrId, cci)
+        sql: `INSERT IGNORE INTO rev_group_rule_cci_map (rgrId, cci)
           SELECT 
             rgr.rgrId,
             tt.cci


### PR DESCRIPTION
Support for importing Benchmarks with duplicate CCI reference elements, as discussed in #1412.