### PR TITLE
fix: Duplicate labels of different case can no longer be created.

### DIFF
--- a/client/src/js/SM/Manage.js
+++ b/client/src/js/SM/Manage.js
@@ -2173,8 +2173,11 @@ SM.Manage.Collection.LabelNameEditor = Ext.extend(Ext.form.Field, {
         }
         if (v === "") { return "Blank values not allowed" }
         // Is there an item in the store like _this?
-        let searchIdx = _this.grid.store.findExact('name', v)
-        // Is it _this?
+
+        let searchIdx = _this.grid.store.findBy(function (rec) {
+          return rec.get('name')?.toLowerCase() === v.toLowerCase()
+        })
+
         let isMe = _this.grid.selModel.isSelected(searchIdx)
         if (searchIdx == -1 || isMe) {
           return true


### PR DESCRIPTION
resolves:  #1581 

This PR fixes a bug that would allow a label of the same name but different case to be created in the UI.

The code now compares incoming labels and existing labels in all lowercase. 