### PR TITLE
fix: only let coverage script run on e2e api tests

### DIFF
--- a/test/api/runMocha.sh
+++ b/test/api/runMocha.sh
@@ -103,7 +103,7 @@ coverage() {
     // Wait for the API to start
     setTimeout(() => {
       console.log('Running Mocha tests...')
-      const tests = spawn('mocha', ['*/**/*.test.js', '--no-timeouts', '--ignore', '*/**/node_modules/**/*', '--recursive', '--ignore', './node_modules/**'], { stdio: 'inherit'})
+      const tests = spawn('mocha', ['./test/api/mocha/**/*.test.js', '--no-timeouts', '--ignore', '*/**/node_modules/**/*', '--recursive', '--ignore', './node_modules/**'], { stdio: 'inherit'})
 
       tests.on('close', (code) => {
         console.log('Tests finished. Stopping server...')


### PR DESCRIPTION
script when ran with coverage was calling state tests which ultimately causes failures. Is now only scopes to e2e api tests.