### PR TITLE
refactor: createAssets dry run failure now returns 200.

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -28,7 +28,7 @@ module.exports.createAsset = async function createAsset (req, res, next) {
     const failures = await dbUtils.createAssetValidation({assets, collectionId})
 
     if (failures.length > 0) {
-      throw new  SmError.UnprocessableError(failures)
+      throw new SmError.UnprocessableError(failures)
     }
 
     let assetId
@@ -67,7 +67,11 @@ module.exports.createAssets = async function createAssets (req, res, next) {
     const failures = await dbUtils.createAssetValidation({assets, collectionId})
 
     if (failures.length > 0) {
-      throw new SmError.UnprocessableError(failures)
+      res.status(200).json({
+        error: 'Validation Error',
+        detail: failures
+      })
+      return
     }
 
     if(dryRun) {

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -889,8 +889,12 @@ paths:
             schema:
               $ref: '#/components/schemas/AssetCreateBatch'
       responses:
-        '204':
-          description: Dry run successful. Validation passed, but no data was persisted.
+        '200':
+          description: Dry Run Failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClientErrorBadAssetPost'
         '201':
           description: Array of AssetProjected responses
           content:
@@ -899,12 +903,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/AssetProjected'
-        '422':
-          description: Unprocessable Entity
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClientErrorBadAssetPost'
+        '204':
+          description: Dry run successful. Validation passed, but no data was persisted.
         default:
           description: unexpected error
           content:
@@ -5989,6 +5989,7 @@ components:
           type: string
           enum:
             - "422"
+          nullable: true
         error:
           type: string
         detail:

--- a/client/src/js/SM/Manage.js
+++ b/client/src/js/SM/Manage.js
@@ -3791,6 +3791,7 @@ SM.Manage.Asset.showParsedData = function (assets, errors, collectionId) {
       try {
         // dry run 
         if(parsedAssetsCopy.length) {
+
           const dryRunResponse = await Ext.Ajax.requestPromise({
             responseType: 'json',
             url: `${STIGMAN.Env.apiBase}/collections/${collectionId}/assets/?dryRun=true`,
@@ -3811,15 +3812,11 @@ SM.Manage.Asset.showParsedData = function (assets, errors, collectionId) {
             updateButtonStates()
             return
           }
-        }
-        // dry run fail
-      }
-      catch (error) {
-        if (error.status === 422) {
-            let responseData = JSON.parse(error.responseText)
+          // dry run fail
+          if (dryRunResponse.error) {
             
             // gather errors from the response
-            let newErrors = responseData.detail
+            let newErrors = dryRunResponse.detail
               // remove label errors
               .filter(err => {
                 const isLabelError = err.detail && err.detail.labelName
@@ -3860,13 +3857,14 @@ SM.Manage.Asset.showParsedData = function (assets, errors, collectionId) {
             updateButtonStates()
   
             // get unknown labels
-            let unknownLabels = [...new Set(responseData.detail.map(e => e.detail.labelName).filter(Boolean))]
+            let unknownLabels = [...new Set(dryRunResponse.detail.map(e => e.detail.labelName).filter(Boolean))]
             newLabels = unknownLabels.map(label => ({ labelName: label }))
             labelStore.loadData(newLabels)
+          }
         }
-        else {
-          SM.Error.handleError(error)
-        }
+      }
+      catch (error) {
+        SM.Error.handleError(error)
       }
       finally {
         Ext.getBody().unmask()

--- a/test/api/mocha/data/asset/assetPost.test.js
+++ b/test/api/mocha/data/asset/assetPost.test.js
@@ -263,7 +263,7 @@ describe('POST - Asset', function () {
           await utils.loadAppData()
         })
 
-        it("Create Assets in batch all projections dry run false ", async function () {
+        it("Create Assets in batch all projections dry run false should create assets", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -370,7 +370,7 @@ describe('POST - Asset', function () {
           }
         })
 
-        it("create two incorrect asssets both have stig that doesnt exist", async function () {
+        it("create two incorrect asssets both have stig that doesnt exist should return 200 for unsucessful dry run ", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -403,7 +403,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(2)
           for(const error of res.body.detail) {
             expect(error.failure).to.equal("unknown benchmarkId")
@@ -427,7 +427,7 @@ describe('POST - Asset', function () {
 
         })
 
-        it("Pass non existing collectionId", async function () {
+        it("Pass non existing collectionId should return 403", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -447,7 +447,7 @@ describe('POST - Asset', function () {
           expect(res.status).to.eql(403)
         })
 
-        it("Pass disabled collectionId", async function () {
+        it("Pass disabled collectionId should return 403 ", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -467,7 +467,7 @@ describe('POST - Asset', function () {
 
         })
 
-        it("Pass empty assets array", async function () {
+        it("Pass empty assets array should violate OAS for min items of 1", async function () {
 
           const res = await utils.executeRequest(`${config.baseUrl}/collections/21/assets`, 'POST', iteration.token,
            []
@@ -476,7 +476,7 @@ describe('POST - Asset', function () {
 
         })
 
-        it("Create assets with one that already exists, expect correct 422 response ", async function () {
+        it("Create assets with one that already exists, expect correct 200 response for dry run failure", async function () {
 
           const assets = [
             {
@@ -511,7 +511,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(1)
           expect(res.body.detail[0].failure).to.equal('name exists')
           expect(res.body.detail[0].detail).to.eql({
@@ -521,7 +521,7 @@ describe('POST - Asset', function () {
 
         })
 
-        it("Create Assets where one has non-existing labelName, expect correct 422 response", async function () {
+        it("Create Assets where one has non-existing labelName, expect correct 200 response for dry run failure", async function () {
           
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -552,7 +552,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(1)
           expect(res.body.detail[0].failure).to.equal("unknown labelName")
           expect(res.body.detail[0].detail).to.eql({
@@ -563,7 +563,7 @@ describe('POST - Asset', function () {
           })
         })
 
-        it("Create Assets where one has a non-existing benchmarkId, expect correct 422 response", async function () {
+        it("Create Assets where one has a non-existing benchmarkId, expect correct 200 response for dry run failure", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -594,7 +594,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(1)
           expect(res.body.detail[0].failure).to.equal("unknown benchmarkId")
           expect(res.body.detail[0].detail).to.eql({
@@ -607,7 +607,7 @@ describe('POST - Asset', function () {
 
         })
 
-        it("Create Assets where one has one correct label/benchmark and one non-existing label/benchmark, expect correct 422 response", async function () {
+        it("Create Assets where one has one correct label/benchmark and one non-existing label/benchmark, expect correct 200 response for dry run failure", async function () {
           
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -638,7 +638,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(2)
           for(const error of res.body.detail) {
             expect(error.failure).to.be.oneOf(["unknown labelName", "unknown benchmarkId"])
@@ -661,7 +661,7 @@ describe('POST - Asset', function () {
           }
         })
 
-        it("Create Duplicate Asset with not-existing benchmark/labelName expect correct 422", async function () {
+        it("Create Duplicate Asset with not-existing benchmark/labelName expect correct 200 for dry run failure", async function () {
 
           const assets = [{
             name: reference.testAsset.name,
@@ -680,7 +680,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(1)
           expect(res.body.detail[0].failure).to.equal("name exists")
           expect(res.body.detail[0].detail).to.eql({
@@ -689,7 +689,7 @@ describe('POST - Asset', function () {
           })
         })
 
-        it("Create Duplicate Asset with not-existing benchmark/labelName expect correct 422", async function () {
+        it("Create Duplicate Asset with not-existing benchmark/labelName expect correct 200 for dry run failure", async function () {
 
           const assets = [{
             name: reference.testAsset.name,
@@ -708,7 +708,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(1)
           expect(res.body.detail[0].failure).to.equal("name exists")
           expect(res.body.detail[0].detail).to.eql({
@@ -717,7 +717,7 @@ describe('POST - Asset', function () {
           })
         })
 
-        it("Create Valid asset with dry run option expect 200", async function () {
+        it("Create Valid asset with dry run option expect 204 no content sucessful dry run", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -740,7 +740,7 @@ describe('POST - Asset', function () {
           expect(res.status).to.eql(204)
         })
 
-        it("Create Valid asset with dry run option and non-existing labelname expect 422 and correct response", async function () {
+        it("Create Valid asset with dry run option and non-existing labelname expect 200 and correct response for dry run failure", async function () {
 
           const assets = [{
             name: 'TestAsset' + utils.getUUIDSubString(10),
@@ -773,7 +773,7 @@ describe('POST - Asset', function () {
             expect(res.status).to.eql(403)
             return
           }
-          expect(res.status).to.eql(422)
+          expect(res.status).to.eql(200)
           expect(res.body.detail).to.be.an('array').of.length(1)
           expect(res.body.detail[0].failure).to.equal("unknown labelName")
           expect(res.body.detail[0].detail).to.eql({


### PR DESCRIPTION
resolves #1609 

This PR alters the 422 response of a createAssets dry run failure to a 200. 