### PR TITLE
fix: display the collection properties panel in app manage

### DIFF
--- a/client/src/js/collectionAdmin.js
+++ b/client/src/js/collectionAdmin.js
@@ -84,7 +84,7 @@ function addCollectionAdmin( params ) {
     iconCls: 'sm-collection-icon',
     title: 'Collections',
     closable: true,
-    layout: 'fit',
+    layout: 'border',
     border: false,
     items: [collectionGrid, adminPropsPanel],
     listeners: {


### PR DESCRIPTION
This PR fixes a bug where the Collection Properties panel for Application Management -> Collections is not being displayed.