### PR TITLE
fix: adds checking if a collection exists when elevated in getCollectionInfoAndCheckPermission

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -256,7 +256,7 @@ module.exports.getAssetsByStig = async function getAssetsByStig (req, res, next)
     const labelMatch = req.query.labelMatch
     const projections = req.query.projection
 
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const response = await AssetService.getAssetsByStig({
       collectionId, 
       benchmarkId, 
@@ -309,7 +309,7 @@ module.exports.attachAssetsToStig = async function attachAssetsToStig (req, res,
     let assetIds = req.body
     let projections = req.query.projection
 
-    const { collectionId, grant } = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Manage)
+    const { collectionId, grant } = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Manage)
     let collection = await CollectionService.getCollection( collectionId, ['assets'], false, req.userObject)
     let collectionAssets = collection.assets.map( a => a.assetId)
     if (assetIds.every( a => collectionAssets.includes(a))) {

--- a/api/source/controllers/Metrics.js
+++ b/api/source/controllers/Metrics.js
@@ -7,7 +7,7 @@ const {stringify: csvStringify} = require('csv-stringify/sync')
 
 async function getCollectionMetrics (req, res, next, {style, aggregation, firstRowOnly = false}) {
   try {
-    const { collectionId, grant } = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const { collectionId, grant } = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const returnType = req.query.format || 'json'
     const filter = {
       labelNames: req.query.labelName,

--- a/api/source/controllers/Review.js
+++ b/api/source/controllers/Review.js
@@ -12,7 +12,7 @@ const _this = this
 
 module.exports.postReviewsByAsset = async function postReviewsByAsset (req, res, next) {
   try {
-    const { collectionId } = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const { collectionId } = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const assetId = req.params.assetId
     const reviews = req.body
     const result = await ReviewService.putReviewsByAsset({
@@ -36,7 +36,7 @@ module.exports.deleteReviewByAssetRule = async function deleteReviewByAssetRule 
     let ruleId = req.params.ruleId
     let projections = req.query.projection
     
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant, checkWritable: true})
     if (userHasRule) {
       let response = await ReviewService.deleteReviewByAssetRule({assetId, ruleId, projections, grant, svcStatus: res.svcStatus})
@@ -61,7 +61,7 @@ module.exports.getReviewByAssetRule = async function (req, res, next) {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
     let projections = req.query.projection
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     
     let response = await ReviewService.getReviews({
       projections, 
@@ -85,7 +85,7 @@ module.exports.getReviewByAssetRule = async function (req, res, next) {
 module.exports.getReviewsByCollection = async function getReviewsByCollection (req, res, next) {
   try {
     let projections = req.query.projection
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
 
     let response = await ReviewService.getReviews({
       projections,
@@ -116,7 +116,7 @@ module.exports.getReviewsByAsset = async function (req, res, next) {
   try {
     let assetId = req.params.assetId
     let projections = req.query.projection
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     
     let response = await ReviewService.getReviews({
       projections,
@@ -141,7 +141,7 @@ module.exports.getReviewsByAsset = async function (req, res, next) {
 
 module.exports.putReviewByAssetRule = async function (req, res, next) {
   try {
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const {assetId, ruleId} = {...req.params}
     const review = {...req.body, ruleId}
     const projections = req.query.projection
@@ -174,7 +174,7 @@ module.exports.patchReviewByAssetRule = async function (req, res, next) {
     if (Object.hasOwn(req.body, 'resultEngine') && !Object.hasOwn(req.body, 'result')) {
       throw new SmError.UnprocessableError('Request body with resultEngine must include a result')
     }
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const {assetId, ruleId} = {...req.params}
     const currentReviews =  await ReviewService.getReviews({
       filter: {assetId, ruleId},
@@ -214,7 +214,7 @@ module.exports.getReviewMetadata = async function (req, res, next) {
   try {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant})
     if (userHasRule) {
       let response = await ReviewService.getReviewMetadata( assetId, ruleId, req.userObject)
@@ -234,7 +234,7 @@ module.exports.patchReviewMetadata = async function (req, res, next) {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
     let metadata = req.body
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant, checkWritable: true})
     if (userHasRule) {
       await ReviewService.patchReviewMetadata( assetId, ruleId, metadata)
@@ -255,7 +255,7 @@ module.exports.putReviewMetadata = async function (req, res, next) {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
     let body = req.body
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant, checkWritable: true})
     if (userHasRule) {
       await ReviewService.putReviewMetadata( assetId, ruleId, body)
@@ -275,7 +275,7 @@ module.exports.getReviewMetadataKeys = async function (req, res, next) {
   try {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant})
     if (userHasRule) {
       let response = await ReviewService.getReviewMetadataKeys( assetId, ruleId, req.userObject)
@@ -298,7 +298,7 @@ module.exports.getReviewMetadataValue = async function (req, res, next) {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
     let key = req.params.key
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant})
     if (userHasRule) {
       let response = await ReviewService.getReviewMetadataValue( assetId, ruleId, key, req.userObject)
@@ -322,7 +322,7 @@ module.exports.putReviewMetadataValue = async function (req, res, next) {
     let ruleId = req.params.ruleId
     let key = req.params.key
     let value = req.body
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant, checkWritable: true})
     if (userHasRule) {
       await ReviewService.putReviewMetadataValue( assetId, ruleId, key, value)
@@ -342,7 +342,7 @@ module.exports.deleteReviewMetadataKey = async function (req, res, next) {
     let assetId = req.params.assetId
     let ruleId = req.params.ruleId
     let key = req.params.key
-    const {collectionId, grant} = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const {collectionId, grant} = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const userHasRule = await ReviewService.checkRuleByAssetUser({ruleId, assetId, collectionId, grant: grant, checkWritable: true})
     if (userHasRule) {
       await ReviewService.deleteReviewMetadataKey( assetId, ruleId, key, req.userObject)
@@ -360,7 +360,7 @@ module.exports.deleteReviewMetadataKey = async function (req, res, next) {
 module.exports.postReviewBatch = async function (req, res, next) {
   try {
   
-    const { collectionId, grant } = Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
+    const { collectionId, grant } = await Collection.getCollectionInfoAndCheckPermission(req, Security.ROLES.Restricted)
     const collectionSettings = await CollectionService.getCollectionSettings(collectionId)
     const historySettings = collectionSettings.history
     const statusSettings = collectionSettings.status

--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -432,6 +432,12 @@ exports.queryCollections = async function ({projections = [], filter = {}, eleva
     return rows  
 }
 
+exports.doesCollectionExist = async function (collectionId) {
+  const sql = `SELECT collectionId FROM collection WHERE collectionId = ?`
+  const [rows] = await dbUtils.pool.query(sql, [collectionId])
+  return rows.length > 0
+}
+
 
 exports.addOrUpdateCollection = async function(writeAction, collectionId, body, projection, userObject, svcStatus = {}) {
   // CREATE: collectionId will be null

--- a/test/api/mocha/data/collection/collectionGet.test.js
+++ b/test/api/mocha/data/collection/collectionGet.test.js
@@ -232,6 +232,19 @@ describe('GET - Collection', function () {
             expect(distinct.validStigs).to.include(stig.benchmarkId)
           }          
         })
+        it('pass non-existent collection Id with elevate, expect 404 (mostly just testing getCollectionInfoAndCheckPermission here) ',async function () {
+
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${'123456'}?elevate=true`, 'GET', iteration.token)
+
+          if(iteration.name === 'stigmanadmin'){
+            expect(res.status).to.eql(404)
+            expect(res.body.error).to.equal("Resource not found.")
+            expect(res.body.detail).to.equal("Collection not found")
+          }
+          else{
+            expect(res.status).to.eql(403)
+          }
+        })
       })
 
       describe('getChecklistByCollectionStig - /collections/{collectionId}/checklists/{benchmarkId}/{revisionStr}', function () {


### PR DESCRIPTION
resolves #1364 

This pr correctly adds proper error handling when `getCollectionInfoAndCheckPermission` is called with elevate=true. 

Changes:

- Adds new function to Collection Service `doesCollectionExist` which will query the database for a collectionId to ensure it exists 
- `getCollectionInfoAndCheckPermission` now calls `doesCollectionExist` when envoked with elevate=true. 
- Makes `getCollectionInfoAndCheckPermission` async 
- Adds await to calls to `getCollectionInfoAndCheckPermission`
- Adds a test to confirm functionality. 