### PR TITLE
feat: save pkce code verifier/challenge for debugging

### DIFF
--- a/client/src/js/modules/oidcProvider.js
+++ b/client/src/js/modules/oidcProvider.js
@@ -195,10 +195,13 @@ function getTokenRequestBody(code, redirectUri) {
   params.append('grant_type', 'authorization_code')
   params.append('client_id', state.clientId)
   params.append('redirect_uri', redirectUri)
-  params.append('code_verifier', localStorage.getItem('oidc-code-verifier'))
+  const codeVerifier = localStorage.getItem('oidc-code-verifier')
+  params.append('code_verifier', codeVerifier)
   
   // Clear saved code verifier to prevent replay error scenarios
   localStorage.removeItem('oidc-code-verifier')
+  // Save last used verifier for debugging purposes
+  localStorage.setItem('last-code-verifier', codeVerifier)
   
   return params
 }
@@ -238,6 +241,8 @@ async function getAuthorizationUrl() {
 
   // Save the code verifier for use after the OP redirect back to us
   localStorage.setItem('oidc-code-verifier', pkce.codeVerifier)
+  // Save the code challenge for debugging purposes
+  localStorage.setItem('last-code-challenge', pkce.codeChallenge)
 
   return `${authEndpoint}?${params.toString()}`
 }


### PR DESCRIPTION
In `oidcProvider.js`, persist to localStorage the values of the last used PKCE `code_verifier` and `code_challenge`. This might help in debugging esoteric issues as reported in #1440.

The last used values can be found using DevTools or a JS console to view localStorage items `last-code-verifier` and `last-code-challenge`. The `last-code-challenge` should be the URL encoded Base64 representation of the SHA256 digest of `last-code-verifier`.

In a Linux shell, the proper code challenge for a given `last-code-verifier` can be calculated by invoking:
```shell
echo -n "<last-code-verifier>" | sha256sum | xxd -r -p | base64 | tr '+/' '-_' | tr -d '='
```