### PR TITLE
fix: ensure integer size when fractional scaling

### DIFF
--- a/client/src/js/overrides.js
+++ b/client/src/js/overrides.js
@@ -1269,7 +1269,7 @@ Ext.Element.prototype.addStyles = function(sides, styles){
     for (i = 0; i < len; i++) {
         side = sidesArr[i];
         // replace parseInt call with parseFloat to account for fractional scaling
-        size = side && parseFloat(this.getStyle(styles[side]));
+        size = side && Math.round(parseFloat(this.getStyle(styles[side])));
         if (size) {
             ttlSize += Math.abs(size);
         }


### PR DESCRIPTION
Improves the local ExtJS override that addresses fractional scaling issues in the browser. Rounds any floating point value to an integer. This fixes border clipping issues seen in current and new development code.