### PR TITLE
stig.version should be string value for cklb

### DIFF
--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -652,7 +652,7 @@ exports.cklbFromAssetStigs = async function cklbFromAssetStigs (assetId, stigs) 
         stig_name: stig.title,
         display_name: stig.title.replace(' Security Technical Implementation Guide', ''),
         stig_id: stig.benchmarkId,
-        version: stig.version,
+        version: `${stig.version}`,
         release_info: `Release: ${stig.release} Benchmark Date: ${stig.benchmarkDate}`,
         uuid: stigUuid,
         reference_identifier: '0000',

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -5790,7 +5790,7 @@ components:
         stig_id:
           type: string
         version:
-          type: integer
+          type: string
         release_info:
           type: string
         uuid:


### PR DESCRIPTION
resolves: #1744 
Outputs cklb stigs[{version}] value as a string, rather than integer. 
This now matches STIG Viewer 3.5.1 output, and is compatible with eMASSter tool.