### PR TITLE
remove :op from required user scopes; handle array in aud claim; re-added "openid" to requested scopes 

### DIFF
--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -423,8 +423,19 @@ function validateClaims(payload) {
 }
 
 function validateAudience(payload) {
-  if (ENV.audienceValue && payload.aud !== ENV.audienceValue) {
-    throw new Error(`Invalid audience in access token payload: ${payload.aud}, expected: ${ENV.audienceValue}`)
+  if (ENV.audienceValue) {
+    if (Array.isArray(payload.aud)) {
+      if (!payload.aud.includes(ENV.audienceValue)) {
+        throw new Error(`Invalid audience in access token payload: ${payload.aud.join(', ')}, expected: ${ENV.audienceValue}`)
+      } 
+    }
+    else if (typeof payload.aud === 'string') {
+      if (payload.aud !== ENV.audienceValue) {
+        throw new Error(`Invalid audience in access token payload: ${payload.aud}, expected: ${ENV.audienceValue}`)
+      }
+    } else {
+      throw new Error(`Invalid audience type in access token payload: ${typeof payload.aud}, expected string or array`)
+    }
   }
   return true
 }

--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -187,8 +187,7 @@ function getScopeStr() {
     `${scopePrefix}stig-manager:collection`,
     `${scopePrefix}stig-manager:user`,
     `${scopePrefix}stig-manager:user:read`,
-    `${scopePrefix}stig-manager:op`,
-    `${scopePrefix}stig-manager:op:read`
+    `${scopePrefix}stig-manager:op`
   ]
   if (ENV.extraScopes) {
     scopes.push(...ENV.extraScopes.split(" "))
@@ -389,7 +388,6 @@ function validateScope(scopeValue, isAdmin = false) {
   const requiredUserScopes = [
     'stig-manager:stig:read',
     'stig-manager:user:read',
-    'stig-manager:op:read',
     'stig-manager:collection'
   ]
 

--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -187,7 +187,8 @@ function getScopeStr() {
     `${scopePrefix}stig-manager:collection`,
     `${scopePrefix}stig-manager:user`,
     `${scopePrefix}stig-manager:user:read`,
-    `${scopePrefix}stig-manager:op`
+    `${scopePrefix}stig-manager:op`,
+    `${scopePrefix}stig-manager:op:read`
   ]
   if (ENV.extraScopes) {
     scopes.push(...ENV.extraScopes.split(" "))
@@ -388,7 +389,7 @@ function validateScope(scopeValue, isAdmin = false) {
   const requiredUserScopes = [
     'stig-manager:stig:read',
     'stig-manager:user:read',
-    'stig-manager:op',
+    'stig-manager:op:read',
     'stig-manager:collection'
   ]
 

--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -182,6 +182,7 @@ function validateOidcConfiguration() {
 function getScopeStr() {
   const scopePrefix = ENV.scopePrefix
   let scopes = [
+    `openid`,
     `${scopePrefix}stig-manager:stig`,
     `${scopePrefix}stig-manager:stig:read`,
     `${scopePrefix}stig-manager:collection`,


### PR DESCRIPTION
removed stig-manager:op from requiredUserScopes
re-added "openid" to scope request to conform with oidc authorization code flow standard