### PR TITLE
fix: assign STIGMAN.oauth.strictPkce to boolean

### DIFF
--- a/api/source/bootstrap/client.js
+++ b/api/source/bootstrap/client.js
@@ -46,7 +46,7 @@ function getClientEnv(){
                 scopePrefix: "${config.client.scopePrefix ?? ''}",
                 responseMode: "${config.client.responseMode}",
                 reauthAction: "${config.client.reauthAction}",
-                strictPkce: "${config.client.strictPkce}",
+                strictPkce: ${config.client.strictPkce},
                 audienceValue: "${config.oauth.audienceValue ?? ''}",
                 claims: ${JSON.stringify(config.oauth.claims)}
             },


### PR DESCRIPTION
Resolves an issue where setting STIGMAN_CLIENT_STRICT_PKCE to `false` does not have the intended effect in the web app.

In `api/source/bootstrap/client.js`, needed to remove the double quotes around the .toString() value of `config.client.strictPkce`.