### PR TITLE
refactor: verifyRequest => validateOauthSecurity

### DIFF
--- a/api/source/index.js
+++ b/api/source/index.js
@@ -97,7 +97,10 @@ app.use((req, res, next) => {
   }
 })
 
-const apiSpecPath = path.join(__dirname, './specification/stig-manager.yaml');
+app.use('/api', auth.validateToken)
+app.use('/api', auth.setupUser)
+
+const apiSpecPath = path.join(__dirname, './specification/stig-manager.yaml')
 app.use( "/api", openApiMiddleware ({
   apiSpec: apiSpecPath,
   validateRequests: {
@@ -115,7 +118,7 @@ app.use( "/api", openApiMiddleware ({
   },
   validateSecurity: {
     handlers:{
-      oauth: auth.verifyRequest 
+      oauth: auth.validateOauthSecurity 
     }
   },
   fileUploader: false

--- a/api/source/utils/error.js
+++ b/api/source/utils/error.js
@@ -54,7 +54,48 @@ class UnprocessableError extends SmError {
 class InternalError extends SmError {
   constructor(error) {
     super(error.message)
+    this.status = 422
     this.detail = { error }
+  }
+}
+
+class OIDCProviderError extends SmError {
+  constructor(detail) {
+    super('OIDC Provider is unreachable, unable to validate tokens.')
+    this.status = 503
+    this.detail = detail
+  }
+}
+
+class NoTokenError extends SmError {
+  constructor(detail) {
+    super('Request requires an access token.')
+    this.status = 401
+    this.detail = detail
+  }
+}
+
+class OutOfScopeError extends SmError {
+  constructor(detail) {
+    super('Required scopes were not found in token.')
+    this.status = 403
+    this.detail = detail
+  }
+}
+
+class ElevationError extends SmError {
+  constructor(detail) {
+    super('Request requires parameter elevate=true.')
+    this.status = 403
+    this.detail = detail
+  }
+}
+
+class InvalidElevationError extends SmError {
+  constructor(detail) {
+    super('Invalid use of parameter elevate=true.')
+    this.status = 403
+    this.detail = detail
   }
 }
 
@@ -65,5 +106,10 @@ module.exports = {
   NotFoundError,
   ClientError,
   UnprocessableError,
+  OIDCProviderError,
+  NoTokenError,
+  OutOfScopeError,
+  ElevationError,
+  InvalidElevationError,
   InternalError 
 }

--- a/api/source/utils/error.js
+++ b/api/source/utils/error.js
@@ -54,15 +54,23 @@ class UnprocessableError extends SmError {
 class InternalError extends SmError {
   constructor(error) {
     super(error.message)
-    this.status = 422
+    this.status = 500
     this.detail = { error }
   }
 }
 
 class OIDCProviderError extends SmError {
   constructor(detail) {
-    super('OIDC Provider is unreachable, unable to validate tokens.')
+    super('OIDC Provider is unreachable, unable to validate token.')
     this.status = 503
+    this.detail = detail
+  }
+}
+
+class SigningKeyNotFoundError extends SmError {
+  constructor(detail) {
+    super('Unknown signing key, unable to validate token.')
+    this.status = 403
     this.detail = detail
   }
 }
@@ -107,6 +115,7 @@ module.exports = {
   ClientError,
   UnprocessableError,
   OIDCProviderError,
+  SigningKeyNotFoundError,
   NoTokenError,
   OutOfScopeError,
   ElevationError,


### PR DESCRIPTION
Resolves #1482 

The existing `verifyRequest()` does too much work for a utility function (non-middleware) attached to EOV:

- validates tokens
- creates the request's userObject property
- creates/updates a user's lastClaims
- checks for improper use of the parameter `elevate=true`
- checks scopes for the request

This PR separates these tasks into two new Express middlewares and limits the renamed EOV utility function to checking scopes.

As far as handling OP outages, the current code actually does a fair job with that. There are three scenarios to handle:

1. OP host is gone (connection requests are ignored)
2. OP host is up but OP service is down (connection requests are actively refused by host OS)
3. OP host and service are up but are slow or unresponsive (connections accepted but slow/no data flows)

In real-world testing, the current code and this PR both handle scenario 2 well, although the error message has been improved in this PR. Scenarios 1 and 3 are handled better by this PR since the timeouts for the JWKS request were reduced from 30s to 5s.

Recommend refactoring our JWKS key fetch/cache/log/retrieve operations and consider moving much of it to local code and remove the `jwks-rsa` dependency. But that's for another day.