### PR TITLE
fix: show filter menu on click of nested header elements

### DIFF
--- a/client/src/js/SM/ColumnFilters.js
+++ b/client/src/js/SM/ColumnFilters.js
@@ -15,7 +15,8 @@ SM.ColumnFilters.extend = function extend (extended, ex) {
     handleHdDown: function (e, target) {
       // Modifies superclass method to support lastHide
   
-      if (target.classList[0] !== 'x-grid3-hd-inner') {
+      // to support headers with tooltip in <span>, check parent node for the hd-inner class
+      if (target.classList[0] !== 'x-grid3-hd-inner' && target.parentElement.classList[0] !== 'x-grid3-hd-inner') {
         return
       }
       e.stopEvent()


### PR DESCRIPTION
Resolves #1570 

This PR modifies the `handleHdDown` override in `client/src/js/SM/ColumnFilters.js`, which is responsible for displaying a column filter menu when a grid header is clicked. A more expansive condition was added that displays the menu if the target **or it's parent element** contains the ExtJS class `x-grid3-hd-inner`. This results in the filter menu being shown more reliably.