### PR TITLE
fix: handling of user-defined jwt claims

### DIFF
--- a/api/source/index.js
+++ b/api/source/index.js
@@ -219,15 +219,7 @@ const STIGMAN = {
           disabled: ${config.client.refreshToken.disabled}
         },
         extraScopes: "${config.client.extraScopes ?? ''}",
-        scopePrefix: "${config.client.scopePrefix ?? ''}",
-        claims: {
-          scope: "${config.oauth.claims.scope}",
-          username: "${config.oauth.claims.username}",
-          servicename: "${config.oauth.claims.servicename}",
-          name: "${config.oauth.claims.name}",
-          privileges: "${config.oauth.claims.privileges}",
-          email: "${config.oauth.claims.email}"
-        }
+        scopePrefix: "${config.client.scopePrefix ?? ''}"
     },
     experimental: {
       appData: "${config.experimental.appData}"

--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -122,7 +122,7 @@ exports.queryCollection = async function ({collectionId, projections = [], eleva
       'userId', CAST(ud.userId as char),
       'username', ud.username,
       'displayName', COALESCE(
-      JSON_UNQUOTE(JSON_EXTRACT(ud.lastClaims, "$.name")),
+      JSON_UNQUOTE(JSON_EXTRACT(ud.lastClaims, "$.${config.oauth.claims.name}")),
       ud.username)),
     'roleId', cgs.roleId,
     'grantees', cgs.grantees))

