### PR TITLE
feat: add workflow_call to build-binary-artifacts.yml

### DIFF
--- a/.github/workflows/build-binary-artifacts.yml
+++ b/.github/workflows/build-binary-artifacts.yml
@@ -1,6 +1,7 @@
 
 name: Build Binary Artifacts and Sign
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
This PR adds `workflow_call` as a trigger to `build-binary-artifacts.yml`. This makes it callable from other workflows. 