### PR TITLE
feat: getRuleByRuleId returns clone rules and revisions related to ruleId

### DIFF
--- a/api/source/service/STIGService.js
+++ b/api/source/service/STIGService.js
@@ -451,10 +451,9 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   }
   
   if (inProjection?.includes('ruleIds')) {
-    columns.push(`cast(concat('[', group_concat(distinct '"' , rvcd2.ruleId , '"'), ']') as json) as ruleIds`)
+    columns.push(`cast(concat('[', group_concat(distinct '"' , rvcd.ruleId , '"'), ']') as json) as ruleIds`)
     joins.push(
       'left join rule_version_check_digest rvcd on (rgr.version = rvcd.version and rgr.checkDigest = rvcd.checkDigest)',
-      'left join rule_version_check_digest rvcd2 on (rgr.version = rvcd2.version and rgr.checkDigest = rvcd2.checkDigest)',
     )
   }
     
@@ -490,9 +489,9 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   }
   
   // CONSTRUCT MAIN QUERY
-  const sql = dbUtils.makeQueryString({columns, joins, predicates, groupBy, orderBy})
+  const sql = dbUtils.makeQueryString({columns, joins, predicates, groupBy, orderBy, format: true})
 
-  const [rows] = await dbUtils.pool.query(sql, predicates.binds)
+  const [rows] = await dbUtils.pool.query(sql)
   return (rows[0])
 }
 

--- a/api/source/service/STIGService.js
+++ b/api/source/service/STIGService.js
@@ -392,7 +392,12 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   ]
   
   let groupBy = [
-    'rgr.rgrId'
+    "rgr.ruleId", 
+    "rgr.version",
+    "rgr.title",
+    "rgr.severity",
+    "rgr.groupId",
+    "rgr.groupTitle"
   ]
 
   const orderBy = ['substring(rgr.ruleId from 4) + 0']
@@ -415,17 +420,17 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   // PROJECTIONS
   if ( inProjection?.includes('detail') ) {
     columns.push(`json_object(
-      'weight', rgr.weight,
-      'vulnDiscussion', rgr.vulnDiscussion,
-      'falsePositives', rgr.falsePositives,
-      'falseNegatives', rgr.falseNegatives,
-      'documentable', rgr.documentable,
-      'mitigations', rgr.mitigations,
-      'severityOverrideGuidance', rgr.severityOverrideGuidance,
-      'potentialImpacts', rgr.potentialImpacts,
-      'thirdPartyTools', rgr.thirdPartyTools,
-      'mitigationControl', rgr.mitigationControl,
-      'responsibility', rgr.responsibility
+      'weight', any_value(rgr.weight),
+      'vulnDiscussion', any_value(rgr.vulnDiscussion),
+      'falsePositives', any_value(rgr.falsePositives),
+      'falseNegatives', any_value(rgr.falseNegatives),
+      'documentable', any_value(rgr.documentable),
+      'mitigations', any_value(rgr.mitigations),
+      'severityOverrideGuidance', any_value(rgr.severityOverrideGuidance),
+      'potentialImpacts', any_value(rgr.potentialImpacts),
+      'thirdPartyTools', any_value(rgr.thirdPartyTools),
+      'mitigationControl', any_value(rgr.mitigationControl),
+      'responsibility', any_value(rgr.responsibility)
     ) as detail`)
   }
 
@@ -441,12 +446,12 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   }
 
   if ( inProjection?.includes('check') ) {
-    columns.push(`json_object('system', rgr.checkSystem,'content', cc.content) as \`check\``)
+    columns.push(`json_object('system', any_value(rgr.checkSystem),'content', any_value(cc.content)) as \`check\``)
     joins.push('left join check_content cc on rgr.checkDigest = cc.digest')
   }
 
   if ( inProjection?.includes('fix') ) {
-    columns.push(`json_object('fixref', rgr.fixref,'text', ft.text) as fix`)
+    columns.push(`json_object('fixref', any_value(rgr.fixref),'text', any_value(ft.text)) as fix`)
     joins.push('left join fix_text ft on rgr.fixDigest = ft.digest')
   }
   
@@ -458,34 +463,8 @@ exports.queryRules = async function ( ruleId, inProjection ) {
   }
     
   if (inProjection?.includes('stigs')) {
-    columns.push(`cast(
-      concat('[', 
-        coalesce (
-          group_concat(distinct 
-            case when sa.benchmarkId is not null then 
-              json_object(
-                'benchmarkId', sa.benchmarkId, 
-                'revisionStr', revision.revisionStr
-                )
-            else null end 
-          order by sa.benchmarkId),
-          ''),
-      ']')
-    as json) as "stigs"`)
-      
-    joins.push(
-      'left join revision on rgr.revId = revision.revId',
-      'left join stig_asset_map sa on revision.benchmarkId = sa.benchmarkId',
-    )
-
-    groupBy = [
-      "rgr.ruleId", 
-      "rgr.version",
-      "rgr.title",
-      "rgr.severity",
-      "rgr.groupId",
-      "rgr.groupTitle"
-    ]
+    columns.push(`cast(concat('[', group_concat(distinct json_object('benchmarkId',revision.benchmarkId,'revisionStr',revision.revisionStr)), ']') as json) as stigs`)
+    joins.push('left join revision on rgr.revId = revision.revId')
   }
   
   // CONSTRUCT MAIN QUERY

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -3399,7 +3399,9 @@ paths:
     get:
       tags:
         - STIG
