### PR TITLE
fix: add ruleIds to ReviewAssetRuleRead; remove String255 references

### DIFF
--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -6847,6 +6847,10 @@ components:
           $ref: '#/components/schemas/ResultEngine'
         rule:
           $ref: '#/components/schemas/RuleAbbr'
+        ruleIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuleId'
         status:
           $ref: '#/components/schemas/ReviewStatusRead'
         stigs:
@@ -6937,7 +6941,7 @@ components:
         ruleIds:
           type: array
           items:
-            $ref: '#/components/schemas/String255'
+            $ref: '#/components/schemas/RuleId'
           maxItems: 500
           minItems: 1
           uniqueItems: true
@@ -7274,7 +7278,7 @@ components:
         ruleIds:
           type: array
           items:
-            $ref: '#/components/schemas/String255'
+            $ref: '#/components/schemas/RuleId'
         status:
           $ref: '#/components/schemas/ReviewStatusRead'
         stigs:


### PR DESCRIPTION
To match the API response, adds the `ruleIds` property to ReviewAssetRuleRead.

Changes `ruleId` references from `String255` => `RuleId`. 

This PR keeps `RuleId` as a ref to `String45Nullable`, but I questioned whether that should change to `String45` and there be a separate `RuleIdNullable` that uses `String45Nullable`. But that means sorting out where ruleId might be null, and that's beyond what this PR was for.