### PR TITLE
feat: detailed status during web app bootstrap; handle token errors

### DIFF
--- a/client/src/js/init.js
+++ b/client/src/js/init.js
@@ -1,6 +1,12 @@
 import { stylesheets, scripts, isMinimizedSource } from './resources.js'
 import * as OP from './modules/oidcProvider.js'
+
+const statusEl = document.getElementById("loading-text")
 window.oidcProvider = OP
+
+function appendStatus(html) {
+  statusEl.innerHTML += `${statusEl.innerHTML ? '<br/><br/>' : ''}${html}`
+}
 
 function getScopeStr() {
   const scopePrefix = STIGMAN.Env.oauth.scopePrefix
@@ -56,19 +62,23 @@ async function authorizeOidc() {
       scope: getScopeStr()
     })
     if (tokens) {
+      appendStatus(`Loading App ${STIGMAN?.Env?.version}`)
       loadResources()
     }
   }
   catch (e) {
-    document.getElementById("loading-text").innerHTML = e.message
+    appendStatus(e.message)
   }
 }
 
 if (window.isSecureContext) {
-  document.getElementById("loading-text").innerHTML = `Loading ${STIGMAN?.Env?.version}`
+  appendStatus(`Authorizing`)
   authorizeOidc()
 }
 else {
-  document.getElementById("loading-text").innerHTML = `SECURE CONTEXT REQUIRED<br><br>The App is not executing in a <a href=https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts target="_blank">secure context</a> and cannot continue. <br><br>To be considered secure, resources that are not local must be served over https:// URLs and the security properties of the network channel used to deliver the resource must not be considered deprecated.`
+  appendStatus(`SECURE CONTEXT REQUIRED<br><br>
+    The App is not executing in a <a href=https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts target="_blank">secure context</a> and cannot continue.
+    <br><br>To be considered secure, resources that are not local must be served over https:// URLs and the security 
+    properties of the network channel used to deliver the resource must not be considered deprecated.`)
 }
 

--- a/client/src/js/modules/oidcProvider.js
+++ b/client/src/js/modules/oidcProvider.js
@@ -188,6 +188,7 @@ function getTokenRequestBody(code, redirectUri) {
     // perhaps from a bookmarked URL of an earlier authorization request.
     // Try to restart authorization from the beginning by redirecting to our entry point.
     window.location.href = redirectUri
+    throw new Error('Redirecting after not finding code verifier')
   }
   const params = new URLSearchParams()
   params.append('code', code)

--- a/client/src/js/modules/oidcProvider.js
+++ b/client/src/js/modules/oidcProvider.js
@@ -52,11 +52,14 @@ function setTokens(tokens, clientTime) {
   state.tokens = tokens
   token = state.tokens.access_token
   refreshToken = state.tokens.refresh_token
+
   tokenParsed = decodeToken(token)
   refreshTokenParsed = decodeToken(refreshToken)
+  
   state.timeSkew = clientTime ? Math.floor(clientTime / 1000) - tokenParsed.iat : 0
   console.log('[OIDCPROVIDER] Estimated time difference between browser and server is ' + state.timeSkew + ' seconds')
   console.log('[OIDCPROVIDER] Token expires ' + new Date(tokenParsed.exp * 1000))
+  
   const tokenExpiresIn = (tokenParsed.exp - (new Date().getTime() / 1000) + state.timeSkew) * 1000
   if (tokenExpiresIn <= 0) {
     expiredCallback()
@@ -67,6 +70,7 @@ function setTokens(tokens, clientTime) {
     }
     state.tokenTimeoutHandle = setTimeout(expiredCallback, tokenExpiresIn)
   }
+
   if (state.autoRefresh && refreshToken) {
     const now = new Date().getTime()
     const expiration = refreshTokenParsed ? refreshTokenParsed.exp : tokenParsed.exp
@@ -158,6 +162,10 @@ async function requestToken(body) {
     method: 'post',
     body
   })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(text)
+  }
   return response.json()
 }
 
