### PR TITLE
fix: getFindingsByCollection handles absent projection

### DIFF
--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -712,7 +712,7 @@ exports.getCollection = async function(collectionId, projections, elevate, userO
 }
 
 
-exports.getFindingsByCollection = async function( {collectionId, aggregator, benchmarkId, assetId, acceptedOnly, projections, grant} ) {
+exports.getFindingsByCollection = async function( {collectionId, aggregator, benchmarkId, assetId, acceptedOnly, projections = [], grant} ) {
   let columns, groupBy, orderBy
   switch (aggregator) {
     case 'ruleId':

--- a/test/api/mocha/data/collection/collectionGet.test.js
+++ b/test/api/mocha/data/collection/collectionGet.test.js
@@ -340,6 +340,16 @@ describe('GET - Collection', function () {
             }
         })
 
+        it('Return the Findings for the specified Collection by cci, no projections', async function () {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/findings?aggregator=cci&acceptedOnly=false`, 'GET', iteration.token)
+            if (distinct.grant === "none"){
+              expect(res.status).to.eql(403)
+              return
+            }
+            expect(res.status).to.eql(200)
+            expect(res.body).to.have.lengthOf(distinct.findings.findingsByCciCnt)
+        })
+
         it('Return the Findings for the specified Collection for benchmarkId x ruleId',async function () {
           const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/findings?aggregator=ruleId&acceptedOnly=false&benchmarkId=${reference.benchmark}&projection=assets`, 'GET', iteration.token)
             if (distinct.grant === "none"){
@@ -373,6 +383,7 @@ describe('GET - Collection', function () {
               expect(finding.assets[0].assetId).to.equal(reference.testAsset.assetId)
             }
         })
+
       })
 
       describe('getEffectiveAclByCollectionUser - /collections/{collectionId}/users/{userId}/effective-acl', function () {


### PR DESCRIPTION
Resolves #1587 

- Updates `api/source/service/CollectionService.js` -> `getFindingsByCollection` so the `projections` parameter has a default value of `[]`.
- Adds a test to `test/api/mocha/data/collection/collectionGet.test.js` that calls `getFindingsByCollection` with no projections.

Note: The tests for `getFindingsByCollection` may require additional attention:
- address comment that says "needs some projection work"
- the test described as `Return the Findings for the specified Collection by ruleId` actually makes a request aggregated by CCI.