### PR TITLE
feat: envvar for client OAuth2 response_mode

### DIFF
--- a/api/source/bootstrap/client.js
+++ b/api/source/bootstrap/client.js
@@ -46,7 +46,8 @@ function getClientEnv(){
                 disabled: ${config.client.refreshToken.disabled}
                 },
                 extraScopes: "${config.client.extraScopes ?? ''}",
-                scopePrefix: "${config.client.scopePrefix ?? ''}"
+                scopePrefix: "${config.client.scopePrefix ?? ''}",
+                responseMode: "${config.client.responseMode}"
             },
             experimental: {
                 appData: "${config.experimental.appData}"

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -29,6 +29,7 @@ const config = {
         directory: process.env.STIGMAN_CLIENT_DIRECTORY || '../../client/dist',
         extraScopes: process.env.STIGMAN_CLIENT_EXTRA_SCOPES,
         scopePrefix: process.env.STIGMAN_CLIENT_SCOPE_PREFIX,
+        responseMode: process.env.STIGMAN_CLIENT_RESPONSE_MODE || "fragment",
         refreshToken: {
             disabled: process.env.STIGMAN_CLIENT_REFRESH_DISABLED ? process.env.STIGMAN_CLIENT_REFRESH_DISABLED === "true" : false,
         },

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -27,6 +27,8 @@
 | String used as a prefix for each scope when authenticating to the OIDC Provider. Some providers (Azure AD) expect scope requests in the format ``api://<application_id>/<scope>``, where ``api://<application_id>/`` is the required prefix.","Client"
 "STIGMAN_CLIENT_REFRESH_DISABLED","| **Default** ``false``
 | Whether the web client should use a provided refresh token to update the access token","Client"
+"STIGMAN_CLIENT_RESPONSE_MODE","| **Default** ``fragment``
+| The response_mode the web client should specify when requesting an authorization code from the OIDC provider. Available values: ``fragment``, ``query`` ","Client"
 "STIGMAN_CLIENT_WELCOME_IMAGE ","| **No default**
 | The URL of an image hosted elsewhere that will be rendered in the Home tab Welcome widget. The STIGMan app does not serve the image itself, only the reference to it. The URL should be in relation to and accessible from the client's browser. The image will be scaled to a max width or height of 125 pixels - If no alternate image is specified, the seal of the Department of the Navy (the project sponsor)  will be displayed. ","Client Appearance"
 "STIGMAN_CLIENT_WELCOME_LINK","| **No default**


### PR DESCRIPTION
Resolves #1580 

This PR introduces support for configuration of the Oauth2 `response_mode` requested by the web app when initiating the Authorization Code Flow with PKCE. Current behavior is to always request `response_mode=fragment`.

`api/source/utils/config.js` was modified to support a new environment variable `STIGMAN_CLIENT_RESPONSE_MODE` which can take the values `query` or `fragment` with a default of `fragment`. I went with `fragment` as the default to ensure backwards compatibility and because there may be a marginal security benefit. Fragments are not logged by many proxies and Chrome Dev Tools suppresses the fragment from HAR files.

`api/source/bootstrap/client.js` was modified to add `STIGMAN.Env.oauth.responseMode` to the dynamically generated `js/Env.js`, with the value taken from the API configuration.

`client/src/js/modules/oidcProvider.js` was modified to honor `STIGMAN.Env.oauth.responseMode` when initiating Authorization Code Flow with PKCE and when parsing the OP's redirect. 

I did not include validation of the user provided value to `STIGMAN_CLIENT_RESPONSE_MODE` since env var validation will be addressed by #1519 which is scheduled for development this month.