@@ -168,18 +176,29 @@ async function requestRefresh() {
     body
   })
   if (!response.ok) {
-    throw new Error()
+    const text = await response.text()
+    throw new Error(text)
   }
   return response.json()
 }
 
 function getTokenRequestBody(code, redirectUri) {
+  if (!localStorage.getItem('oidc-code-verifier')) {
+    // Will assume this function was called while handling a replayed request,
+    // perhaps from a bookmarked URL of an earlier authorization request.
+    // Try to restart authorization from the beginning by redirecting to our entry point.
+    window.location.href = redirectUri
+  }
   const params = new URLSearchParams()
   params.append('code', code)
   params.append('grant_type', 'authorization_code')
   params.append('client_id', state.clientId)
   params.append('redirect_uri', redirectUri)
   params.append('code_verifier', localStorage.getItem('oidc-code-verifier'))
+  
+  // Clear saved code verifier to prevent replay error scenarios
+  localStorage.removeItem('oidc-code-verifier')
+  
   return params
 }
 
@@ -215,6 +234,8 @@ async function getAuthorizationUrl() {
   params.append('code_challenge_method', 'S256')
 
   const authEndpoint = state.oidcConfiguration.authorization_endpoint
+
+  // Save the code verifier for use after the OP redirect back to us
   localStorage.setItem('oidc-code-verifier', pkce.codeVerifier)
 
   return `${authEndpoint}?${params.toString()}`

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -28,24 +28,22 @@ Ext.Ajax.disableCaching = false
 
 async function start () {
 	let timer
+	const el = Ext.get('loading-text').dom
+
 	try {
 		if ('serviceWorker' in navigator) {
 			await navigator.serviceWorker.register('serviceWorker.js')
 		}
-		timer = setTimeout(() => {
-			Ext.get( 'loading-text' ).dom.innerHTML = "Getting configuration..."
-		}, 250)
+		el.innerHTML += "<br/><br/>Fetching user data"
 		await SM.GetUserObject()
 		if (curUser.username !== undefined) {
-			clearTimeout(timer)
 			loadApp();
 		} else {
-			Ext.get( 'loading-text' ).dom.innerHTML =`No account for ${window.oidcProvider.token}`;
+			el.innerHTML += `<br/>No account for ${window.oidcProvider.token}`
 		}
 	}
 	catch (e) {
-		clearTimeout(timer)
-		Ext.get( 'loading-text' ).dom.innerHTML = e.message
+		el.innerHTML += `<br/>${e.message}`
 	}
 }
 

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -27,7 +27,6 @@ function myContextMenu (e,t,eOpts) {
 Ext.Ajax.disableCaching = false
 
 async function start () {
-	let timer
 	const el = Ext.get('loading-text').dom
 
 	try {

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -34,7 +34,13 @@ async function start () {
 			await navigator.serviceWorker.register('serviceWorker.js')
 		}
 		el.innerHTML += "<br/><br/>Fetching user data"
-		await SM.GetUserObject()
+		try {
+			await SM.GetUserObject()
+		}
+		catch (e) {
+			el.innerHTML += `<br/><br/>Error Fetching user data`
+			throw(e)
+		}
 		if (curUser.username !== undefined) {
 			loadApp();
 		} else {
@@ -42,7 +48,7 @@ async function start () {
 		}
 	}
 	catch (e) {
-		el.innerHTML += `<br/>${e.message}`
+		el.innerHTML += `<br/></br/><textarea rows=12 cols=80 style="font-size: 10px" readonly>${JSON.stringify(STIGMAN.serializeError(e), null, 2)}</textarea>`
 	}
 }
 


### PR DESCRIPTION
Resolves #1447 

`init.js` and `stigman.js` were updated to display concatenated status messages during the bootstrap phases 1) authorization, 2) app loading, and 3) initial API request for `/user`.

`OIDCProvider.js` was updated to throw on errors from the `token` endpoint. Also, the stored PKCE code verifier is now removed after being used for the token request. Before making the token request, OIDCProvider now checks if the stored code verifier exists. If not, it restarts the authorization phase by redirecting back to the base URL.

These updates appear to handle the scenario where a user has bookmarked our authorization request while viewing the OP login page, and later uses this bookmark.

Handling of the API request to `/user` was not modified, it uses our common routine for making API requests which does not support retry rounds.

Token inspection was not added because token issues should result in an API error response, which is already being displayed by the web app.