### PR TITLE
Use JSON.stringify to escape value for mysql when GET assets called with metadata key:value filter

### DIFF
--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -209,7 +209,7 @@ exports.queryAssets = async function (inProjection = [], inPredicates = {}, elev
     for (const pair of inPredicates.metadata) {
       const [key, value] = pair.split(/:(.*)/s)
       predicates.statements.push('JSON_CONTAINS(a.metadata, ?, ?)')
-      predicates.binds.push( `"${value}"`,  `$.${key}`)
+      predicates.binds.push( `${JSON.stringify(value)}`,  `$.${key}`)
     }
   }
   predicates.statements.push('cg.userId = ?')


### PR DESCRIPTION
get assets called with a metadata key:value pair with a single backslash in the value is causing mysql to return ER_INVALID_JSON_TEXT_IN_PARAM.

Resolved w/ JSON.stringify and removing outer double quotes from string construction (since stringify adds them).
Resolves: #1436 , originally identified in Watcher repo: https://github.com/NUWCDIVNPT/stigman-watcher/issues/141