### PR TITLE
Feat: Adds application managers to home screen controlled by env var

### DIFF
--- a/api/launchers/stig-manager.bat
+++ b/api/launchers/stig-manager.bat
@@ -81,7 +81,7 @@
 ::==============================================================================
 :: STIGMAN_CLIENT_DISPLAY_APPMANAGERS
 ::
-::  | Default:  "false" | Set to "true" to display application manager names
+::  | Default:  "true" | Set to "false" to hide application manager names
 ::   along with their email addresses on the Stig-Manager home page.
 ::
 ::  Affects: Client

--- a/api/launchers/stig-manager.bat
+++ b/api/launchers/stig-manager.bat
@@ -79,6 +79,16 @@
 :: set STIGMAN_CLIENT_DISABLED=
 
 ::==============================================================================
+:: STIGMAN_CLIENT_DISPLAY_APPMANAGERS
+::
+::  | Default:  "false" | Set to "true" to display application manager names
+::   along with their email addresses on the Stig-Manager home page.
+::
+::  Affects: Client
+::==============================================================================
+:: set STIGMAN_CLIENT_DISPLAY_APPMANAGERS=
+
+::==============================================================================
 :: STIGMAN_CLIENT_EXTRA_SCOPES
 ::
 ::  | No default. | A space separated list of OAuth2 scopes to request in

--- a/api/launchers/stig-manager.sh
+++ b/api/launchers/stig-manager.sh
@@ -78,6 +78,16 @@
 # export STIGMAN_CLIENT_DISABLED=
 
 #==============================================================================
+# STIGMAN_CLIENT_DISPLAY_APPMANAGERS
+#
+#  | Default:  "false" | Set to "true" to display application manager names
+#   along with their email addresses on the Stig-Manager home page.
+#
+#  Affects: Client
+#==============================================================================
+# set STIGMAN_CLIENT_DISPLAY_APPMANAGERS=
+
+#==============================================================================
 # STIGMAN_CLIENT_EXTRA_SCOPES
 #
 #  | No default. | A space separated list of OAuth2 scopes to request in

--- a/api/launchers/stig-manager.sh
+++ b/api/launchers/stig-manager.sh
@@ -80,7 +80,7 @@
 #==============================================================================
 # STIGMAN_CLIENT_DISPLAY_APPMANAGERS
 #
-#  | Default:  "false" | Set to "true" to display application manager names
+#  | Default:  "true" | Set to "false" to hide application manager names
 #   along with their email addresses on the Stig-Manager home page.
 #
 #  Affects: Client

