### PR TITLE
Feat: Replaces pkg with a maintained pkg fork ''@yao-pkg/pkg"

### DIFF
--- a/api/build.sh
+++ b/api/build.sh
@@ -2,7 +2,7 @@
 
 # This file is used to build API binaries on the team workstations. It is not tested elsewhere, yet.
 # Requires:
-# - Node.js and module "pkg" (npm install -g pkg)
+# - Node.js and module "@yao-pkg/pkg" (npm install -g @yao-pkg/pkg)
 # - zip
 # - tar
 
@@ -32,7 +32,7 @@ echo "Fetching node_modules"
 rm -rf ./source/node_modules
 cd ./source
 npm ci
-npm install -g pkg
+npm install -g @yao-pkg/pkg
 cd ..
 ../client/build.sh
 ../docs/build.sh
@@ -43,7 +43,7 @@ echo $DESCRIBE
 
 # Make binaries
 echo "Building binaries"
-pkg -C gzip --public --public-packages=* --no-bytecode pkg.config.json
+pkg ./source/index.js -C gzip --public --public-packages=* --no-bytecode -c pkg.config.json
 check_exit_status "Building binaries" 1
 
 echo "Creating archives with launchers"

--- a/api/build.sh
+++ b/api/build.sh
@@ -2,7 +2,7 @@
 
 # This file is used to build API binaries on the team workstations. It is not tested elsewhere, yet.
 # Requires:
-# - Node.js and module "@yao-pkg/pkg" (npm install -g @yao-pkg/pkg)
+# - Node.js and module "@yao-pkg/pkg" (npm install -g @yao-pkg/pkg@6.3.0)
 # - zip
 # - tar
 
@@ -32,7 +32,7 @@ echo "Fetching node_modules"
 rm -rf ./source/node_modules
 cd ./source
 npm ci
-npm install -g @yao-pkg/pkg
+npm install -g @yao-pkg/pkg@6.3.0
 cd ..
 ../client/build.sh
 ../docs/build.sh

--- a/api/pkg.config.json
+++ b/api/pkg.config.json
@@ -3,8 +3,16 @@
     "bin": "./source/index.js",
     "pkg": {
         "scripts": ["./source/controllers/**/*.js", "./source/service/**/*.js"],
-        "assets": ["../client/dist/**/*", "../docs/_build/html", "./source/service/**/*.sql", "./source/node_modules/csv-stringify/**/*", "./source/node_modules/swagger-ui-dist/**/*", "./source/node_modules/axios/**/*", "./source/utils/*.xlsx"],
-        "targets": [ "node18-win", "node18-linuxstatic" ],
+        "assets": [
+            "../client/dist/**/*",
+            "../docs/_build/html",
+            "./source/service/**/*.sql",
+            "./source/node_modules/csv-stringify/**/*",
+            "./source/node_modules/swagger-ui-dist/**/*",
+            "./source/node_modules/axios/**/*",
+            "./source/utils/*.xlsx"
+        ],
+        "targets": ["node22-win", "node22-linuxstatic"],
         "outputPath": "./bin"
     }
 }

--- a/api/pkg.config.json
+++ b/api/pkg.config.json
@@ -1,6 +1,5 @@
 {
     "name": "stig-manager",
-    "bin": "./source/index.js",
     "pkg": {
         "scripts": ["./source/controllers/**/*.js", "./source/service/**/*.js"],
         "assets": [


### PR DESCRIPTION
resolves #1176 
resolves #1501 

The original PKG was deprecated so this pr replaces pkg with a maintained fork named "@yao-pkg/pkg". 

We now can support building binaries on latest node version.  

