### PR TITLE
Add retry logic to getKeys

### DIFF
--- a/api/source/utils/auth.js
+++ b/api/source/utils/auth.js
@@ -103,17 +103,6 @@ const getBearerToken = req => {
     if (headerParts[0].toLowerCase() === 'bearer') return headerParts[1]
 }
 
-// function getKey(header, callback){
-//     client.getSigningKey(header.kid, function(err, key) {
-//         if (!err) {
-//             let signingKey = key.publicKey || key.rsaPublicKey
-//             callback(null, signingKey)
-//         } else {
-//             callback(err, null)
-//         }
-//     })
-// }
-
 async function getKey(header, callback) {
     async function fetchSigningKey() {
         return await new Promise((resolve, reject) => {


### PR DESCRIPTION
addresses intermittent errors caused by failure of the api to fetch keycloak jwks_uri (ie. when keycloak is briefly inacessible)