### PR TITLE
fix: handle spaces in benchmarkId when used in class name

### DIFF
--- a/client/src/js/collectionReview.js
+++ b/client/src/js/collectionReview.js
@@ -6,7 +6,7 @@ $Id: collectionReview.js 885 2018-02-20 16:26:08Z bmassey $
 async function addCollectionReview ( params ) {
 	let { leaf, selectedRule, selectedAsset, treePath } = params
 	try {
-		var idAppend = '-' + leaf.collectionId + '-' + leaf.benchmarkId.replace(".","_");
+		var idAppend = '-' + leaf.collectionId + '-' + leaf.benchmarkId.replace(/[. ]/g,'_');
 		const tab = Ext.getCmp('main-tab-panel').getItem('collection-review-tab' + idAppend);
 		if (tab) {
 			tab.show()

--- a/client/src/js/review.js
+++ b/client/src/js/review.js
@@ -1,6 +1,6 @@
 async function addReview( params ) {
   let { leaf, selectedRule, selectedResource, treePath, dblclick = false } = params
-  const idAppend = '-' + leaf.assetId + '-' + leaf.benchmarkId.replace(".", "_");
+  const idAppend = '-' + leaf.assetId + '-' + leaf.benchmarkId.replace(/[. ]/g,'_');
   const tab = Ext.getCmp('main-tab-panel').getItem('reviewTab' + idAppend);
   if (tab) {
     if (dblclick) {


### PR DESCRIPTION
Resolves the bug discussed in #1463 

Replace spaces in benchmarkId with `_` when using it as an identifier that becomes part of class name string.