### PR TITLE
Added test for op/definition with jsonPath param

### DIFF
--- a/api/source/bootstrap/docs.js
+++ b/api/source/bootstrap/docs.js
@@ -22,15 +22,14 @@ function serveDocs(app) {
 }
 
 function serveApiDocs(app) {
- 
-     if (config.swaggerUi.enabled) {
-        const oasDoc = getOAS()
+    const oasDoc = getOAS()
+    if (config.swaggerUi.enabled) {
         configureSwaggerUI(app, oasDoc)
-     }
-     else 
-     {
+    }
+    else 
+    {
         logger.writeDebug('serveApiDocs', 'SwaggerUI', { message: 'Swagger UI is disabled in configuration' })
-     }
+    }
 }
 
 function getOAS(){

--- a/test/api/mocha/data/operation/op.test.js
+++ b/test/api/mocha/data/operation/op.test.js
@@ -60,6 +60,20 @@ describe('GET - Op', () => {
           expect(res.status).to.eql(200)
         })
       })
+      describe('getDefinition - /op/definition - with jsonPath param', () => {
+        it('Return API Deployment Definition', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/op/definition?jsonpath=%24.components.schemas.RoleId`, 'GET', iteration.token)
+          expect(res.status).to.eql(200)
+          const expectedSchema =  [
+            {
+              "maximum": 4,
+              "minimum": 1,
+              "type": "integer"
+            }
+          ]
+          expect(res.body).to.eql(expectedSchema)
+        })
+      })
     })
   }
 })

--- a/test/api/mocha/data/operation/op.test.js
+++ b/test/api/mocha/data/operation/op.test.js
@@ -71,7 +71,7 @@ describe('GET - Op', () => {
               type: "integer"
             }
           ]
-          expect(res.body).to.eql(expectedSchema)
+          expect(res.body[0]).to.deep.equal(expectedSchema[0])
         })
       })
     })

--- a/test/api/mocha/data/operation/op.test.js
+++ b/test/api/mocha/data/operation/op.test.js
@@ -66,9 +66,9 @@ describe('GET - Op', () => {
           expect(res.status).to.eql(200)
           const expectedSchema =  [
             {
-              "maximum": 4,
-              "minimum": 1,
-              "type": "integer"
+              maximum: 4,
+              minimum: 1,
+              type: "integer"
             }
           ]
           expect(res.body).to.eql(expectedSchema)


### PR DESCRIPTION
checks that endpoint responds with correct portion of api definition when provided with jsonPath param