### PR TITLE
feat: optional lighter weight appInfo response

### DIFF
--- a/api/source/controllers/Operation.js
+++ b/api/source/controllers/Operation.js
@@ -98,7 +98,10 @@ module.exports.getAppInfo = async function getAppInfo (req, res, next) {
   try {
     let elevate = req.query.elevate
     if ( elevate ) {
-      const response = await OperationService.getAppInfo()
+      const options = {
+        includeRowCounts: req.query.includeRowCounts
+      }
+      const response = await OperationService.getAppInfo(options)
       res.json(response)
     }
     else {

--- a/api/source/service/OperationService.js
+++ b/api/source/service/OperationService.js
@@ -466,7 +466,8 @@ exports.replaceAppData = async function (buffer, contentType, progressCb = () =>
   }
 }
 
-exports.getAppInfo = async function() {
+exports.getAppInfo = async function(options = {}) {
+  const { includeRowCounts } = options
   const schema = 'stig-manager-appinfo-v1.1'
   const sqlAnalyze = `ANALYZE TABLE collection, asset, review, review_history, user`
   const sqlInfoSchema = `
@@ -731,11 +732,30 @@ exports.getAppInfo = async function() {
   const [schemaInfoArray] = await dbUtils.pool.query(sqlInfoSchema, [config.database.schema])
   const tables = createObjectFromKeyValue(schemaInfoArray, "tableName")
 
-  const rowCountQueries = []
-  for (const table in tables) {
-    rowCountQueries.push(dbUtils.pool.query(`SELECT "${table}" as tableName, count(*) as rowCount from ${table}`))
+  const queries = [
+    dbUtils.pool.query(sqlCollectionAssetStigs),
+    dbUtils.pool.query(sqlCountsByCollection),
+    dbUtils.pool.query(sqlLabelCountsByCollection),
+    dbUtils.pool.query(sqlGrantsByCollection),
+    dbUtils.pool.query(sqlRoleCountsByCollection),
+    dbUtils.pool.query(sqlUserInfo),
+    dbUtils.pool.query(sqlUserGroupInfo),
+    dbUtils.pool.query(sqlMySqlVersion),
+    dbUtils.pool.query(sqlMySqlVariablesValues),
+    dbUtils.pool.query(sqlMySqlStatusValues)
+  ]
+
+  // Conditionally add row count queries
+  if (includeRowCounts) {
+    const rowCountQueries = []
+    for (const table in tables) {
+      rowCountQueries.push(dbUtils.pool.query(`SELECT "${table}" as tableName, count(*) as rowCount from ${table}`))
+    }
+    queries.push(Promise.all(rowCountQueries))
   }
 
+  const results = await Promise.all(queries)
+  
   let [
     [assetStigByCollection],
     [countsByCollection],
@@ -748,22 +768,18 @@ exports.getAppInfo = async function() {
     [mySqlVariables],
     [mySqlStatus],
     rowCountResults
-  ] = await Promise.all([
-    dbUtils.pool.query(sqlCollectionAssetStigs),
-    dbUtils.pool.query(sqlCountsByCollection),
-    dbUtils.pool.query(sqlLabelCountsByCollection),
-    dbUtils.pool.query(sqlGrantsByCollection),
-    dbUtils.pool.query(sqlRoleCountsByCollection),
-    dbUtils.pool.query(sqlUserInfo),
-    dbUtils.pool.query(sqlUserGroupInfo),
-    dbUtils.pool.query(sqlMySqlVersion),
-    dbUtils.pool.query(sqlMySqlVariablesValues),
-    dbUtils.pool.query(sqlMySqlStatusValues),
-    Promise.all(rowCountQueries)
-  ])
+  ] = results
 
-  for (const result of rowCountResults) {
-    tables[result[0][0].tableName].rowCount = result[0][0].rowCount
+  // Set row counts from individual queries or use null when not counting
+  if (includeRowCounts && rowCountResults) {
+    for (const result of rowCountResults) {
+      tables[result[0][0].tableName].rowCount = result[0][0].rowCount
+    }
+  } else {
+    // Use null to indicate exact row counts were not requested
+    for (const tableName in tables) {
+      tables[tableName].rowCount = null
+    }
   }
 
   // remove strings from user privileges array that are not meaningful to stigman

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -3310,6 +3310,12 @@ paths:
       operationId: getAppInfo
       parameters:
         - $ref: '#/components/parameters/ElevateQuery'
+        - name: includeRowCounts
+          in: query
+          description: Include exact row counts for each table (slower) or use estimated counts (faster)
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: AppInfo response

--- a/client/src/js/SM/AppInfo.js
+++ b/client/src/js/SM/AppInfo.js
@@ -3435,7 +3435,18 @@ SM.AppInfo.SourcePanel = Ext.extend(Ext.Panel, {
         {
           text: 'Fetch from API',
           iconCls: 'icon-refresh',
-          handler: this.onFetchFromApi || Ext.emptyFn
+          menu: [
+            {
+              text: 'Quick fetch (estimated row counts)',
+              tooltip: 'Faster fetch using estimated row counts',
+              handler: () => this.onFetchFromApi?.(false) || Ext.emptyFn
+            },
+            {
+              text: 'Full fetch (exact row counts)',
+              tooltip: 'Slower fetch with exact row counts for all tables',
+              handler: () => this.onFetchFromApi?.(true) || Ext.emptyFn
+            }
+          ]
         },
 
       ]
@@ -3465,12 +3476,13 @@ SM.AppInfo.SourcePanel = Ext.extend(Ext.Panel, {
   }
 })
 
-SM.AppInfo.fetchFromApi = async function () {
+SM.AppInfo.fetchFromApi = async function (includeRowCounts = false) {
   return Ext.Ajax.requestPromise({
     responseType: 'json',
     url: `${STIGMAN.Env.apiBase}/op/appinfo`,
     params: {
-      elevate: curUser.privileges.admin
+      elevate: curUser.privileges.admin,
+      includeRowCounts
     },
     method: 'GET'
   })
@@ -3567,10 +3579,13 @@ SM.AppInfo.showAppInfoTab = async function (options) {
     }
   }
 
-  async function onFetchFromApi() {
+  async function onFetchFromApi(includeRowCounts = false) {
     try {
-      thisTab.getEl().mask('Fetching from API...')
-      data = await SM.AppInfo.fetchFromApi()
+      const maskMsg = includeRowCounts 
+        ? 'Fetching from API with exact row counts...' 
+        : 'Fetching from API with estimated row counts...'
+      thisTab.getEl().mask(maskMsg)
+      data = await SM.AppInfo.fetchFromApi(includeRowCounts)
       sourcePanel.loadData({ data, source: 'API' })
       tabPanel.loadData(data)
     }
@@ -3651,5 +3666,5 @@ SM.AppInfo.showAppInfoTab = async function (options) {
   })
   thisTab.show()
 
-  await onFetchFromApi()
+  await onFetchFromApi(false)
 }


### PR DESCRIPTION
Makes full row count queries optional when requesting AppInfo . 

Adds query param to opId getAppInfo:
name: includeRowCounts
description: Include exact row counts for each table (slower) or use estimated counts (faster)
type: boolean
default: false

AppInfo returns nulls in place of exact row count values, as per spec.

UI requests includeRowCounts=false on App Info load, added menu option to fetch with includeRowCounts=true

