### PR TITLE
fix: open meta dashboard on button click

### DIFF
--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -294,7 +294,7 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
                 expanded: true,
                 listeners: {
                   beforeclick: function (n, e) {
-                    if (e.target.className === "sm-tree-toolbar") {
+                    if (e.target.className === "sm-tree-toolbar sm-tree-toolbar-persistent") {
                       SM.MetaPanel.showMetaTab({
                         treePath: n.getPath(),
                         initialCollectionIds: SM.safeJSONParse(localStorage.getItem('metaCollectionIds')) ?? []


### PR DESCRIPTION
Fixes a regression introduced by #1699.

The test for `e.target.className` was not checking for the additional class `sm-tree-toolbar-persistent` so clicking the tool would not open the Meta Dashboard.