### PR TITLE
feat: test oidc state before token request

### DIFF
--- a/client/src/js/modules/oidcProvider.js
+++ b/client/src/js/modules/oidcProvider.js
@@ -38,7 +38,7 @@ async function authorize({clientId, oidcProvider, scope, autoRefresh}) {
       tokens = await requestToken(tokenRequestBody)
     }
     catch (e) {
-      e.message = `<textarea rows="10" cols="80" style="font-size: 8px;">Error:\n${e.message}\n\nContext:\n${JSON.stringify(lastOidc, null, 2)}</textarea><br><br><a href="${redirectUrl}">Retry authorization.</a>`
+      e.message = `<textarea readonly wrap="off" rows="18" cols="80" style="font-size: 8px;">Error:\n${e.message}\n\nContext:\n${JSON.stringify(lastOidc, null, 2)}</textarea><br><br><a href="${redirectUrl}">Retry authorization.</a>`
       throw e
     }
     const clientTime = (beforeTime + new Date().getTime()) / 2

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -48,7 +48,7 @@ async function start () {
 		}
 	}
 	catch (e) {
-		el.innerHTML += `<br/></br/><textarea rows=12 cols=80 style="font-size: 10px" readonly>${JSON.stringify(STIGMAN.serializeError(e), null, 2)}</textarea>`
+		el.innerHTML += `<br/></br/><textarea wrap="off" rows=12 cols=80 style="font-size: 10px" readonly>${JSON.stringify(STIGMAN.serializeError(e), null, 2)}</textarea>`
 	}
 }
 


### PR DESCRIPTION
In `oidcProvider.js`:
- when redirecting to the OP authorization endpoint, store the `state` value we generated along with the PKCE code challenge we sent and the associated code verifier. 
- when processing the OP's redirected authorization code response, test whether the OP `state` matches our last stored `state`. If it does, continue with a token request using the stored code verifier. If it does not, display an error and offer to restart the authorization flow.
- If the token request fails, display a textarea with context details including the saved PKCE data, the full authorization request, the OP's authorization code redirect URL, and the full token request body.

This might help in debugging esoteric issues as reported in #1440. The PKCE values can be found using DevTools or a JS console to view localStorage item `last-oidc`. The `pkce.codeChallenge` should be the URL encoded Base64 representation of the SHA256 digest of `pkce.codeVerifier`.

In a Linux shell, the proper code challenge for a given `pkce.codeVerifier` can be calculated by invoking:
```shell
echo -n "<pkce.codeVerifier>" | sha256sum | xxd -r -p | base64 | tr '+/' '-_' | tr -d '='
```