### PR TITLE
oidcWorker: Store refresh token even if we can't read it.

### DIFF
--- a/client/src/js/oidcWorker.js
+++ b/client/src/js/oidcWorker.js
@@ -348,6 +348,7 @@ function setTokensWithRefresh(tokensResponse) {
     setRefreshTokenTimer(refreshTimes.timeoutInMs)
   } else {
     console.log(logPrefix, 'Refresh expiration unknown or zero, Access token expires: ', accessTimes.expiresDateISO, ' timeout: ', accessTimes.timeoutDateISO)
+    tokens.refreshToken = tokensResponse.refresh_token ? tokensResponse.refresh_token : null
     setAccessTokenTimer(accessTimes.timeoutInMs)
     return
   }


### PR DESCRIPTION
With opaque refresh tokens, we set a timer based on the access token expiration (since we can't read the refresh expiration), but were not storing the actual refresh token if present. 