-      summary: Return the defintion and associated check and fix for the specified Rule
+      summary: Return the definition and associated check and fix for the specified Rule
+      description: |
+        Note: A very small number of edge cases are known to exist where published STIGs have updated Rule Content without updating the associated RuleId. In these cases, it is possible this endpoint may return inconsistent Rule info. If you need specific Rule information for a given STIG Revision, use the `/stigs/{benchmarkId}/revisions/{revisionStr}/rules/{ruleId}` endpoint.
       operationId: getRuleByRuleId
       parameters:
         - $ref: '#/components/parameters/RuleProjectionQuery'

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -7508,8 +7508,16 @@ components:
           $ref: '#/components/schemas/GroupTitle'
         ruleId:
           $ref: '#/components/schemas/RuleId'
+        ruleIds:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuleId'
         severity:
           type: string
+        stigs:  
+          type: array
+          items:
+            $ref: '#/components/schemas/RevisionBasic'
         title:
           $ref: '#/components/schemas/RuleTitle'
         version:
@@ -8514,6 +8522,8 @@ components:
             - ccis
             - check
             - fix
+            - ruleIds
+            - stigs
     RuleSeverityQuery:
       name: severity
       in: query

--- a/test/api/mocha/data/stig/stigs.test.js
+++ b/test/api/mocha/data/stig/stigs.test.js
@@ -82,6 +82,23 @@ describe('GET - Stig', () => {
                     expect(res.body.version, "expect fix version to be the test version").to.be.equal(reference.testRule.version)
                     
                 })
