### PR TITLE
feat: adds dry run to batch asset creation

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -52,6 +52,7 @@ module.exports.createAssets = async function createAssets (req, res, next) {
     let projections = req.query.projection
     const collectionId  = req.params.collectionId
     let assets = req.body
+    let dryRun = req.query.dryRun
 
     const grant = req.userObject.grants[collectionId]
     if (!grant || grant.roleId < 3) throw new SmError.PrivilegeError()
@@ -66,9 +67,14 @@ module.exports.createAssets = async function createAssets (req, res, next) {
     const failures = await dbUtils.validateItems({assets, collectionId})
 
     if (failures.length > 0) {
-      throw new  SmError.UnprocessableError(failures)
+      throw new SmError.UnprocessableError(failures)
     }
 
+    if(dryRun) {
+      res.status(200).json({ message: "Validation successful, no errors detected." })
+      return
+    }
+    
     let assetIds
     assetIds = await AssetService.createAssets( {assets, collectionId, svcStatus: res.svcStatus})
     

--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -25,7 +25,7 @@ module.exports.createAsset = async function createAsset (req, res, next) {
     assets.noncomputing = assets.hasOwnProperty("noncomputing") ? (assets.noncomputing ? 1 : 0) : 0
     assets = [assets]
 
-    const failures = await dbUtils.validateItems({assets, collectionId})
+    const failures = await dbUtils.createAssetValidation({assets, collectionId})
 
     if (failures.length > 0) {
       throw new  SmError.UnprocessableError(failures)
@@ -64,14 +64,14 @@ module.exports.createAssets = async function createAssets (req, res, next) {
       noncomputing: asset.hasOwnProperty("noncomputing") ? (asset.noncomputing ? 1 : 0) : 0
     }))
 
-    const failures = await dbUtils.validateItems({assets, collectionId})
+    const failures = await dbUtils.createAssetValidation({assets, collectionId})
 
     if (failures.length > 0) {
       throw new SmError.UnprocessableError(failures)
     }
 
     if(dryRun) {
-      res.status(200).json({ message: "Validation successful, no errors detected." })
+      res.status(204).send()
       return
     }
     

--- a/api/source/service/utils.js
+++ b/api/source/service/utils.js
@@ -625,7 +625,7 @@ module.exports.retryOnDeadlock2 = async function ({ transactionFn, statusObj = {
 }
 
 
-exports.validateItems = async function({ assets, collectionId}) {
+exports.createAssetValidation = async function({ assets, collectionId}) {
   const assetJson = JSON.stringify(assets)
   const validationQuery = `
   WITH cteFails AS (

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -889,16 +889,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AssetCreateBatch'
       responses:
-        '200':
-          description: Array of AssetProjected responses. Dry run successful, returns expected response structure without persisting data.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-                    example: "Validation successful, no errors detected."
+        '204':
+          description: Dry run successful. Validation passed, but no data was persisted.
         '201':
           description: Array of AssetProjected responses
           content:
@@ -911,7 +903,6 @@ paths:
           description: Unprocessable Entity
           content:
             application/json:
-
               schema:
                 $ref: '#/components/schemas/ClientErrorBadAssetPost'
         default:

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -894,9 +894,11 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/AssetProjected'
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Validation successful, no errors detected."
         '201':
           description: Array of AssetProjected responses
           content:

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -881,6 +881,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/CollectionIdPath'
         - $ref: '#/components/parameters/AssetProjectionQuery'
+        - $ref: '#/components/parameters/DryRunQuery'
       requestBody:
         required: true
         content:
@@ -888,6 +889,14 @@ paths:
             schema:
               $ref: '#/components/schemas/AssetCreateBatch'
       responses:
+        '200':
+          description: Array of AssetProjected responses. Dry run successful, returns expected response structure without persisting data.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AssetProjected'
         '201':
           description: Array of AssetProjected responses
           content:
@@ -8817,6 +8826,13 @@ components:
           type: string
           enum:
             - assets
+    DryRunQuery:
+      name: dryRun
+      in: query
+      description: If set to `true`, performs validation without persisting data.
+      required: false
+      schema:
+        type: boolean
     DstCollectionIdPath:
       name: dstCollectionId
       in: path

--- a/test/api/mocha/data/asset/assetPost.test.js
+++ b/test/api/mocha/data/asset/assetPost.test.js
@@ -263,7 +263,7 @@ describe('POST - Asset', function () {
           await utils.loadAppData()
         })
 
-        it("Create Assets in batch all projections", async function () {
+        it("Create Assets in batch all projections dry run false ", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -289,7 +289,7 @@ describe('POST - Asset', function () {
             stigs: []
           }]
 
-          const res = await utils.executeRequest(`${config.baseUrl}/collections/21/assets?projection=stigs&projection=statusStats`, 'POST', iteration.token,
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/21/assets?projection=stigs&projection=statusStats&dryRun=false`, 'POST', iteration.token,
             assets
           )
             
@@ -716,7 +716,74 @@ describe('POST - Asset', function () {
             assetIndex: 1,
           })
         })
-        
+
+        it("Create Valid asset with dry run option expect 200", async function () {
+
+          const assets = [{
+            name: 'TestAsset' + utils.getUUIDSubString(10),
+            description: 'batch',
+            ip: '1.1.1.1',
+            noncomputing: true,
+            labelNames: [reference.testCollection.fullLabelName, reference.testCollection.lvl1LabelName],
+            metadata: {
+              batch: 'batch',
+            },
+            stigs: reference.testCollection.validStigs
+          }]
+
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/21/assets?dryRun=true&projection=stigs&projection=statusStats`, 'POST', iteration.token,
+            assets )
+          if(!distinct.canModifyCollection){
+            expect(res.status).to.eql(403)
+            return
+          }
+          expect(res.status).to.eql(200)
+          expect(res.body.message).to.equal("Validation successful, no errors detected.")
+        })
+
+        it("Create Valid asset with dry run option and non-existing labelname expect 422 and correct response", async function () {
+
+          const assets = [{
+            name: 'TestAsset' + utils.getUUIDSubString(10),
+            description: 'batch',
+            ip: '1.1.1.1',
+            noncomputing: true,
+            labelNames: [],
+            metadata: {
+              batch: 'batch',
+            },
+            stigs: reference.testCollection.validStigs
+          },
+          {
+            name: 'TestAsset' + utils.getUUIDSubString(10),
+            description: 'batch',
+            ip: '1.1.1.1',
+            noncomputing: true,
+            labelNames: ["unknownLabel"],
+            metadata: {
+              batch: 'batch',
+            },
+            stigs: reference.testCollection.validStigs
+          },
+        ]
+
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/21/assets?dryRun=true&projection=stigs&projection=statusStats`, 'POST', iteration.token,
+            assets )
+
+          if(!distinct.canModifyCollection){
+            expect(res.status).to.eql(403)
+            return
+          }
+          expect(res.status).to.eql(422)
+          expect(res.body.detail).to.be.an('array').of.length(1)
+          expect(res.body.detail[0].failure).to.equal("unknown labelName")
+          expect(res.body.detail[0].detail).to.eql({
+            name: assets[1].name,
+            labelName: "unknownLabel",
+            assetIndex: 2,
+            labelIndex: 1,
+          })
+        })
       })
     })
   }

--- a/test/api/mocha/data/asset/assetPost.test.js
+++ b/test/api/mocha/data/asset/assetPost.test.js
@@ -737,8 +737,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(200)
-          expect(res.body.message).to.equal("Validation successful, no errors detected.")
+          expect(res.status).to.eql(204)
         })
 
         it("Create Valid asset with dry run option and non-existing labelname expect 422 and correct response", async function () {


### PR DESCRIPTION
Part of issue 1533

Behavior with dryRun=true:

- Runs validation check only, without creating assets.
- Returns 204 if validation passes.
- Returns 422 Unprocessable Entity if validation fails with the validation errors.

Behavior without dryRun (as it was before):
- Runs validation and proceeds with asset creation.
- Returns 201 Created on success or 422 Unprocessable Entity on validation failure with validation errors.