### PR TITLE
fix: correctly handles new response for duplicate asset name

### DIFF
--- a/client/src/js/SM/Manage.js
+++ b/client/src/js/SM/Manage.js
@@ -2882,7 +2882,7 @@ SM.Manage.Asset.showAssetProps = async function (assetId, initialCollectionId) {
         catch (e) {
           if (e.responseText) {
             const response = SM.safeJSONParse(e.responseText)
-            if (response?.detail === 'Duplicate name exists.') {
+            if (response?.detail[0].failure === 'name exists') {
               Ext.Msg.alert('Name unavailable', 'The Asset name is already used in this Collection. Please try a different name.')
             }
             else {


### PR DESCRIPTION
Attempting to create a duplicate asset in a collection now gracefully handles the error returned by the API. This functionality was broken when createAsset was altered during #1567. 