### PR TITLE
deps: Update client modules to 1.5.1

### DIFF
--- a/client/src/js/modules/package-lock.json
+++ b/client/src/js/modules/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.5.0",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.5.1",
         "chart.js": "^4.4.2",
         "serialize-error": "^11.0.0"
       }
@@ -16,9 +16,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.5.0.tgz",
-      "integrity": "sha512-cBqt6UmXLzQMc1tV/tnabObMbigbvPbbeTYpm4WJ27qmXw2uxL8Rekd4goblG2/42NEIWKB1vZlUnYpNg1KRHA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.5.1.tgz",
+      "integrity": "sha512-13keys8o3hesRAT6BWO+6hFcx2i9FlUBP4u6ldJnsfTKJMvq8O+ksBSEVLoKS+pTgdv0/JUNqTBBZyztUHZ3jw==",
       "hasInstallScript": true
     },
     "node_modules/chart.js": {

--- a/client/src/js/modules/package.json
+++ b/client/src/js/modules/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.5.0",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.5.1",
     "chart.js": "^4.4.2",
     "serialize-error": "^11.0.0"
   }


### PR DESCRIPTION
no longer requires ckl/b element releaseInfo