+                it("get test rule data with all projections, uses a ruleId present in two revisions", async () => {
+
+                    const res = await utils.executeRequest(`${config.baseUrl}/stigs/rules/${reference.VPN_SRG_TEST_sharedRule}?projection=detail&projection=ccis&projection=check&projection=fix&projection=stigs&projection=ruleIds`, 'GET', iteration.token)
+                    expect(res.status).to.eql(200)
+                    expect(res.body).to.be.an('object')
+                    expect(res.body.ruleId, "expect ruleId returned to be the test ruleId").to.be.equal(reference.VPN_SRG_TEST_sharedRule)
+                    expect(res.body.groupId, "expect fix groupId to be the test groupId").to.be.equal("V-97043")
+                    expect(res.body.version, "expect fix version to be the test version").to.be.equal("SRG-NET-000041-VPN-000110")
+                    expect(res.body.stigs, "expect to get back two stig revisions").to.be.lengthOf(2)
+                    for(let stig of res.body.stigs){
+                        expect(stig.benchmarkId, "expect to get back test benchmark").to.be.equal(reference.benchmark)
+                        expect(stig.revisionStr, "expect to get back test revision string").to.be.oneOf(["V1R1", "V1R0"])                   
+                    }
+                    for(let rule of res.body.ruleIds){
+                        expect(rule, "expect ruleId returned to be the test ruleId").to.be.equal(reference.VPN_SRG_TEST_sharedRule)
+                    }
+                })
                 it("get test rule data with stigs projection, expecting to get two stig revisions back which will contain a shared ruleId", async () => {
 
                     const res = await utils.executeRequest(`${config.baseUrl}/stigs/rules/${reference.VPN_SRG_TEST_sharedRule}?projection=stigs`, 'GET', iteration.token)

--- a/test/api/mocha/data/stig/stigs.test.js
+++ b/test/api/mocha/data/stig/stigs.test.js
@@ -17,6 +17,7 @@ describe('GET - Stig', () => {
     before(async function () {
         await utils.loadAppData()
         await utils.uploadTestStig("U_VPN_SRG_V1R0_Manual-xccdf.xml")
+        await utils.uploadTestStig("U_VPN_SRG-OTHER_V1R1_twoRules-matchingFingerprints.xml")
     })
 
     for(const iteration of iterations){
@@ -72,7 +73,7 @@ describe('GET - Stig', () => {
                 })
             })
             describe('GET - getRuleByRuleId - /stigs/rules/{ruleId}', () => {
-                it('get test ruledata with all projections', async () => {
+                it('get test ruledata with all projections besides stigs and ruleIds', async () => {
                     const res = await utils.executeRequest(`${config.baseUrl}/stigs/rules/${reference.testRule.ruleId}?projection=detail&projection=ccis&projection=check&projection=fix`, 'GET', iteration.token)
                     expect(res.status).to.eql(200)
                     expect(res.body).to.be.an('object')
@@ -80,6 +81,46 @@ describe('GET - Stig', () => {
                     expect(res.body.groupId, "expect fix groupId to be the test groupId").to.be.equal(reference.testRule.groupId)
                     expect(res.body.version, "expect fix version to be the test version").to.be.equal(reference.testRule.version)
                     
+                })
+                it("get test rule data with stigs projection, expecting to get two stig revisions back which will contain a shared ruleId", async () => {
+
+                    const res = await utils.executeRequest(`${config.baseUrl}/stigs/rules/${reference.VPN_SRG_TEST_sharedRule}?projection=stigs`, 'GET', iteration.token)
+                    expect(res.status).to.eql(200)
+                    expect(res.body).to.be.an('object')
+                    expect(res.body.ruleId, "expect ruleId returned to be the test ruleId").to.be.equal(reference.VPN_SRG_TEST_sharedRule)
+                    expect(res.body.groupId, "expect fix groupId to be the test groupId").to.be.equal("V-97043")
+                    expect(res.body.version, "expect fix version to be the test version").to.be.equal("SRG-NET-000041-VPN-000110")
+                    expect(res.body.stigs, "expect to get back two stig revisions").to.be.lengthOf(2)
+                    for(let stig of res.body.stigs){
+                        expect(stig.benchmarkId, "expect to get back test benchmark").to.be.equal(reference.benchmark)
+                        expect(stig.revisionStr, "expect to get back test revision string").to.be.oneOf(["V1R1", "V1R0"])                   
+                    }
+                })
+                it("get test rule data with ruleIds projection, should return ruleIds with equivalent check content hash + version. will query for both ruleIds in a single test", async () => {
+
+                    const rule1 = "SV-106179r1_zzzzzz"
+                    const rule2 = "SV-106179r1_xxxx"
+
+                    const res = await utils.executeRequest(`${config.baseUrl}/stigs/rules/${rule1}?projection=ruleIds`, 'GET', iteration.token)
+                    expect(res.status).to.eql(200)
+                    expect(res.body.ruleId, "expect ruleId returned to be the test ruleId").to.be.equal(rule1)
+                    expect(res.body.groupId, "expect fix groupId to be the test groupId").to.be.equal("V-97041")
+                    expect(res.body.version, "expect fix version to be the test version").to.be.equal("SRG-NET-000019-VPN-000040")
+                    expect(res.body.ruleIds, "expect to get back two ruleIds with equivalent check content hash + version. ").to.be.lengthOf(2)
+                    for(let rule of res.body.ruleIds){
+                        expect(rule, "expect ruleId returned to be the test ruleId").to.be.oneOf([rule1, rule2])
+                    }
+
+                    const res2 = await utils.executeRequest(`${config.baseUrl}/stigs/rules/${rule2}?projection=ruleIds`, 'GET', iteration.token)
+                    expect(res2.status).to.eql(200)
+                    expect(res2.body.ruleId, "expect ruleId returned to be the test ruleId").to.be.equal(rule2)
+                    expect(res2.body.groupId, "expect fix groupId to be the test groupId").to.be.equal(res.body.groupId)
+                    expect(res2.body.version, "expect fix version to be equal to previous clone rule").to.be.equal(res.body.version)
+                    expect(res2.body.ruleIds, "expect to get back two ruleIds with equivalent check content hash + version. ").to.be.lengthOf(2)
+                    for(let rule of res2.body.ruleIds){
+                        expect(rule, "expect ruleId returned to be the test ruleId").to.be.oneOf([rule1, rule2])
+                    }
+
                 })
             })
             describe('GET - getScapMap - /stigs/scap-maps', () => {

--- a/test/api/mocha/referenceData.js
+++ b/test/api/mocha/referenceData.js
@@ -521,6 +521,7 @@ const reference = {
     groupId: "V-97041",
     version: "SRG-NET-000019-VPN-000040",
   },
+  VPN_SRG_TEST_sharedRule: "SV-106181r1_rule",
   testRuleNoMetadata: {
     ruleId: "SV-106191r1_rule",
   },


### PR DESCRIPTION
resolves #1509

This PR introduced two new projections [`"stigs", "ruleIds"]` to GET `/stigs/rules/{ruleId} `

Schema:
- getRuleByRuleId now accepts two new projections [`"stigs", "ruleIds"]`
- getRuleByRuleId's response can now optionally include a ruleIds array and stigs array

API:

- Code was added to handle two new projections [`"stigs", "ruleIds"]`

Tests:

- Test were added to ensure correct functionality