### PR TITLE
refactor: web-preferences

### DIFF
--- a/api/source/controllers/User.js
+++ b/api/source/controllers/User.js
@@ -365,18 +365,6 @@ module.exports.getUserWebPreferences = async (req, res, next) => {
   }
 }
 
-module.exports.putUserWebPreferences = async (req, res, next) => {
-  try {
-    const body = req.body
-    await UserService.putUserWebPreferences(req.userObject.userId, body)
-    const response = await UserService.getUserWebPreferences(req.userObject.userId)
-    res.json(response)
-  }
-  catch (err) {
-    next(err)
-  }
-}
-
 module.exports.patchUserWebPreferences = async (req, res, next) => {
   try {
     const body = req.body
@@ -388,44 +376,4 @@ module.exports.patchUserWebPreferences = async (req, res, next) => {
     next(err)
   }
 }
-
-module.exports.getUserWebPreferencesKeys = async (req, res, next) => {
-  try {  
-    const response = await UserService.getUserWebPreferenceKeys(req.userObject.userId)
-    res.json(response)
-  }
-  catch (err) {
-    next(err)
-  }
-}
-
-module.exports.getUserWebPreferenceByKey = async (req, res, next) => {
-  try {
-    const key = req.params.key
-    // get the user web preference by key
-    const response = await UserService.getUserWebPreferenceByKey(req.userObject.userId, key)
-    if (response === null) {
-      throw new SmError.NotFoundError('web preference key not found')
-    }
-    res.json(response)
-  }
-  catch (err) {
-    next(err)
-  }
-}
-
-module.exports.putUserWebPreferenceByKey = async (req, res, next) => {
-
-  try {
-    const key = req.params.key
-    const value = req.body
-    await UserService.putUserWebPreferenceByKey(req.userObject.userId, key, value)
-    const currentKeyValue = await UserService.getUserWebPreferenceByKey(req.userObject.userId, key)
-    res.json(currentKeyValue)
-  }
-  catch (err) {
-    next(err)
-  }
-}
-
 

--- a/api/source/service/UserService.js
+++ b/api/source/service/UserService.js
@@ -535,40 +535,8 @@ exports.getUserWebPreferences = async function (userId) {
   return rows[0]?.webPreferences
 }
 
-exports.putUserWebPreferences = async function (userId, preferences) {
-  const sql = `UPDATE user_data SET webPreferences = ? WHERE userId = ?`
-  await dbUtils.pool.query(sql, [JSON.stringify(preferences), userId])
-  return preferences
-}
-
 exports.patchUserWebPreferences = async function (userId, preferences) {
   const sql = `UPDATE user_data SET webPreferences = JSON_MERGE_PATCH(webPreferences, ?) WHERE userId = ?`
   await dbUtils.pool.query(sql, [JSON.stringify(preferences), userId])
   return preferences
 }
-
-exports.getUserWebPreferenceKeys = async function (userId) {
-  const sql = `SELECT JSON_KEYS(webPreferences) as keyArray FROM user_data WHERE userId = ?`
-  const [rows] = await dbUtils.pool.query(sql, [userId])
-  const preferences = rows[0]?.keyArray || []
-  return preferences
-}
-
-exports.getUserWebPreferenceByKey = async function (userId, key) {
-  const sql = `SELECT JSON_EXTRACT(webPreferences, ?) as value FROM user_data WHERE userId = ?`
-  const [rows] = await dbUtils.pool.query(sql, [`$.${key}`, userId])
-  return rows[0]?.value ?? null
-}
-
-exports.putUserWebPreferenceByKey = async function (userId, key, value) {
-  let sql = `
-    update
-      user_data
-    set 
-      webPreferences = JSON_SET(webPreferences, ?, ?)
-    where 
-      userId = ?`
-  await dbUtils.pool.query(sql, [`$.${key}`, value, userId])
-  return value
-}
-

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -3952,34 +3952,6 @@ paths:
       security:
         - oauth:
             - 'stig-manager:user:read'
-    put:
-      tags:
-        - User
-      summary: Set the requester's web-preferences
-      operationId: putUserWebPreferences
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/WebPreferences'
-      responses:
-        '200':
-          description: User Web Preferences response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/WebPreferences'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-        # not semantically correct but needed 
-            - 'stig-manager:user:read'
     patch:
       tags:
         - User
@@ -4006,83 +3978,7 @@ paths:
                 $ref: '#/components/schemas/Error'
       security:
         - oauth:
-        # not semantically correct but needed 
-            - 'stig-manager:user:read'
-  /user/web-preferences/keys:
-    get:
-      tags:
-        - User
-      summary: Return the requester's web-preferences keys
-      operationId: getUserWebPreferencesKeys
-      responses:
-        '200':
-          description: UserWebPreferencesKeys response
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/WebPreferenceKey'
-      security:
-        - oauth:
-            - 'stig-manager:user:read'
-  /user/web-preferences/keys/{key}:
-    get:
-      tags:
-        - User
-      summary: Return the requester's user preference for the specified key
-      operationId: getUserWebPreferenceByKey
-      description: | 
-        Acceptable Keys: "darkMode" (bool), "lastWhatsNew" (date).
-      parameters:
-        - $ref: '#/components/parameters/WebPreferenceKeyPath'
-      responses:
-        '200':
-          description: UserWebPreference response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/WebPreferenceValue'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-            - 'stig-manager:user:read'
-    put:
-      tags:
-        - User
-      summary: Set the requester's user preference for the specified key
-      description: | 
-        Acceptable Keys: "darkMode" (bool), "lastWhatsNew" (date).
-      operationId: putUserWebPreferenceByKey
-      parameters:
-        - $ref: '#/components/parameters/WebPreferenceKeyPath'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/WebPreferenceValue'
-      responses:
-        '200':
-          description: UserPreference response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/WebPreferenceValue'
-        default:
-          description: unexpected error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-      security:
-        - oauth:
-        # not semantically correct but needed 
+        # not semantically correct but needed for backwards compatability
             - 'stig-manager:user:read'
   /users:
     parameters:
@@ -9059,14 +8955,6 @@ components:
           format: date
       additionalProperties: false
       minProperties: 1
-    WebPreferenceValue:
-      oneOf:
-        - type: boolean
-        - type: string
-          format: date
-    WebPreferenceKey:
-      type: string
-      enum: [darkMode, lastWhatsNew]
     Version:
       description: |
         API version string
@@ -9721,13 +9609,6 @@ components:
             - statistics
             - userGroups
             - webPreferences
-    WebPreferenceKeyPath:
-      name: key
-      in: path
-      required: true
-      description: A path parameter that specifies a web preference key
-      schema:
-        $ref: '#/components/schemas/WebPreferenceKey'
   responses:
     Forbidden:
       description: The requesting User does not have access rights to the content

--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -346,9 +346,9 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
                         try {
                           await Ext.Ajax.requestPromise({
                             responseType: 'json',
-                            url: `${STIGMAN.Env.apiBase}/user/web-preferences/keys/darkMode`,
-                            method: 'PUT',
-                            jsonData: JSON.stringify(checked),
+                            url: `${STIGMAN.Env.apiBase}/user/web-preferences`,
+                            method: 'PATCH',
+                            jsonData: {darkMode: checked}
                           })
                         } catch (error) {
                             SM.Error.handleError(error)

--- a/client/src/js/SM/WhatsNew.js
+++ b/client/src/js/SM/WhatsNew.js
@@ -585,9 +585,9 @@ SM.WhatsNew.showDialog = function (lastDate) {
       try {
         await Ext.Ajax.requestPromise({
           responseType: 'json',
-          url: `${STIGMAN.Env.apiBase}/user/web-preferences/keys/lastWhatsNew`,
-          method: 'PUT',
-          jsonData: JSON.stringify(lastWhatsNew),
+          url: `${STIGMAN.Env.apiBase}/user/web-preferences`,
+          method: 'PATCH',
+          jsonData: { lastWhatsNew }
         })
       } catch (error) {
           SM.Error.handleError(error)

--- a/test/api/mocha/data/user/user.test.js
+++ b/test/api/mocha/data/user/user.test.js
@@ -283,27 +283,6 @@ describe('user', () => {
             expect(res.body.lastWhatsNew).to.eql(distinct.webPreferences.lastWhatsNew)
           })
         })
-
-        describe(`getUserWebPreferencesKeys - /user/web-preferences/keys`, () => {
-          it("should return user web preferences keys for user", async () => {
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys`, 'GET', iteration.token)
-            expect(res.status).to.eql(200)
-            expect(res.body).to.be.an('array').to.have.lengthOf(2)
-            expect(res.body).to.include.members(['darkMode', 'lastWhatsNew'])
-          })
-        })
-
-        describe(`getUserWebPreferenceByKey - /user/web-preferences/{key}`, () => {
-          it("should return user web preference by key for user", async () => {
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys/darkMode`, 'GET', iteration.token)
-            expect(res.status).to.eql(200)
-            expect(res.body).to.eql(distinct.webPreferences.darkMode)
-          })
-          it("should throw SmError.NotFoundError for non-existing key", async () => {
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys/non-existing-key`, 'GET', iteration.token)
-            expect(res.status).to.eql(400)
-          })
-        })
       })
 
       describe('POST - user', () => {
@@ -527,7 +506,7 @@ describe('user', () => {
             expect(res.status).to.eql(400)
           })
 
-          it('should reject request with invalid value type fir darkMode', async () => {
+          it('should reject request with invalid value type for darkMode', async () => {
             const patch = {
               darkMode: "not-a-boolean"
             }
@@ -682,62 +661,6 @@ describe('user', () => {
             expect(res.status).to.eql(404)
           })
 
-        })
-
-        describe(`PUT - putUserWebPreferences - /user/web-preferences`, () => {
-          it("should update user web preferences for user", async () => {
-            const put = {
-              darkMode: true,
-              lastWhatsNew: "2025-02-02"
-            }
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences`, 'PUT', iteration.token, put)
-            expect(res.status).to.eql(200)
-            expect(res.body).to.eql({
-              "darkMode": true,
-              "lastWhatsNew": "2025-02-02"
-            })
-          })
-
-          it('should reject request with invalid key', async () => {
-            const put = {
-              test: true,
-              lastWhatsNew: "2025-02-02"
-            }
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences`, 'PUT', iteration.token, put)
-            expect(res.status).to.eql(400)
-          })
-        })
-
-        describe(`PUT - putUserWebPreferenceByKey - /user/web-preferences/keys/{key}`, () => {
-          it("should update user web preferences for user by key lastWhatsNew", async () => {
-            const value = '2025-03-03'
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys/lastWhatsNew`, 'PUT', iteration.token, value)
-            expect(res.status).to.eql(200)
-            expect(res.body).to.eql(value)
-          })
-
-          it("should update user web preferences for user by key darkMode", async () => {
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys/darkMode`, 'PUT', iteration.token, true)
-            expect(res.status).to.eql(200)
-            expect(res.body).to.eql(true)
-          })
-
-          it("should throw SmError.NotFoundError for non-existing key", async () => {
-            const put = {
-              value: "test"
-            }
-            const res = await utils.executeRequest(`${config.baseUrl}/users/${reference.wfTest.userId}/web-preferences/keys/non-existing-key`, 'PUT', iteration.token, put)
-            expect(res.status).to.eql(404)
-          })
-
-          it('should throw, because of invalid value type for key darkMode', async () => {
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys/darkMode`, 'PUT', iteration.token, "not-a-boolean")
-            expect(res.status).to.eql(400)
-          })
-          it('should throw, because of invalid value type for key lastWhatsNew', async () => {
-            const res = await utils.executeRequest(`${config.baseUrl}/user/web-preferences/keys/lastWhatsNew`, 'PUT', iteration.token, false)
-            expect(res.status).to.eql(400)
-          })
         })
       })
 


