### PR TITLE
fix: Error as a result of unregistering a user

### DIFF
--- a/client/src/js/SM/User.js
+++ b/client/src/js/SM/User.js
@@ -951,9 +951,12 @@ SM.User.UserGrid = Ext.extend(Ext.grid.GridPanel, {
                     else {
                       const apiUser = await Ext.Ajax.requestPromise({
                         responseType: 'json',
-                        url: `${STIGMAN.Env.apiBase}/users/${user.data.userId}?elevate=${curUser.privileges.admin}&projection=collectionGrants&projection=statistics`,
+                        url: `${STIGMAN.Env.apiBase}/users/${user.data.userId}?elevate=${curUser.privileges.admin}&projection=collectionGrants&projection=statistics&projection=userGroups`,
                         method: 'PATCH',
-                        jsonData: { collectionGrants: [] }
+                        jsonData: {
+                          collectionGrants: [],
+                          userGroups: [],
+                        }
                       })
                       // userStore.remove(user)
                       SM.Dispatcher.fireEvent('userchanged', apiUser)


### PR DESCRIPTION
resolves #1512 

This pr resolves a bug which would cause the client to throw.

Changes include:

1.  Adding the userGroups projection when patching a user. (this is where we were throwing) 
2. Patching the unregistered users userGroups to remove ALL of its grants. 