### PR TITLE
re: recalculate stats only on enabled collections

### DIFF
--- a/.github/workflows/api-audit-test-coverage-response.yml
+++ b/.github/workflows/api-audit-test-coverage-response.yml
@@ -24,6 +24,8 @@ env:
   STIGMAN_DB_HOST: localhost
   STIGMAN_DB_PORT: 3306
   STIGMAN_DB_PASSWORD: stigman
+  STIGMAN_DB_SCHEMA: stigman
+  STIGMAN_DB_USER: stigman
   STIGMAN_API_AUTHORITY: http://127.0.0.1:8080/auth/realms/stigman
   STIGMAN_SWAGGER_ENABLED: true
   STIGMAN_SWAGGER_SERVER: http://localhost:64001/api

--- a/.github/workflows/api-binary-tests.yml
+++ b/.github/workflows/api-binary-tests.yml
@@ -28,6 +28,8 @@ on:
 env:
   STIGMAN_API_PORT: 64001
   STIGMAN_DB_HOST: localhost
+  STIGMAN_DB_SCHEMA: stigman
+  STIGMAN_DB_USER: stigman
   STIGMAN_DB_PORT: 3306
   STIGMAN_DB_PASSWORD: stigman
   STIGMAN_API_AUTHORITY: http://127.0.0.1:8080/auth/realms/stigman

--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -71,6 +71,10 @@ jobs:
           -e STIGMAN_DEV_ALLOW_INSECURE_TOKENS=true \
           ${{ matrix.container.name }}
 
+      - name: Install API dependencies
+        run: npm ci
+        working-directory: ./api/source/
+
       - name: Install test dependencies
         run: npm ci
         working-directory: ./test/api/

--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -63,6 +63,8 @@ jobs:
           -e STIGMAN_DB_HOST=localhost \
           -e STIGMAN_DB_PORT=3306 \
           -e STIGMAN_DB_PASSWORD=stigman \
+          -e STIGMAN_DB_SCHEMA=stigman \
+          -e STIGMAN_DB_USER=stigman \
           -e STIGMAN_API_AUTHORITY=http://127.0.0.1:8080/auth/realms/stigman \
           -e STIGMAN_DEV_RESPONSE_VALIDATION=logOnly \
           -e STIGMAN_EXPERIMENTAL_APPDATA=true \

--- a/api/source/service/utils.js
+++ b/api/source/service/utils.js
@@ -464,6 +464,7 @@ module.exports.updateStatsAssetStig = async function(connection, {
        
        from
          enabled_asset a
+         ${(benchmarkId || benchmarkIds) ? 'inner join enabled_collection ec on a.collectionId = ec.collectionId' : ''}
          left join stig_asset_map sa using (assetId)
          left join default_rev dr on (sa.benchmarkId = dr.benchmarkId and a.collectionId = dr.collectionId)
          left join rev_group_rule_map rgr on dr.revId = rgr.revId

--- a/test/api/mocha/testConfig.js
+++ b/test/api/mocha/testConfig.js
@@ -22,5 +22,8 @@ export const config = {
             "enabled": "always",
             "required": "always"
         }
+    },
+    "db": {
+        "password": "stigman",
     }
 }

--- a/test/api/mocha/utils/testUtils.js
+++ b/test/api/mocha/utils/testUtils.js
@@ -12,6 +12,23 @@ const saveMetricsData = process.env.STIGMAN_SAVE_METRICS_DATA === 'true'
 // New flag to control whether to create new files or update existing ones
 const createNewMetricsFiles = process.env.STIGMAN_NEW_METRICS_FILES === 'true'
 
+const getAppInfo = async () => {
+  const res = await fetch(`${baseUrl}/op/appinfo?elevate=true`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      'Content-Type': 'application/json'
+    },
+  })
+  if (!res.ok) {
+    const errorText = await res.text()
+    throw new Error(`HTTP error! Status: ${res.status}, Message: ${errorText}`)
+  }
+  const data = await res.json()
+  return data
+}
+
+
 const executeRequest = async (url, method, token, body = null) => {
 
   const options = {
@@ -757,5 +774,6 @@ export {
   deleteStigByRevision,
   getUUIDSubString,
   executeRequest,
-  outputMetricsToJSON
+  outputMetricsToJSON,
+  getAppInfo
 }

--- a/test/api/package-lock.json
+++ b/test/api/package-lock.json
@@ -16,6 +16,7 @@
         "fast-xml-parser": "^4.5.0",
         "jszip": "^3.10.1",
         "mocha": "^11.0.1",
+        "mysql2": "^3.14.2",
         "uuid": "^11.0.3"
       },
       "devDependencies": {
@@ -180,6 +181,14 @@
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -408,6 +417,14 @@
         "sort-any": "^2.0.0"
       }
     },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -554,6 +571,14 @@
       "integrity": "sha512-xQVsnjJ/5pQtcKh+KjUoZGzVWn4uNkchxTF6Lwjr4Gf7nQr8fmUfhKJ62zE77+xQg9xnxi5KUps7XGs+VC986A==",
       "dev": true
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -628,6 +653,17 @@
         "he": "bin/he"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -691,6 +727,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -844,6 +885,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -865,6 +911,20 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
+      }
     },
     "node_modules/minimatch": {
       "version": "5.1.6",
@@ -1025,6 +1085,44 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mysql2": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.2.tgz",
+      "integrity": "sha512-YD6mZMeoypmheHT6b2BrVmQFvouEpRICuvPIREulx2OvP1xAxxeqkMQqZSTBefv0PiOBKGYFa2zQtY+gf/4eQw==",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -1227,6 +1325,16 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -1276,6 +1384,14 @@
       "integrity": "sha512-T9JoiDewQEmWcnmPn/s9h/PH9t3d/LSWi0RgVmXSuDYeZXTZOZ1/wrK2PHaptuR1VXe3clLLt0pD6sgVOwjNEA==",
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/string_decoder": {

--- a/test/api/package.json
+++ b/test/api/package.json
@@ -18,6 +18,7 @@
     "fast-xml-parser": "^4.5.0",
     "jszip": "^3.10.1",
     "mocha": "^11.0.1",
+    "mysql2": "^3.14.2",
     "uuid": "^11.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This is a continuation on closed pr #1691 
resolves: #1388 

based on enabled-view-pr, with change to updateStatsAssetStig that joins against enabled_collection when recalculating for benchmarkId/s, to avoid reclaculating stats for disabled collections.

(enabled-view-pr already adjusts targets to enabled_asset only)

Adds tests to updateStatsAssetStig. 