### PR DESCRIPTION
This pull request simplifies the implementation of user web preferences which were introduced by #1722. It retains only two endpoints:
- `GET /user/web-preferences`
- `PATCH /user/web-preferences`

The changes streamline the codebase, reduce redundancy, and improve maintainability.

### OpenAPI Specification Updates
* Removed endpoints for specific web preference operations (`/user/web-preferences/keys`, `/user/web-preferences/keys/{key}`, and `PUT /user/web-preferences`) from `stig-manager.yaml`. The `PATCH /user/web-preferences` endpoint now handles all web preference updates. [[1]](diffhunk://#diff-9f0f1a173ef69bcbd3ddc0f420c723f60b94a56abbcba8b71f13bffe1c7b8788L3955-L3982) [[2]](diffhunk://#diff-9f0f1a173ef69bcbd3ddc0f420c723f60b94a56abbcba8b71f13bffe1c7b8788L4009-R3981)
* Removed related schemas (`WebPreferenceValue`, `WebPreferenceKey`) and path parameters (`WebPreferenceKeyPath`) from the OpenAPI specification. [[1]](diffhunk://#diff-9f0f1a173ef69bcbd3ddc0f420c723f60b94a56abbcba8b71f13bffe1c7b8788L9062-L9069) [[2]](diffhunk://#diff-9f0f1a173ef69bcbd3ddc0f420c723f60b94a56abbcba8b71f13bffe1c7b8788L9724-L9730)

### API Changes: Consolidation of Web Preferences Operations
* Removed multiple methods from `User.js` and `UserService.js` for handling individual web preference keys (`getUserWebPreferencesKeys`, `getUserWebPreferenceByKey`, `putUserWebPreferenceByKey`) and replaced them with a single `patchUserWebPreferences` method. [[1]](diffhunk://#diff-24806bd98e6bae0b5e60f0e75ac7dc07aff7adcf02eeb2091122e6ab55e52ab9L368-L379) [[2]](diffhunk://#diff-24806bd98e6bae0b5e60f0e75ac7dc07aff7adcf02eeb2091122e6ab55e52ab9L392-L431) [[3]](diffhunk://#diff-441772698d39aa0bc50a7ac81774c3e82f830bf44af69f0809941907018016d5L538-L574)
* Removed the `putUserWebPreferences` method in favor of the `patchUserWebPreferences` method, which uses `JSON_MERGE_PATCH` for more flexible updates. [[1]](diffhunk://#diff-24806bd98e6bae0b5e60f0e75ac7dc07aff7adcf02eeb2091122e6ab55e52ab9L368-L379) [[2]](diffhunk://#diff-441772698d39aa0bc50a7ac81774c3e82f830bf44af69f0809941907018016d5L538-L574)


### Frontend Adjustments
* Updated AJAX requests in `SM.NavTree.js` and `SM.WhatsNew.js` to use the consolidated `PATCH /user/web-preferences` endpoint instead of the removed `PUT /user/web-preferences/keys/{key}` endpoint. [[1]](diffhunk://#diff-6aef3a2ba1e44d6dc3cce62fcf792e06da65f399c0e50b5cbf193ede7371155dL349-R351) [[2]](diffhunk://#diff-f9473c79e481858e9264fea98dbe02a893d505f383e85ac1f5137ffeea4103f5L588-R590)

### Test Updates
* Removed test cases for deprecated operations (`getUserWebPreferencesKeys`, `getUserWebPreferenceByKey`, `putUserWebPreferences`, `putUserWebPreferenceByKey`) and added validation for the consolidated `PATCH /user/web-preferences` endpoint. [[1]](diffhunk://#diff-ba8049a78e285ede0d2ac408c9fdf294580383e9b07d879e3dbc0f3e96e51beaL286-L306) [[2]](diffhunk://#diff-ba8049a78e285ede0d2ac408c9fdf294580383e9b07d879e3dbc0f3e96e51beaL530-R509) [[3]](diffhunk://#diff-ba8049a78e285ede0d2ac408c9fdf294580383e9b07d879e3dbc0f3e96e51beaL686-L741)