### PR TITLE
feat: now runs when changes are made to scripts involved with building binaries.

### DIFF
--- a/.github/workflows/api-binary-tests.yml
+++ b/.github/workflows/api-binary-tests.yml
@@ -22,7 +22,7 @@ on:
       - ".github/workflows/api-binary-tests.yml"
       - "api/build.sh"
       - "client/build.sh"
-      - "/docs/build.sh"
+      - "docs/build.sh"
 
       
 env:

--- a/.github/workflows/api-binary-tests.yml
+++ b/.github/workflows/api-binary-tests.yml
@@ -11,7 +11,7 @@ on:
       - ".github/workflows/api-binary-tests.yml"
       - "api/build.sh"
       - "client/build.sh"
-      - "/docs/build.sh"
+      - "docs/build.sh"
 
   push:
     branches:

--- a/.github/workflows/api-binary-tests.yml
+++ b/.github/workflows/api-binary-tests.yml
@@ -9,6 +9,10 @@ on:
       - "api/source/**"
       - "test/api/**"
       - ".github/workflows/api-binary-tests.yml"
+      - "api/build.sh"
+      - "client/build.sh"
+      - "/docs/build.sh"
+
   push:
     branches:
       - main
@@ -16,6 +20,10 @@ on:
       - "api/source/**"
       - "test/api/**"
       - ".github/workflows/api-binary-tests.yml"
+      - "api/build.sh"
+      - "client/build.sh"
+      - "/docs/build.sh"
+
       
 env:
   STIGMAN_API_PORT: 64001


### PR DESCRIPTION
This pr alters the api-binary-tests workflow so that it triggers when there are changes to the scripts involved with building binaries.

This ensures that any modifications to the binary build scripts are validated by Mocha tests, confirming the accuracy of the Linux binary's API.

Should be merged before #1528 