### PR TITLE
fix: Fixes disappearing gear icon after modifying collection.

### DIFF
--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -160,7 +160,8 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
         const collectionLeaf = me.getCollectionLeaf(apiCollection.collectionId)
         if (collectionLeaf) {
           collectionLeaf.collectionName = apiCollection.name
-          collectionLeaf.setText(SM.he(collectionLeaf.collectionName))
+          const text = SM.he(collectionLeaf.collectionName) + '<img class="sm-tree-toolbar" src="img/gear.svg" width="12" height="12" ext:qtip="Manage Collection">'
+          collectionLeaf.setText(text)
           collectionLeaf.parentNode.sort(sortFn)
         }
       }


### PR DESCRIPTION
This PR has no issue. 

This PR fixes an issue where the gear icon to open the collection management screen would disappear after updating a collection.

To reproduce, open a collection management tab and alter a collection setting such as max reviews history. Notice the gear icon in the nav tree disappear. 

This PR prevents that the gear icon from disappearing. 