--- a/api/source/service/OperationService.js
+++ b/api/source/service/OperationService.js
@@ -616,7 +616,7 @@ exports.getAppInfo = async function() {
     ud.created, 
     ud.lastAccess,
     coalesce(
-      JSON_EXTRACT(ud.lastClaims, "$.${config.oauth.claims.privilegesPath}"),
+      JSON_EXTRACT(ud.lastClaims, '$.${config.oauth.claims.privileges}'),
       json_array()
     ) as privileges,
     json_object(

--- a/api/source/service/UserService.js
+++ b/api/source/service/UserService.js
@@ -82,8 +82,8 @@ exports.queryUsers = async function (inProjection, inPredicates, elevate, userOb
     binds: [
       `$.${config.oauth.claims.email}`,
       `$.${config.oauth.claims.name}`,
-      `$.${config.oauth.claims.privilegesPath}`,
-      `$.${config.oauth.claims.privilegesPath}`
+      `$.${config.oauth.claims.privileges}`,
+      `$.${config.oauth.claims.privileges}`
     ]
   }
   if (inPredicates.userId) {

--- a/api/source/utils/auth.js
+++ b/api/source/utils/auth.js
@@ -10,7 +10,7 @@ const SmError = require('./error')
 
 let client
 
-const privilegeGetter = new Function("obj", "return obj?." + config.oauth.claims.privileges + " || [];");
+const privilegeGetter = new Function("obj", "return obj?." + config.oauth.claims.privilegesChain + " || [];");
 
 // express middleware to validate token
 const validateToken = async function (req, res, next) {

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -76,8 +76,8 @@ const config = {
             username: process.env.STIGMAN_JWT_USERNAME_CLAIM,
             servicename: process.env.STIGMAN_JWT_SERVICENAME_CLAIM,
             name: process.env.STIGMAN_JWT_NAME_CLAIM || process.env.STIGMAN_JWT_USERNAME_CLAIM || "name",
-            privileges: formatChain(process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || "realm_access.roles"),
-            privilegesPath: process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || "realm_access.roles",
+            privileges: formatMySqlJsonPath(process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || "realm_access.roles"),
+            privilegesChain: formatJsChain(process.env.STIGMAN_JWT_PRIVILEGES_CLAIM || "realm_access.roles"),
             email: process.env.STIGMAN_JWT_EMAIL_CLAIM || "email",
             assertion: process.env.STIGMAN_JWT_ASSERTION_CLAIM || "jti"
         }
@@ -92,13 +92,17 @@ const config = {
     }
 }
 
-function formatChain(path) {
+function formatJsChain(path) {
     const components = path?.split('.')
     if (components?.length === 1) return path
     for (let x=0; x < components.length; x++) {
       components[x] = `['${components[x]}']`
     }
     return components.join('?.')
-  }
+}
+
+function formatMySqlJsonPath(path) {
+    return path?.split('.').map(p => `"${p}"`).join('.')
+}
   
-module.exports = config
+module.exports = config 

--- a/client/src/js/SM/User.js
+++ b/client/src/js/SM/User.js
@@ -1371,7 +1371,7 @@ SM.User.showUserProps = async function showUserProps(userId) {
         apiUser.statistics.lastClaims.scope = apiUser.statistics.lastClaims.scope.split(' ')
       }
       const privileges = []
-      for (privilege in apiUser.privileges) {
+      for (const privilege in apiUser.privileges) {
         if (apiUser.privileges[privilege]) privileges.push(privilege)
       }
       const formValues = {

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -62,19 +62,19 @@
 "STIGMAN_LOG_MODE","| **Default** ``combined``
 | Controls whether the logs will create one “combined” log entry for http requests that includes both the request and response information; or two separate log entries, one for the request and one for the response, that can be correlated via a generated Request GUID in each entry","API"
 "STIGMAN_JWT_ASSERTION_CLAIM","| **Default** ``jti``
-| The access token claim whose value is the OIDC provider's Assertion ID. Updates to this value trigger the API to update a User's ``lastClaims`` property. The claim MUST be a top-level claim and cannot be nested.","API"
+| The access token claim whose value is the OIDC provider's Assertion ID. Updates to this value trigger the API to update a User's ``lastClaims`` property. The claim MUST NOT be nested and MUST be a valid ECMAScript identifier.","API"
 "STIGMAN_JWT_EMAIL_CLAIM","| **Default** ``email``
-| The access token claim whose value is the user's email address","API, Client"
+| The access token claim whose value is the user's email address. The claim MUST NOT be nested and MUST be a valid ECMAScript identifier.","API, Client"
 "STIGMAN_JWT_NAME_CLAIM","| **Default** ``name``
-| The access token claim whose value is the user's full name","API, Client"
+| The access token claim whose value is the user's full name. The claim MUST NOT be nested and MUST be a valid ECMAScript identifier.","API, Client"
 "STIGMAN_JWT_PRIVILEGES_CLAIM","| **Default** ``realm_access.roles``
-| The access token claim whose value is the user’s privileges ","API, Client"
+| The access token claim whose value is the user’s privileges. The claim MAY be nested but SHOULD avoid invalid ECMAScript identifiers. ","API, Client"
 "STIGMAN_JWT_SCOPE_CLAIM","| **Default** ``scope``
-| The access token claim whose value is the user's scopes. Some OIDC Providers (Okta, Azure AD) use the claim ``scp`` to enumerate scopes","API, Client"
+| The access token claim whose value is the user's scopes. Some OIDC Providers (Okta, Azure AD) use the claim ``scp`` to enumerate scopes. The claim MUST NOT be nested and MUST be a valid ECMAScript identifier.","API, Client"
 "STIGMAN_JWT_SERVICENAME_CLAIM","| **Default** ``clientId``
-| The access token claim whose value is the user's client","API, Client"
+| The access token claim whose value is the user's client. The claim MUST NOT be nested and MUST be a valid ECMAScript identifier.","API, Client"
 "STIGMAN_JWT_USERNAME_CLAIM","| **Default** ``preferred_username``
-| The access token claim whose value is the user's username","API, Client"
+| The access token claim whose value is the user's username. The claim MUST NOT be nested and MUST be a valid ECMAScript identifier.","API, Client"
 "STIGMAN_OIDC_PROVIDER","| **Default** ``http://localhost:8080/auth/realms/stigman``
 | The base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended when fetching metadata.","API, Client     "
 "STIGMAN_SWAGGER_ENABLED","| **Default** ``false``


### PR DESCRIPTION
Resolves #1515 

- (API) Formats `config.oauth.claims.privileges` to conform to MySQL JSON path syntax by double-quoting all object properties.
- (API) Updates queries that consume `config.oauth.claims.privileges` to surround the path statement with single-quotes in order to support the double-quoted path components
- (API) Renames function `formatChain()` to `formatJsChain()` for clarity
- (API) Renames properties of `config.oauth.claims` for clarity: 
    - `privileges` => `privilegesChain`
    - `privilegesPath` => `privileges`
- (API) Removes `oauth.claims` from `Env.js` served to the web app since it is no longer used by any web app code
- (API) Adds a missing `const` declaration in `User.js`
- (API) Replaces hardcoded path `$.name` with `$.${config.oauth.claims.name}` in `CollectionService.js`
- (Doc) Updates documentation of the `STIGMAN_JWT_*_CLAIM` environment variables to describe which variables MUST NOT be nested and MUST be valid ECMAScript identifiers, or MAY be nested and SHOULD be valid ECMAScript identifiers. `STIGMAN_JWT_PRIVILEGES_CLAIM` is the only variable documented as allowing nesting.
