### PR TITLE
feat: report semantic version with build

### DIFF
--- a/api/source/bootstrap/bootstrapUtils.js
+++ b/api/source/bootstrap/bootstrapUtils.js
@@ -1,6 +1,5 @@
 const path = require('node:path')
 const logger = require('../utils/logger')
-const packageJson = require("../package.json")
 
 function modulePathResolver( handlersPath, route, apiDoc ) {
     const pathKey = route.openApiRoute.substring(route.basePath.length)
@@ -36,7 +35,7 @@ function buildResponseValidationConfig(willValidateResponse) {
 
 function logAppConfig(config) {
     logger.writeInfo('bootstrapUtils', 'starting bootstrap', {
-      version: packageJson.version,
+      version: config.version,
       env: logger.serializeEnvironment(),
       dirname: __dirname,
       cwd: process.cwd()

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -4,7 +4,7 @@ const ourPackage = require("../package.json")
 const insecureKids = ['FJ86GcF3jTbNLOco4NvZkUCIUmfYCqoqtOQeMfbhNlE']
 
 const config = {
-    version: ourPackage.version,
+    version: `${process.env.COMMIT_DESCRIBE ? process.env.COMMIT_DESCRIBE.replace(/-g[0-9a-f]+$/, "").replace(/-/g, "+") : ourPackage.version}`,
     commit: {
         branch: process.env.COMMIT_BRANCH || 'na',
         sha: process.env.COMMIT_SHA || 'na',


### PR DESCRIPTION
This pull request updates how the application sets `config.version` in `config.js`. If a `git describe` string is available via envvar `COMMIT_DESCRIBE`, it will be used to construct the semantic version string. If the describe string reports distance from a version tag (e.g. `1.5.10-15-gd937d97a`), the distance is appended as `+<distance>` as documented at [https://semver.org/](https://semver.org/). For the example, the resulting semantic version string is `1.5.10+15`.

The changes aim to make version handling more dynamic by leveraging environment variables and reducing direct dependencies on `package.json`.

### Version handling updates:

* Modified `api/source/utils/config.js` to dynamically determine the version using the `COMMIT_DESCRIBE` environment variable, falling back to `package.json` if the environment variable is not available.
* Removed the direct import of `package.json` in `api/source/bootstrap/bootstrapUtils.js`.
* Updated the `logAppConfig` function in `api/source/bootstrap/bootstrapUtils.js` to use `config.version` instead of `packageJson.version` for logging the application version.
