### PR TITLE
Handle scopeValue that is either an array or space-separated string

### DIFF
--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -182,7 +182,6 @@ function validateOidcConfiguration() {
 function getScopeStr() {
   const scopePrefix = ENV.scopePrefix
   let scopes = [
-    `openid`,
     `${scopePrefix}stig-manager:stig`,
     `${scopePrefix}stig-manager:stig:read`,
     `${scopePrefix}stig-manager:collection`,
@@ -372,8 +371,9 @@ function validateTokensResponse(tokensResponse) {
   return true
 }
 
-function validateScope(scopeStr, isAdmin = false) {
-  const scopes = scopeStr.split(' ')
+function validateScope(scopeValue, isAdmin = false) {
+  // Depending on OIDC provider, scopeValue can be a space-separated string (the standard) or an array of scopes. If a string, split it on spaces into an array.
+  const scopes = typeof scopeValue === 'string' ? scopeValue.split(' ') : scopeValue
   const hasScope = (s) => scopes.includes(s)
 
   // Required scopes for each privilege

--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -373,7 +373,9 @@ function validateTokensResponse(tokensResponse) {
 
 function validateScope(scopeValue, isAdmin = false) {
   // Depending on OIDC provider, scopeValue can be a space-separated string (the standard) or an array of scopes. If a string, split it on spaces into an array.
-  const scopes = typeof scopeValue === 'string' ? scopeValue.split(' ') : scopeValue
+  const scopes = typeof scopeValue === 'string' ? scopeValue.split(' ')
+	    : Array.isArray(scopeValue) ? scopeValue
+	    : []
   const hasScope = (s) => scopes.includes(s)
 
   // Required scopes for each privilege
@@ -396,7 +398,7 @@ function validateScope(scopeValue, isAdmin = false) {
   const required = isAdmin ? requiredAdminScopes : requiredUserScopes
   for (const s of required) {
     if (!hasScope(s)) {
-      throw new Error(`Missing required scope "${ENV.scopePrefix}${s}" for ${isAdmin ? 'admin' : 'user'} in access token payload. Received scopes: ${JSON.stringify(scopes)}`)
+      throw new Error(`Missing required scope "${ENV.scopePrefix}${s}" for ${isAdmin ? 'admin' : 'user'} in access token payload. Received scopes: ${JSON.stringify(scopeValue)}`)
     }
   }
   return true

--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -396,7 +396,7 @@ function validateScope(scopeValue, isAdmin = false) {
   const required = isAdmin ? requiredAdminScopes : requiredUserScopes
   for (const s of required) {
     if (!hasScope(s)) {
-      throw new Error(`Missing required scope "${ENV.scopePrefix}${s}" for ${isAdmin ? 'admin' : 'user'} in access token payload`)
+      throw new Error(`Missing required scope "${ENV.scopePrefix}${s}" for ${isAdmin ? 'admin' : 'user'} in access token payload. Received scopes: ${JSON.stringify(scopes)}`)
     }
   }
   return true


### PR DESCRIPTION
Handle scopeValue that is either an array or space-separated string.
Remove hard-coded openid scope from token request.