### PR TITLE
fix: corrects asset batch create 422 response

### DIFF
--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -5974,9 +5974,9 @@ components:
                     type: string
                   benchmarkIdIndex:
                     type: integer
-                  labelId:
+                  labelName:
                     type: string
-                  labelIdIndex:
+                  labelIndex:
                     type: integer
       required:
         - error


### PR DESCRIPTION
This PR does not resolve an issue. 

Fixes incorrect OAS. 