### PR TITLE
feat: sync theme change across tabs

### DIFF
--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -383,6 +383,9 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
                     node.ui.checkbox.checked = !node.ui.checkbox.checked
                     SM.Dispatcher.fireEvent('themechanged', node.ui.checkbox.checked ? 'dark' : 'light', 'local')
                     return false
+                  },
+                  checkchange: function (node, checked) {
+                    SM.Dispatcher.fireEvent('themechanged', checked ? 'dark' : 'light', 'local')
                   }
                 }
               }

--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -172,6 +172,17 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
         }
       }
 
+      this.onThemeChanged = function (theme, source) {
+        if (source === 'broadcast') {
+          // Update the dark mode checkbox state if the interface node is expanded
+          const interfaceNode = me.getRootNode()?.findChild('id', 'interface-root')
+          if (interfaceNode?.expanded) {
+            const darkModeNode = interfaceNode.findChild('id', 'dark-mode')
+            darkModeNode && (darkModeNode.ui.checkbox.checked = theme === 'dark')
+          }
+        }
+      }
+
       this.getApiStig = async (benchmarkId) => {
         try {
           let result = await Ext.Ajax.requestPromise({
@@ -227,6 +238,7 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
       SM.Dispatcher.addListener('collectioncreated', this.onCollectionCreated)
       SM.Dispatcher.addListener('collectionchanged', this.onCollectionChanged)
       SM.Dispatcher.addListener('collectiondeleted', this.onCollectionDeleted)
+      SM.Dispatcher.addListener('themechanged', this.onThemeChanged)
     },
     loadTree: async function (node, cb) {
         try {
@@ -317,54 +329,16 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
             )
             content.push(
               {
-                id: `theme-root`,
+                id: `interface-root`,
                 node: 'theme',
                 text: 'Interface',
                 iconCls: 'sm-setting-icon',
                 expanded: false,
-                children: [
-                  {
-                    id: 'whats-new',
-                    text: "What's New",
-                    iconCls: 'sm-stig-icon',
-                    leaf: true
-                  },
-                  {
-                    id: 'dark-mode',
-                    text: 'Dark mode',
-                    leaf: true,
-                    checked: curUser?.webPreferences?.darkMode,
-                    iconCls: 'sm-dark-mode-icon',
-                    listeners: {
-                      beforeclick: function (node , e) {
-                        node.ui.checkbox.checked = !node.ui.checkbox.checked
-                        node.fireEvent('checkchange', node, node.ui.checkbox.checked)
-                        return false
-                      },
-                      checkchange: async function (node, checked) {
-                        document.querySelector("link[href='css/dark-mode.css']").disabled = !checked
-                        try {
-                          await Ext.Ajax.requestPromise({
-                            responseType: 'json',
-                            url: `${STIGMAN.Env.apiBase}/user/web-preferences/keys/darkMode`,
-                            method: 'PUT',
-                            jsonData: JSON.stringify(checked),
-                          })
-                        } catch (error) {
-                            SM.Error.handleError(error)
-                        }
-                        curUser.webPreferences.darkMode = checked
-                        SM.Dispatcher.fireEvent('themechanged', checked ? 'dark' : 'light')
-                      }
-                    }
-                  }
-                ]
               }
             )
             cb(content, { status: true })
             return
-          }
-          if (node === 'library-root') {
+          } else if (node === 'library-root') {
             const apiStigs = await Ext.Ajax.requestPromise({
               responseType: 'json',
               url: `${STIGMAN.Env.apiBase}/stigs?projection=revisions`,
@@ -373,8 +347,7 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
             let content = SM.NavTree.LibraryNodesConfig(apiStigs)
             cb(content, { status: true })
             return
-          }
-          if (node === 'collections-root') {
+          } else if (node === 'collections-root') {
             const collectionMap = await SM.Cache.getCollections()
             const apiCollections = [...collectionMap.values()].sort((a, b) => a.name.localeCompare(b.name))
             let content = apiCollections.map(collection => SM.NavTree.CollectionLeafConfig(collection))
@@ -391,7 +364,32 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
             }
             cb(content, { status: true })
             return
-          }     
+          } else if (node === 'interface-root') {
+            const content = [
+              {
+                id: 'whats-new',
+                text: "What's New",
+                iconCls: 'sm-stig-icon',
+                leaf: true
+              },
+              {
+                id: 'dark-mode',
+                text: 'Dark mode',
+                leaf: true,
+                checked: curUser?.webPreferences?.darkMode,
+                iconCls: 'sm-dark-mode-icon',
+                listeners: {
+                  beforeclick: function (node) {
+                    node.ui.checkbox.checked = !node.ui.checkbox.checked
+                    SM.Dispatcher.fireEvent('themechanged', node.ui.checkbox.checked ? 'dark' : 'light', 'local')
+                    return false
+                  }
+                }
+              }
+            ]
+            cb(content, { status: true })
+            return
+          }
         }
         catch (e) {
           SM.Error.handleError(e)

--- a/client/src/js/SM/NavTree.js
+++ b/client/src/js/SM/NavTree.js
@@ -379,11 +379,15 @@ SM.NavTree.TreePanel = Ext.extend(Ext.tree.TreePanel, {
                 checked: curUser?.webPreferences?.darkMode,
                 iconCls: 'sm-dark-mode-icon',
                 listeners: {
+                  //beforeclick gets click events on the text of the node, but not checkbox clicks
                   beforeclick: function (node) {
+                    //toggle the checkbox state
                     node.ui.checkbox.checked = !node.ui.checkbox.checked
-                    SM.Dispatcher.fireEvent('themechanged', node.ui.checkbox.checked ? 'dark' : 'light', 'local')
+                    // Fire checkchange event manually to centralize the theme change logic
+                    node.fireEvent('checkchange', node, node.ui.checkbox.checked)
                     return false
                   },
+                  // checkchange captures the click event on the checkbox, then fires the themechanged event
                   checkchange: function (node, checked) {
                     SM.Dispatcher.fireEvent('themechanged', checked ? 'dark' : 'light', 'local')
                   }


### PR DESCRIPTION
### Synchronizes change to the web app theme across multiple browser contexts (tabs).

This PR introduces enhancements to the theme management system, enabling synchronization of dark mode state across browser tabs/windows and improving code clarity. The changes primarily focus on refactoring the Navigation Tree's Interface node structure, adding event listeners for theme updates, and broadcasting theme changes to other application browsing contexts.

### Broadcast Channel Integration:

* **Introduced `STIGMAN.webPreferencesChannel` for dark mode synchronization:** A new broadcast channel (`stigman-web-preferences`) was added to allow application browsing contexts to report when a theme change was made. The channel's message handler in `stigman.js` propagates a report to the rest of the application by firing the `themechanged` event. [ [`client/src/js/stigman.jsR80-R86`]](diffhunk://#diff-aa0f495e62a21b9363d882bf9b909a64822072a016a01904f2bd92dd06777e21R80-R86)

### `themechanged` Event Enhancements

* **Introduced the `source` event parameter:** The parameter value can be `local` or `broadcast`. When a user clicks the `dark-mode` node, the event source is `local`. When the broadcast channel reports a theme change, the event source is `broadcast`.

### `stigman.js` Enhancements

* **Added `onThemeChanged` logic:** The `themechanged` handler distinguishes between local and broadcast event sources. For events from both sources, it updates the current user's dark mode preference and enables/disables the CSS. If the event source is `local` it sends a message to the broadcast channel and an API request to persist the changes. [[`client/src/js/stigman.jsR247-R265`]](diffhunk://#diff-aa0f495e62a21b9363d882bf9b909a64822072a016a01904f2bd92dd06777e21R247-R265)

### `SM.NavTree.TreePanel`  Enhancements:

* **Added `onThemeChanged` method to handle `themechanged` events:** This method updates the dark mode checkbox state when a theme change event is received from a broadcast source. [[`client/src/js/SM/NavTree.jsR175-R185`]](diffhunk://#diff-6aef3a2ba1e44d6dc3cce62fcf792e06da65f399c0e50b5cbf193ede7371155dR175-R185)
* **Refactored interface node structure:** The `theme-root` node was renamed to `interface-root`, and its children (`dark-mode` and `whats-new`) were restructured for better organization. The `dark-mode` node now directly fires the `themechanged` event when toggled. [[1]](diffhunk://#diff-6aef3a2ba1e44d6dc3cce62fcf792e06da65f399c0e50b5cbf193ede7371155dL320-R341), [[2]](diffhunk://#diff-6aef3a2ba1e44d6dc3cce62fcf792e06da65f399c0e50b5cbf193ede7371155dR367-R391)