--- a/api/source/controllers/User.js
+++ b/api/source/controllers/User.js
@@ -120,11 +120,12 @@ module.exports.getUsers = async function getUsers (req, res, next) {
     let elevate = req.query.elevate
     let username = req.query.username
     let usernameMatch = req.query['username-match']
+    let privilege = req.query['privilege']
     let projection = req.query.projection
     if ( !elevate && projection?.length > 0) {
       throw new SmError.PrivilegeError()
     }
-    let response = await UserService.getUsers( username, usernameMatch, projection, elevate, req.userObject)
+    let response = await UserService.getUsers( username, usernameMatch, privilege, projection, elevate, req.userObject)
     res.json(response)
   }
   catch(err) {

--- a/api/source/index.js
+++ b/api/source/index.js
@@ -200,6 +200,7 @@ const STIGMAN = {
   Env: {
     version: "${config.version}",
     apiBase: "${config.client.apiBase}",
+    displayAppManagers: ${config.client.displayAppManagers},
     welcome: {
       image: "${config.client.welcome.image}",
       title: "${config.client.welcome.title.replace(/"/g, '\\"')}",

--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stig-management-api",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stig-management-api",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stig-management-api",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "An API for managing evaluations of Security Technical Implementation Guide (STIG) assessments.",
   "main": "index.js",
   "scripts": {

--- a/api/source/service/UserService.js
+++ b/api/source/service/UserService.js
@@ -109,6 +109,15 @@ exports.queryUsers = async function (inProjection, inPredicates, elevate, userOb
     predicates.statements.push(`ud.username ${matchStr}`)
     predicates.binds.push(inPredicates.username)
   }
+  
+  if (inPredicates.privilege) {
+    predicates.statements.push(
+      `JSON_CONTAINS(JSON_EXTRACT(ud.lastClaims, ?), ?) `
+    )
+    predicates.binds.push(`$.${config.oauth.claims.privilegesPath}`, JSON.stringify([inPredicates.privilege]))
+  }
+  
+  
   if (needsCollectionGrantees) {
     ctes.push(dbUtils.sqlGrantees({userId: inPredicates.userId, username: inPredicates.username, returnCte: true}))
   }
@@ -293,11 +302,12 @@ exports.getUserByUsername = async function(username, projection, elevate, userOb
   }
 }
 
-exports.getUsers = async function(username, usernameMatch, projection, elevate, userObject) {
+exports.getUsers = async function(username, usernameMatch, privilege, projection, elevate, userObject) {
   try {
     let rows = await _this.queryUsers( projection, {
       username: username,
-      usernameMatch: usernameMatch
+      usernameMatch: usernameMatch,
+      privilege: privilege
     }, elevate, userObject)
     return (rows)
   }

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -3855,6 +3855,7 @@ paths:
       operationId: getUsers
       parameters:
         - $ref: '#/components/parameters/UsernameQuery'
+        - $ref: '#/components/parameters/PrivilegeQuery'
         - $ref: '#/components/parameters/UsernameMatchQuery'
       responses:
         '200':
@@ -8377,6 +8378,15 @@ components:
           - EMASS
           - MCCAST
         default: EMASS
+    PrivilegeQuery:
+      name: privilege
+      in: query
+      description: Selects Users with the specified privilege
+      schema:
+        type: string
+        enum:
+          - admin
+          - create_collection
     RetentionDateQuery:
       name: retentionDate
       in: query

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -6848,6 +6848,10 @@ components:
           $ref: '#/components/schemas/ResultEngine'
         rule:
           $ref: '#/components/schemas/RuleAbbr'
+        ruleIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuleId'
         status:
           $ref: '#/components/schemas/ReviewStatusRead'
         stigs:
@@ -6938,7 +6942,7 @@ components:
         ruleIds:
           type: array
           items:
-            $ref: '#/components/schemas/String255'
+            $ref: '#/components/schemas/RuleId'
           maxItems: 500
           minItems: 1
           uniqueItems: true
@@ -7275,7 +7279,7 @@ components:
         ruleIds:
           type: array
           items:
-            $ref: '#/components/schemas/String255'
+            $ref: '#/components/schemas/RuleId'
         status:
           $ref: '#/components/schemas/ReviewStatusRead'
         stigs:

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -18,7 +18,7 @@ const config = {
     },
     client: {
         clientId: process.env.STIGMAN_CLIENT_ID || "stig-manager",
-        displayAppManagers: process.env.STIGMAN_CLIENT_DISPLAY_APPMANAGERS === "true",
+        displayAppManagers: process.env.STIGMAN_CLIENT_DISPLAY_APPMANAGERS || "true",
         authority: process.env.STIGMAN_CLIENT_OIDC_PROVIDER || process.env.STIGMAN_OIDC_PROVIDER || "http://localhost:8080/realms/stigman",
         apiBase: process.env.STIGMAN_CLIENT_API_BASE || "api",
         disabled: process.env.STIGMAN_CLIENT_DISABLED === "true",

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -18,6 +18,7 @@ const config = {
     },
     client: {
         clientId: process.env.STIGMAN_CLIENT_ID || "stig-manager",
+        displayAppManagers: process.env.STIGMAN_CLIENT_DISPLAY_APPMANAGERS === "true",
         authority: process.env.STIGMAN_CLIENT_OIDC_PROVIDER || process.env.STIGMAN_OIDC_PROVIDER || "http://localhost:8080/realms/stigman",
         apiBase: process.env.STIGMAN_CLIENT_API_BASE || "api",
         disabled: process.env.STIGMAN_CLIENT_DISABLED === "true",

--- a/api/source/utils/log-schema.json
+++ b/api/source/utils/log-schema.json
@@ -129,6 +129,9 @@
                 "clientId": {
                   "type": "string"
                 },
+                "displayAppManagers": {
+                  "type": "boolean"
+                },
                 "authority": {
                   "type": "string"
                 },

--- a/client/build.sh
+++ b/client/build.sh
@@ -111,6 +111,7 @@ uglifyjs \
 'SM/Global.js' \
 'SM/StackTrace.js' \
 'SM/Error.js' \
+'SM/FlexboxLayout.js' \
 'BufferView.js' \
 'SM/EventDispatcher.js' \
 'SM/Cache.js' \

--- a/client/src/css/dark-mode.css
+++ b/client/src/css/dark-mode.css
@@ -2369,6 +2369,10 @@ td.sort-asc, td.sort-desc, td.x-grid3-hd-menu-open, td.x-grid3-hd-over {
     background-color: #2b2e30
 }
 
+.sm-user-list {
+    background-color: #2b2e30;
+}
+
 .sm-home-widget-header {
     background-color: #313537
 }

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -1111,21 +1111,35 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   margin: 10px;
   height: 400px;
   width: 380px;
+}
+
+.sm-scroll-home-widget-body {
+  max-height: 340px; 
   overflow: auto;
+  scrollbar-width: thin;
+  margin-right: 8px;
+  margin-top: 5px;
 }
 
 .sm-user-list {
   list-style: none;
-  margin: 0;
-  background-color: #dedede;
-  max-height: 400px;
-  overflow: auto;
+  max-height: 340px;
+  padding : 0;
+  margin-left: 0;
+
 }
+
 .sm-user-item {
   padding: 3px;
   display: flex;
   align-items: left;
+}
 
+.sm-user-item::before {
+  content: "• ";
+  font-size: 16px;
+  color: #dedede; 
+  margin-right: 3px;
 }
 
 .sm-user-details {

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -2431,4 +2431,6 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
 .sm-flexbox-layout-ct {
 	display: flex;
 	flex-wrap: wrap;
+	overflow: auto;
+	
 }

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -2432,5 +2432,8 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
 	display: flex;
 	flex-wrap: wrap;
 	overflow: auto;
-	
+	scrollbar-width: none;
+}
+.sm-flexbox-layout-ct:hover {
+	scrollbar-width: auto;
 }

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -2448,6 +2448,7 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
 	flex-wrap: wrap;
 	overflow: auto;
 	scrollbar-width: none;
+	align-content: flex-start;
 }
 .sm-flexbox-layout-ct:hover {
 	scrollbar-width: auto;

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -2428,3 +2428,7 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
 .sm-checklist-read {
 	background-color: hsl(330 55% 24% / 1);
 }
+.sm-flexbox-layout-ct {
+	display: flex;
+	flex-wrap: wrap;
+}

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -1110,7 +1110,8 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   border: none;
   margin: 10px;
   height: 400px;
-  width: 380px
+  width: 380px;
+  overflow: auto;
 }
 
 .sm-user-list {
@@ -1118,7 +1119,7 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   margin: 0;
   background-color: #dedede;
   max-height: 400px;
-  overflow-y: auto;
+  overflow: auto;
 }
 .sm-user-item {
   padding: 3px;

--- a/client/src/css/stigman.css
+++ b/client/src/css/stigman.css
@@ -1112,9 +1112,42 @@ td.x-grid3-hd-over .x-grid3-hd-inner {
   height: 400px;
   width: 380px
 }
+
+.sm-user-list {
+  list-style: none;
+  margin: 0;
+  background-color: #dedede;
+  max-height: 400px;
+  overflow-y: auto;
+}
+.sm-user-item {
+  padding: 3px;
+  display: flex;
+  align-items: left;
+
+}
+
+.sm-user-details {
+  display: flex;
+  flex-direction: column;
+  font-size: 13px;
+}
+
+.sm-user-name {
+  font-size: 13px;
+  font-weight: bold;
+}
+
+.sm-user-email {
+  font-size: 11px;
+  font-style: italic;
+}
+
+
 .sm-home-widget-header {
   background-color: #d3d3d3
 }
+
 .sm-home-widget-title {
   padding: 10px 20px;
   font: bold 18px Open Sans,helvetica,sans-serif;

--- a/client/src/js/SM/FlexboxLayout.js
+++ b/client/src/js/SM/FlexboxLayout.js
@@ -1,0 +1,13 @@
+SM.FlexboxLayout = Ext.extend(Ext.layout.ContainerLayout, {
+  onLayout : function(ct, target){
+    target.addClass('sm-flexbox-layout-ct');
+    this.renderAll(ct, target); 
+  },
+  renderItem : function(c, position, target){
+    if(c && !c.rendered){
+        c.render(target);
+        this.configureItem(c);
+    }
+  }
+})
+Ext.Container.LAYOUTS['sm-flexbox'] = SM.FlexboxLayout

--- a/client/src/js/SM/MainPanel.js
+++ b/client/src/js/SM/MainPanel.js
@@ -200,6 +200,66 @@ SM.ResourcesWidget = Ext.extend(Ext.Panel, {
 })
 Ext.reg('sm-home-widget-resources', SM.ResourcesWidget)
 
+SM.DeploymentInfo = Ext.extend(Ext.Panel, {
+  initComponent: function() {
+      const me = this
+      me.userListId = Ext.id()
+
+      const tpl = new Ext.XTemplate(
+       `<div class="sm-home-widget-header">`,
+      `<div class="sm-home-widget-title">Deployment Information</div>`,
+      `</div>`,
+      `<div class="sm-home-widget-text">`,
+      `<div class="sm-home-widget-subtitle">App Managers:</div>`,
+      `<div id="${me.userListId}" class="sm-user-list"></div>`,
+      `</div>`
+        )
+      const config = {
+        tpl: tpl,
+        bodyCssClass: 'sm-home-widget-body',
+        border: false,
+        data: {},
+        autoScroll: false
+      }
+      Ext.apply(this, Ext.apply(this.initialConfig, config))
+      SM.DeploymentInfo.superclass.initComponent.call(this)
+      this.on('afterrender', this.loadDeploymentInfo, this)
+  },
+  loadDeploymentInfo: async function () {
+    const me = this;
+    try {
+      const response = await Ext.Ajax.requestPromise({
+        responseType: 'json',
+        url: `${STIGMAN.Env.apiBase}/users?privilege=admin`,
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json;charset=utf-8' },
+      })
+
+      const userList = Ext.get(me.userListId)
+      if (userList) {
+        const userItems = response
+          .map((user) => {
+            const email = user.email ? user.email : "Email not available"
+            return `
+           <li class="sm-user-item">
+              <div class="sm-user-details">
+                <span class="sm-user-name">${user.displayName}</span>
+                ${user.email 
+                  ? `<span class="sm-user-email">&lt;${user.email}&gt;</span>` 
+                  : `<span class="sm-user-email">No Email Available</span>`}
+              </div>
+          </li>`
+          })
+          .join('')
+        userList.update(`<ul>${userItems}</ul>`)
+      }
+    } catch (e) {
+      SM.Error.handleError(e)
+    }
+  }
+})
+Ext.reg('sm-home-widget-deployment', SM.DeploymentInfo)
+
 SM.StigWidget = Ext.extend(Ext.Panel, {
   initComponent: function() {
       const me = this

--- a/client/src/js/SM/MainPanel.js
+++ b/client/src/js/SM/MainPanel.js
@@ -200,7 +200,7 @@ SM.ResourcesWidget = Ext.extend(Ext.Panel, {
 })
 Ext.reg('sm-home-widget-resources', SM.ResourcesWidget)
 
-SM.DeploymentInfo = Ext.extend(Ext.Panel, {
+SM.ApplicationManagers = Ext.extend(Ext.Panel, {
   initComponent: function() {
       const me = this
       me.userListId = Ext.id()
@@ -221,10 +221,10 @@ SM.DeploymentInfo = Ext.extend(Ext.Panel, {
         autoScroll: false
       }
       Ext.apply(this, Ext.apply(this.initialConfig, config))
-      SM.DeploymentInfo.superclass.initComponent.call(this)
-      this.on('afterrender', this.loadDeploymentInfo, this)
+      SM.ApplicationManagers.superclass.initComponent.call(this)
+      this.on('afterrender', this.loadApplicationManagers, this)
   },
-  loadDeploymentInfo: async function () {
+  loadApplicationManagers: async function () {
     const me = this;
     try {
       const response = await Ext.Ajax.requestPromise({
@@ -256,7 +256,7 @@ SM.DeploymentInfo = Ext.extend(Ext.Panel, {
     }
   }
 })
-Ext.reg('sm-home-widget-deployment', SM.DeploymentInfo)
+Ext.reg('sm-home-widget-app-managers', SM.ApplicationManagers)
 
 SM.StigWidget = Ext.extend(Ext.Panel, {
   initComponent: function() {

--- a/client/src/js/SM/MainPanel.js
+++ b/client/src/js/SM/MainPanel.js
@@ -243,7 +243,7 @@ SM.DeploymentInfo = Ext.extend(Ext.Panel, {
               <div class="sm-user-details">
                 <span class="sm-user-name">${user.displayName}</span>
                 ${user.email 
-                  ? `<span class="sm-user-email">&lt;${user.email}&gt;</span>` 
+                  ? `<span class="sm-user-email">${user.email}</span>` 
                   : `<span class="sm-user-email">No Email Available</span>`}
               </div>
           </li>`

--- a/client/src/js/SM/MainPanel.js
+++ b/client/src/js/SM/MainPanel.js
@@ -234,12 +234,10 @@ SM.DeploymentInfo = Ext.extend(Ext.Panel, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json;charset=utf-8' },
       })
-
       const userList = Ext.get(me.userListId)
       if (userList) {
         const userItems = response
           .map((user) => {
-            const email = user.email ? user.email : "Email not available"
             return `
            <li class="sm-user-item">
               <div class="sm-user-details">
@@ -253,6 +251,7 @@ SM.DeploymentInfo = Ext.extend(Ext.Panel, {
           .join('')
         userList.update(`<ul>${userItems}</ul>`)
       }
+ 
     } catch (e) {
       SM.Error.handleError(e)
     }

--- a/client/src/js/SM/MainPanel.js
+++ b/client/src/js/SM/MainPanel.js
@@ -207,10 +207,9 @@ SM.DeploymentInfo = Ext.extend(Ext.Panel, {
 
       const tpl = new Ext.XTemplate(
        `<div class="sm-home-widget-header">`,
-      `<div class="sm-home-widget-title">Deployment Information</div>`,
+      `<div class="sm-home-widget-title">Application Managers</div>`,
       `</div>`,
       `<div class="sm-home-widget-text">`,
-      `<div class="sm-home-widget-subtitle">App Managers:</div>`,
       `<div id="${me.userListId}" class="sm-user-list"></div>`,
       `</div>`
         )

--- a/client/src/js/SM/MainPanel.js
+++ b/client/src/js/SM/MainPanel.js
@@ -90,18 +90,22 @@ SM.WelcomeWidget = Ext.extend(Ext.Panel, {
           `<div class=sm-home-widget-header>`,
             `<div class='sm-home-widget-title'>Welcome</div>`,
           `</div>`,
-          `<div class='sm-home-widget-text'>`,
-            `<div class=sm-home-widget-image-text-wrap>`,
-              `<img src=${STIGMAN.Env.welcome.image ? `"${STIGMAN.Env.welcome.image}" onerror="this.onerror=null;this.src='img/navy.svg';"` : '"img/navy.svg"'} style="max-width:100%;max-height:100%;"/>`,
-            `</div>`,
-            `<b>STIG Manager</b> is an API and Web client for managing the assessment of Information Systems for compliance with <a href="https://public.cyber.mil/stigs/">security checklists</a> published by the United States Defense Information Systems Agency (DISA). The software is <a target="_blank" href="https://github.com/NUWCDIVNPT/stig-manager">an open source project</a> maintained by the Naval Sea Systems Command (NAVSEA) of the United States Navy.`,
-          `</div>`, 
-          `<div class='sm-home-widget-text'>`,
-            `<div class='sm-home-widget-subtitle'>${STIGMAN.Env.welcome.title ? SM.he(STIGMAN.Env.welcome.title) : STIGMAN.Env.welcome.message || STIGMAN.Env.welcome.link ? 'Support' : ''}</div>`,
-            `${SM.he(STIGMAN.Env.welcome.message)}${STIGMAN.Env.welcome.message && STIGMAN.Env.welcome.link ? '<br><br>' : ''}`,
-            `${STIGMAN.Env.welcome.link ? '<a href="' + STIGMAN.Env.welcome.link + '">' + STIGMAN.Env.welcome.link  + '</a>': ''}`,
-          `</div>`
+          `<div class="sm-scroll-home-widget-body">`,
+            `<div class='sm-home-widget-text'>`,
+              `<div class=sm-home-widget-image-text-wrap>`,
+                `<img src=${STIGMAN.Env.welcome.image ? `"${STIGMAN.Env.welcome.image}" onerror="this.onerror=null;this.src='img/navy.svg';"` : '"img/navy.svg"'} style="max-width:100%;max-height:100%;"/>`,
+              `</div>`,
+              `<b>STIG Manager</b> is an API and Web client for managing the assessment of Information Systems for compliance with <a href="https://public.cyber.mil/stigs/">security checklists</a> published by the United States Defense Information Systems Agency (DISA). The software is <a target="_blank" href="https://github.com/NUWCDIVNPT/stig-manager">an open source project</a> maintained by the Naval Sea Systems Command (NAVSEA) of the United States Navy.`,
+            `</div>`, 
 
+            `<div class='sm-home-widget-text'>`,
+              `<div class='sm-home-widget-subtitle'>
+                ${STIGMAN.Env.welcome.title ? SM.he(STIGMAN.Env.welcome.title) : STIGMAN.Env.welcome.message || STIGMAN.Env.welcome.link ? 'Support' : ''}
+                </div>`,
+                `${SM.he(STIGMAN.Env.welcome.message)}${STIGMAN.Env.welcome.message && STIGMAN.Env.welcome.link ? '<br><br>' : ''}`,
+                `${STIGMAN.Env.welcome.link ? '<a href="' + STIGMAN.Env.welcome.link + '">' + STIGMAN.Env.welcome.link  + '</a>': ''}`,
+            `</div>`,
+          `</div>`,
         )
       const config = {
         tpl: tpl,
@@ -206,12 +210,18 @@ SM.ApplicationManagers = Ext.extend(Ext.Panel, {
       me.userListId = Ext.id()
 
       const tpl = new Ext.XTemplate(
-       `<div class="sm-home-widget-header">`,
-      `<div class="sm-home-widget-title">Application Managers</div>`,
+      `<div class="sm-home-widget-header">`,
+        `<div class="sm-home-widget-title">
+          Application Managers
+        </div>`,
       `</div>`,
-      `<div class="sm-home-widget-text">`,
-      `<div id="${me.userListId}" class="sm-user-list"></div>`,
+      `<div class="sm-scroll-home-widget-body">`,
+        `<div class="sm-home-widget-text">`,
+          `<div id="${me.userListId}" class="sm-user-list">
+          </div>`,
+        `</div>`,
       `</div>`
+      
         )
       const config = {
         tpl: tpl,

--- a/client/src/js/SM/User.js
+++ b/client/src/js/SM/User.js
@@ -951,9 +951,12 @@ SM.User.UserGrid = Ext.extend(Ext.grid.GridPanel, {
                     else {
                       const apiUser = await Ext.Ajax.requestPromise({
                         responseType: 'json',
-                        url: `${STIGMAN.Env.apiBase}/users/${user.data.userId}?elevate=${curUser.privileges.admin}&projection=collectionGrants&projection=statistics`,
+                        url: `${STIGMAN.Env.apiBase}/users/${user.data.userId}?elevate=${curUser.privileges.admin}&projection=collectionGrants&projection=statistics&projection=userGroups`,
                         method: 'PATCH',
-                        jsonData: { collectionGrants: [] }
+                        jsonData: {
+                          collectionGrants: [],
+                          userGroups: [],
+                        }
                       })
                       // userStore.remove(user)
                       SM.Dispatcher.fireEvent('userchanged', apiUser)

--- a/client/src/js/resources.js
+++ b/client/src/js/resources.js
@@ -20,6 +20,7 @@ const scripts = [
   'js/stigmanUtils.js',
   'js/SM/Global.js',
   'js/SM/Error.js',
+  'js/SM/FlexboxLayout.js',
   'js/BufferView.js',
   'js/SM/EventDispatcher.js',
   'js/SM/Cache.js',

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -117,34 +117,34 @@ async function loadApp () {
 		const homeTab = new SM.HomeTab({
 			border: false,
 			region: 'center',
-			layout: 'table',
+			layout: 'vbox',
 			layoutConfig: {
-				tableAttrs: {
-					style: {
-						padding: '20px',
-						"table-layout": 'fixed'
-
-					}
-				},
-				columns: 4
+				align: 'stretch',
 			},
 			items: [
 				{
 					html: appTitleHtml,
-					colspan: 4,
+					height: 80,
 					border: false
 				},
 				{
-					xtype: 'sm-home-widget-welcome'
-				},
-				{
-					xtype: 'sm-home-widget-doc'
-				},
-				{
-					xtype: 'sm-home-widget-resources'
-				},
-				{
-					xtype: 'sm-home-widget-deployment'
+					layout: 'sm-flexbox',
+					flex: 1,
+					border: false,
+					items: [
+						{
+							xtype: 'sm-home-widget-welcome'
+						},
+						{
+							xtype: 'sm-home-widget-doc'
+						},
+						{
+							xtype: 'sm-home-widget-resources'
+						},
+						{
+							xtype: 'sm-home-widget-deployment'
+						}
+					]
 				}
 			]
 		})

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -126,12 +126,12 @@ async function loadApp () {
 
 					}
 				},
-				columns: 3
+				columns: 4
 			},
 			items: [
 				{
 					html: appTitleHtml,
-					colspan: 3,
+					colspan: 4,
 					border: false
 				},
 				{
@@ -142,6 +142,9 @@ async function loadApp () {
 				},
 				{
 					xtype: 'sm-home-widget-resources'
+				},
+				{
+					xtype: 'sm-home-widget-deployment'
 				}
 			]
 		})

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -140,7 +140,7 @@ async function loadApp () {
 						{
 							xtype: 'sm-home-widget-resources'
 						},
-						...(STIGMAN.Env.displayAppManagers ? [{ xtype: 'sm-home-widget-deployment' }] : [])
+						...(STIGMAN.Env.displayAppManagers ? [{ xtype: 'sm-home-widget-app-managers' }] : [])
 					]
 				}
 			]

--- a/client/src/js/stigman.js
+++ b/client/src/js/stigman.js
@@ -113,7 +113,6 @@ async function loadApp () {
 
 		const appTitleHtml = `<div class='sm-home-title'>
 		STIG Manager<span id='sm-home-oss-sprite'>OSS</span><span id='sm-home-version-sprite'>${STIGMAN.Env.version}</span></div>`
-		
 		const homeTab = new SM.HomeTab({
 			border: false,
 			region: 'center',
@@ -141,9 +140,7 @@ async function loadApp () {
 						{
 							xtype: 'sm-home-widget-resources'
 						},
-						{
-							xtype: 'sm-home-widget-deployment'
-						}
+						...(STIGMAN.Env.displayAppManagers ? [{ xtype: 'sm-home-widget-deployment' }] : [])
 					]
 				}
 			]

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -15,6 +15,8 @@
 | The location of the web client files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the client is located at `../../clients` relative to the API directory. ","API, Client"
 "STIGMAN_CLIENT_DISABLED","| **Default** ``false``
 | Whether to *not* serve the reference web client","Client"
+"STIGMAN_CLIENT_DISPLAY_APPMANAGERS","| **Default** ``false``
+| Whether to *not* display application managers the home page of web client","Client"
 "STIGMAN_CLIENT_EXTRA_SCOPES","| **No default**
 | A space separated list of OAuth2 scopes to request in addition to ``stig-manager:stig`` ``stig-manager:stig:read`` ``stig-manager:collection`` ``stig-manager:user`` ``stig-manager:user:read`` ``stig-manager:op``. Some OIDC providers (Okta) generate a refresh token only if the scope ``offline_access`` is requested","Client"
 "STIGMAN_CLIENT_ID","| **Default** ``stig-manager``

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -15,8 +15,8 @@
 | The location of the web client files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the client is located at `../../clients` relative to the API directory. ","API, Client"
 "STIGMAN_CLIENT_DISABLED","| **Default** ``false``
 | Whether to *not* serve the reference web client","Client"
-"STIGMAN_CLIENT_DISPLAY_APPMANAGERS","| **Default** ``false``
-| Whether to *not* display application managers the home page of web client","Client"
+"STIGMAN_CLIENT_DISPLAY_APPMANAGERS","| **Default** ``true``
+| Whether to display application managers the home page of web client","Client"
 "STIGMAN_CLIENT_EXTRA_SCOPES","| **No default**
 | A space separated list of OAuth2 scopes to request in addition to ``stig-manager:stig`` ``stig-manager:stig:read`` ``stig-manager:collection`` ``stig-manager:user`` ``stig-manager:user:read`` ``stig-manager:op``. Some OIDC providers (Okta) generate a refresh token only if the scope ``offline_access`` is requested","Client"
 "STIGMAN_CLIENT_ID","| **Default** ``stig-manager``

--- a/docs/user-guide/user-guide.rst
+++ b/docs/user-guide/user-guide.rst
@@ -264,6 +264,18 @@ The table below describes the fields that are included in the exports available 
      - Total number of required Evaluations assigned to this item (ie. total number of Rules in all assigned STIGs). 
      - **X**
      - **X**
+   * - assessmentsLow
+     - Total number of Rules assigned to this item with a Severity 3 category 
+     - 
+     - **X**
+   * - assessmentsMedium
+     - Total number of Rules assigned to this item with a Severity 2 category 
+     - 
+     - **X**
+   * - assessmentsHigh
+     - Total number of Rules assigned to this item with a Severity 1 category 
+     - 
+     - **X**
    * - assessed
      - Total number of Reviews that have been marked "pass," "fail," or "notapplicable."
      - **X**
@@ -398,18 +410,6 @@ The table below describes the fields that are included in the exports available 
      - **X**
    * - fixedResultEngine
      - Number of Reviews with a "fixed" result that were evaluated by an automated tool. 
-     - 
-     - **X**
-   * - resultEngines
-     - Array of JSON objects containing an entry for each version of a resultEngine (ie. Evaluate-STIG 1.2, Evaluate-STIG 2.4, OpenSCAP, etc.) that is associated with a current Review in the Collection, and the number of Reviews that tool evaluated.
-     - 
-     - **X**
-   * - users
-     - Array of JSON objects containing an entry for each User that has set the current Evaluation of a Review in the Collection, and the number of Reviews they evaluated.
-     - 
-     - **X**
-   * - statusUsers
-     - Array of JSON objects containing an entry for each User that set the current Status of a Review in the Collection, and the number of Reviews they have set the Status for.
      - 
      - **X**
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,5 +1,25 @@
+1.5.3
+-------
+
+Changes:
+
+  - (API/UI/DB) The Collection Grants system has been significantly reworked to allow for more dynamic and flexible Grant management. The new Grant system also allows for "Read Only" access to Collection Reviews. Details of the new Role-Based Access Control system are found in the [STIG Manager documentation](https://stig-manager.readthedocs.io/en/latest/user-guide/roles-and-access.html).
+  - (API/UI/DB) [New User Groups feature.](https://stig-manager.readthedocs.io/en/latest/admin-guide/admin-guide.html#user-groups-admin-panel)
+  - (UI) The Collection Review Workspace has been reworked to give more room to Checklist statistics columns and enable future expansion. The display should now be significantly less constrained, especially when viewing extra columns that are usually hidden by default.
+  - (OAS/API) Updates to the OpenAPI definition. 
+  - (API) Refactoring of API token validation processing. 
+  - (Docs) Updated sphinx and other documentation build dependencies.
+  - (Build) Fixed issue preventing binary versions from creating POA&M.
+  - (Workflows) Automated testing of linux binaries.
+
+**NOTES:** 
+  - This release includes a database migration to support new features. 
+  - This release changes the minimum required MySQL version from 8.0.21 => 8.0.24
+  - This migration will convert any existing "Asset-STIG" style assignments for Restricted Users to the equivalent Access Control List style Grants under the new system. After migration, you may want to remove the granular Access Control Rules and create new ones with the more flexible system (for example, creating one Access Control Rule granting access to an entire Asset, rather than each individual Asset-STIG).
+  - **This release introduces "breaking" changes to the API and STIG Manager OpenAPI definition.** If you have custom integrations or clients that rely on the STIG Manager API, you may need to update them to accommodate these changes. Check the [rbac v2 implementation Pull Request](https://github.com/NUWCDIVNPT/stig-manager/pull/1487) for details of the changes to the API with this release.
+
 1.5.2
------
+-------
 
 Changes:
 
@@ -10,17 +30,15 @@ Changes:
 
   - **NOTE:** This release includes a database migration that changes the data type of the review_history.historyId column to a bigint. This migration may take quite some time to complete on deployments maintaining large numbers of Review History records.  
 
-
 1.5.1
------
+-------
 
 Changes:
 
   - (UI) fix: Handle STIG Ids with spaces 
 
-
 1.5.0
------
+-------
 
 Changes:
 
@@ -29,19 +47,17 @@ Changes:
   - (UI) provide detailed status during web app bootstrap; handle token errors; test oidc state before token request
   - (Docs) Update license/contributors for 2025
   - (Docs) Update build dependency
-  
-  
- 1.4.19
------
+
+1.4.19
+-------
 
 Changes:
 
   - (API) chore: Update dependency Cross-Spawn 
   - (API) fix: Allow for use and proper handling of backslashes in metadata values
- 
 
 1.4.18
------
+-------
 
 Changes:
 
@@ -54,7 +70,7 @@ Changes:
   - (API) Dependency updates
 
 1.4.17
------
+--------
 
 Changes:
 
@@ -66,7 +82,7 @@ Changes:
   - **NOTE:** This release includes a database migration that adds an index for the ``state`` columns in the ``asset`` and ``collection`` tables. 
 
 1.4.16
------
+-------
 
 Changes:
 
@@ -81,7 +97,7 @@ Changes:
   - **NOTE:** The "Experimental" Export/Import Data feature that used to share the "App Info" tab must now be enabled explicitly with an Environment Variable (`STIGMAN_EXPERIMENTAL_APPDATA=true`). When enabled, it will have its own node in the Application Management NavTree. See the documentation for more details.
 
 1.4.15
------
+-------
 
 Changes:
 
@@ -91,7 +107,7 @@ Changes:
   - (API) chore: dependency updates
 
 1.4.14
------
+-------
 
 Changes:
 
@@ -105,7 +121,7 @@ Changes:
   - (API) chore: dependency updates
 
 1.4.13
------
+-------
 
 Changes:
 
@@ -119,7 +135,7 @@ Changes:
   - (API) chore: dependency updates
 
 1.4.12
------
+-------
 
 Changes:
 
@@ -135,21 +151,21 @@ Changes:
   - **Includes database migration to update settings for existing Collections to reflect the new Review History cap where appropriate. No history is altered as part of the migration, history entries will be trimmed to new max as Reviews are subsequently updated.**
 
 1.4.11
------
+-------
 
 Changes:
 
   - (UI/API) Removing feature from Release 1.4.8 adding resultEngine, user, statusUser columns to Detail metrics exports. The feature was found to cause poor performance in large deployments. 
 
 1.4.10
------
+-------
 
 Changes:
 
   - (API) bugfix: Resolves issue allowing Collection Owner/Managers to create restricted grant assignments outside of Collection boundary
   
 1.4.9
------
+------
 
 Changes:
 

--- a/test/api/mocha/data/metrics/metricsGet.js
+++ b/test/api/mocha/data/metrics/metricsGet.js
@@ -2905,6 +2905,766 @@ export const metrics = {
       }
     ]
   },
+  'test metrics on collection with labelMatch=null': {
+    stigmanadmin: [
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "VPN_SRG_TEST",
+        title: "Virtual Private Network (VPN) Security Requirements Guide",
+        revisionStr: "V1R1",
+        revisionPinned: false,
+        metrics: {
+          maxTs: "2022-02-02T20:20:18Z",
+          minTs: "2020-08-11T22:30:42Z",
+          results: {
+            fail: {
+              total: 3,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 1,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 1,
+              resultEngine: 0,
+            },
+          },
+          assessed: 5,
+          findings: {
+            low: 1,
+            high: 0,
+            medium: 2,
+          },
+          statuses: {
+            saved: {
+              total: 3,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 2,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: "2022-02-02T20:20:18Z",
+          assessments: 81,
+          assessmentsBySeverity: {
+            low: 7,
+            high: 11,
+            medium: 63,
+          },
+        },
+      },
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "Windows_10_STIG_TEST",
+        title: "Windows 10 Security Technical Implementation Guide",
+        revisionStr: "V1R23",
+        revisionPinned: false,
+        metrics: {
+          maxTs: null,
+          minTs: null,
+          results: {
+            fail: {
+              total: 0,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 0,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          assessed: 0,
+          findings: {
+            low: 0,
+            high: 0,
+            medium: 0,
+          },
+          statuses: {
+            saved: {
+              total: 0,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: null,
+          assessments: 287,
+          assessmentsBySeverity: {
+            low: 18,
+            high: 26,
+            medium: 243,
+          },
+        },
+      },
+    ],
+    lvl1: [
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "VPN_SRG_TEST",
+        title: "Virtual Private Network (VPN) Security Requirements Guide",
+        revisionStr: "V1R1",
+        revisionPinned: false,
+        metrics: {
+          maxTs: "2022-02-02T20:20:18Z",
+          minTs: "2020-08-11T22:30:42Z",
+          results: {
+            fail: {
+              total: 3,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 1,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 1,
+              resultEngine: 0,
+            },
+          },
+          assessed: 5,
+          findings: {
+            low: 1,
+            high: 0,
+            medium: 2,
+          },
+          statuses: {
+            saved: {
+              total: 3,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 2,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: "2022-02-02T20:20:18Z",
+          assessments: 81,
+          assessmentsBySeverity: {
+            low: 7,
+            high: 11,
+            medium: 63,
+          },
+        },
+      },
+    ],
+    lvl2: [
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "VPN_SRG_TEST",
+        title: "Virtual Private Network (VPN) Security Requirements Guide",
+        revisionStr: "V1R1",
+        revisionPinned: false,
+        metrics: {
+          maxTs: "2022-02-02T20:20:18Z",
+          minTs: "2020-08-11T22:30:42Z",
+          results: {
+            fail: {
+              total: 3,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 1,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 1,
+              resultEngine: 0,
+            },
+          },
+          assessed: 5,
+          findings: {
+            low: 1,
+            high: 0,
+            medium: 2,
+          },
+          statuses: {
+            saved: {
+              total: 3,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 2,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: "2022-02-02T20:20:18Z",
+          assessments: 81,
+          assessmentsBySeverity: {
+            low: 7,
+            high: 11,
+            medium: 63,
+          },
+        },
+      },
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "Windows_10_STIG_TEST",
+        title: "Windows 10 Security Technical Implementation Guide",
+        revisionStr: "V1R23",
+        revisionPinned: false,
+        metrics: {
+          maxTs: null,
+          minTs: null,
+          results: {
+            fail: {
+              total: 0,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 0,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          assessed: 0,
+          findings: {
+            low: 0,
+            high: 0,
+            medium: 0,
+          },
+          statuses: {
+            saved: {
+              total: 0,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: null,
+          assessments: 287,
+          assessmentsBySeverity: {
+            low: 18,
+            high: 26,
+            medium: 243,
+          },
+        },
+      },
+    ],
+    lvl3: [
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "VPN_SRG_TEST",
+        title: "Virtual Private Network (VPN) Security Requirements Guide",
+        revisionStr: "V1R1",
+        revisionPinned: false,
+        metrics: {
+          maxTs: "2022-02-02T20:20:18Z",
+          minTs: "2020-08-11T22:30:42Z",
+          results: {
+            fail: {
+              total: 3,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 1,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 1,
+              resultEngine: 0,
+            },
+          },
+          assessed: 5,
+          findings: {
+            low: 1,
+            high: 0,
+            medium: 2,
+          },
+          statuses: {
+            saved: {
+              total: 3,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 2,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: "2022-02-02T20:20:18Z",
+          assessments: 81,
+          assessmentsBySeverity: {
+            low: 7,
+            high: 11,
+            medium: 63,
+          },
+        },
+      },
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "Windows_10_STIG_TEST",
+        title: "Windows 10 Security Technical Implementation Guide",
+        revisionStr: "V1R23",
+        revisionPinned: false,
+        metrics: {
+          maxTs: null,
+          minTs: null,
+          results: {
+            fail: {
+              total: 0,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 0,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          assessed: 0,
+          findings: {
+            low: 0,
+            high: 0,
+            medium: 0,
+          },
+          statuses: {
+            saved: {
+              total: 0,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: null,
+          assessments: 287,
+          assessmentsBySeverity: {
+            low: 18,
+            high: 26,
+            medium: 243,
+          },
+        },
+      },
+    ],
+    lvl4: [
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "VPN_SRG_TEST",
+        title: "Virtual Private Network (VPN) Security Requirements Guide",
+        revisionStr: "V1R1",
+        revisionPinned: false,
+        metrics: {
+          maxTs: "2022-02-02T20:20:18Z",
+          minTs: "2020-08-11T22:30:42Z",
+          results: {
+            fail: {
+              total: 3,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 1,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 1,
+              resultEngine: 0,
+            },
+          },
+          assessed: 5,
+          findings: {
+            low: 1,
+            high: 0,
+            medium: 2,
+          },
+          statuses: {
+            saved: {
+              total: 3,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 2,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: "2022-02-02T20:20:18Z",
+          assessments: 81,
+          assessmentsBySeverity: {
+            low: 7,
+            high: 11,
+            medium: 63,
+          },
+        },
+      },
+      {
+        assetId: "154",
+        name: "Collection_X_lvl1_asset-2",
+        labels: [
+        ],
+        benchmarkId: "Windows_10_STIG_TEST",
+        title: "Windows 10 Security Technical Implementation Guide",
+        revisionStr: "V1R23",
+        revisionPinned: false,
+        metrics: {
+          maxTs: null,
+          minTs: null,
+          results: {
+            fail: {
+              total: 0,
+              resultEngine: 0,
+            },
+            pass: {
+              total: 0,
+              resultEngine: 0,
+            },
+            error: {
+              total: 0,
+              resultEngine: 0,
+            },
+            fixed: {
+              total: 0,
+              resultEngine: 0,
+            },
+            unknown: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notchecked: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notselected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            informational: {
+              total: 0,
+              resultEngine: 0,
+            },
+            notapplicable: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          assessed: 0,
+          findings: {
+            low: 0,
+            high: 0,
+            medium: 0,
+          },
+          statuses: {
+            saved: {
+              total: 0,
+              resultEngine: 0,
+            },
+            accepted: {
+              total: 0,
+              resultEngine: 0,
+            },
+            rejected: {
+              total: 0,
+              resultEngine: 0,
+            },
+            submitted: {
+              total: 0,
+              resultEngine: 0,
+            },
+          },
+          maxTouchTs: null,
+          assessments: 287,
+          assessmentsBySeverity: {
+            low: 18,
+            high: 26,
+            medium: 243,
+          },
+        },
+      },
+    ]
+
+  },
   'Return detail metrics - assset agg': {
     stigmanadmin: [
       {

--- a/test/api/mocha/data/metrics/metricsGet.test.js
+++ b/test/api/mocha/data/metrics/metricsGet.test.js
@@ -54,6 +54,36 @@ describe('GET - Metrics', function () {
                     expect(res.body).to.deep.equalInAnyOrder(expectedData['stigmanadmin'])
                 }
             })
+            it("test metrics on empty collection", async function () {
+
+                const res = await utils.executeRequest(`${config.baseUrl}/collections/${'84'}/metrics/detail`, 'GET', iteration.token)
+                if(iteration.name !== "stigmanadmin"){
+                    expect(res.status).to.eql(403)
+                    return
+                }
+                expect(res.status).to.eql(200)
+                expect(res.body).to.be.empty
+
+            })
+            it("test metrics on collection with labelMatch=null", async function () {
+
+                const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/metrics/detail?labelMatch=null`, 'GET', iteration.token)
+                if(iteration.name === "collectioncreator"){
+                    expect(res.status).to.eql(403)
+                    return
+                }
+                expect(res.status).to.eql(200)
+                const expectedData = metrics[this.test.title]
+
+                if(iteration.name === 'lvl1'){
+                    expect(res.body).to.deep.equalInAnyOrder(expectedData['lvl1'])
+                }
+                else 
+                {
+                    expect(res.body).to.deep.equalInAnyOrder(expectedData['stigmanadmin'])
+                }
+
+            })
         })
 
         describe('GET - getMetricsDetailByCollectionAggAsset - /collections/{collectionId}/metrics/detail/asset', function () {

--- a/test/api/mocha/data/user/user.test.js
+++ b/test/api/mocha/data/user/user.test.js
@@ -184,6 +184,33 @@ describe('user', () => {
             expect(res.body[0].userGroups, "expect user to be in TestGroup").to.eql([{ userGroupId: reference.testCollection.testGroup.userGroupId, name: reference.testCollection.testGroup.name }])
 
           })
+          it("should return all users with admin privileges", async () => {
+
+            const res = await utils.executeRequest(`${config.baseUrl}/users?elevate=true&privilege=admin`, 'GET', iteration.token)
+
+            if(iteration.name != "stigmanadmin"){
+              expect(res.status).to.eql(403)
+              return
+            }
+            expect(res.status).to.eql(200)
+
+            for(const user of res.body) {
+              expect(user.privileges.admin, "expect user to have admin privilege").to.be.true
+            }
+          })
+          it("should return all users with create_collection privileges", async () => {
+
+            const res = await utils.executeRequest(`${config.baseUrl}/users?elevate=true&privilege=create_collection`, 'GET', iteration.token)
+
+            if(iteration.name != "stigmanadmin"){
+              expect(res.status).to.eql(403)
+              return
+            }
+            expect(res.status).to.eql(200)
+            for(const user of res.body) {
+              expect(user.privileges.create_collection, "expect user to have create_collection privilege").to.be.true
+            }
+          })
           it("should throw SmError.PrivilegeError no elevate with projections.", async () => {
             const res = await utils.executeRequest(`${config.baseUrl}/users?projection=collectionGrants`, 'GET', iteration.token)
             expect(res.status).to.eql(403)

--- a/test/api/mocha/data/user/user.test.js
+++ b/test/api/mocha/data/user/user.test.js
@@ -219,7 +219,7 @@ describe('user', () => {
 
         describe(`getUserByUserId - /users{userId}`, async () => {
 
-          it('Return a user', async () => {
+          it('Return wfTest user user', async () => {
             const res = await utils.executeRequest(`${config.baseUrl}/users/${reference.wfTest.userId}?elevate=true&projection=collectionGrants&projection=statistics`, 'GET', iteration.token)
             if(iteration.name != "stigmanadmin"){
               expect(res.status).to.eql(403)
@@ -231,6 +231,19 @@ describe('user', () => {
             expect(res.body).to.have.property('statistics')
             expect(res.body.username, "expect username to be wf-Test").to.equal(reference.wfTest.username)
             expect(res.body.userId, "expect userId to be wf-Test userId (22)").to.equal(reference.wfTest.userId)
+            expect(res.body.privileges).to.eql({admin: false, create_collection: false})
+          })
+          it("return adminBurke user and verify its privileges", async () => {
+
+            const res = await utils.executeRequest(`${config.baseUrl}/users/${reference.adminBurke.userId}?elevate=true`, 'GET', iteration.token)
+            if(iteration.name != "stigmanadmin"){
+              expect(res.status).to.eql(403)
+              return
+            }
+            expect(res.status).to.eql(200)
+            expect(res.body.username, "expect username to be admin").to.equal(reference.adminBurke.username)
+            expect(res.body.userId, "expect userId to be admin userId").to.equal(reference.adminBurke.userId)
+            expect(res.body.privileges).to.eql({admin: true, create_collection: true})
           })
           it("return lvl1 user and verify its group membership", async () => {
             const res =  await utils.executeRequest(`${config.baseUrl}/users/${reference.lvl1User.userId}?elevate=true&projection=userGroups`, 'GET', iteration.token)


### PR DESCRIPTION
resolves #1451 
resolves #418 

API: 
1. _getUsers_ operation ID gained a query param of _'privilege'_ whos values can be _["admin" , "create_collection"]_. This will return users with the specified privilege.

Client

1. Adds an env var to control the display of app managers on the home page  "_STIGMAN_CLIENT_DISPLAY_APPMANAGERS_"
2. Adds card on home screen that lists display names and emails of users with _"admin"_ privilege.
3. Additionally adds new css which allows for the new card aswell as the "Welcome" card to be scrollable when content overflows.