### PR TITLE
feat: Double click other assets in collection review for more complete info.

### DIFF
--- a/client/src/js/SM/Global.js
+++ b/client/src/js/SM/Global.js
@@ -250,12 +250,22 @@ SM.RuleContentTpl = new Ext.XTemplate(
       if (!value) return
 
       if (value.length > SM.TruncateLimit) {
-          return `${value.slice(0,SM.TruncateLimit)}... <span class=sm-truncated-action onclick="SM.ShowUntruncated('${record.store.storeId}','${record.id}','${property}')">Full text</span>`
+         return `${value.slice(0,SM.TruncateLimit)}... <span class=sm-truncated-action onclick="SM.ShowUntruncated('${record.store.storeId}','${record.id}','${property}')">Full text</span>`
       }
       else {
           return value
       }
-  }
+    }
+
+    SM.TruncateOnly = function (record, property) {
+        const value = SM.he(record.data[property])
+        if (!value) return ''
+
+        return value.length > SM.TruncateLimit
+            ? value.slice(0, SM.TruncateLimit) + '......'
+            : value
+    }
+
 
   SM.ShowUntruncated = function (storeId, recordId, property) {
     const record = Ext.StoreMgr.get(storeId).getById(recordId)


### PR DESCRIPTION
Resolves #847 

This PR enables users to double-click a row in the "Other Assets" grid within the collection review. Doing so opens a modal displaying an expanded, untrimmed version of the review for the selected asset.