### PR TITLE
feat: include header x-accel-buffering: no

### DIFF
--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -1049,6 +1049,8 @@ module.exports.cloneCollection = async function (req, res, next) {
       }
 
       res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+      res.setHeader('X-Accel-Buffering', 'no'); // Disable buffering for nginx
+
       req.noCompression = true
 
       const cloned = await CollectionService.cloneCollection({
@@ -1095,6 +1097,8 @@ module.exports.exportToCollection = async function (req, res, next) {
     const parsedRequest = await processAssetStigRequests (req.body, srcCollectionId, 'multi', grant)
     
     res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+    res.setHeader('X-Accel-Buffering', 'no'); // Disable buffering for nginx
+
     req.noCompression = true
 
     await CollectionService.exportToCollection({

--- a/api/source/controllers/Operation.js
+++ b/api/source/controllers/Operation.js
@@ -177,6 +177,7 @@ module.exports.streamStateSse = function (req, res, next) {
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');
+    res.setHeader('X-Accel-Buffering', 'no'); // Disable buffering for nginx
 
     // Helper to send SSE events
     function sendEvent(eventName, data) {


### PR DESCRIPTION
Resolves: #1757

Modifies controllers to send the HTTP header `X-Accel-Buffering: no` for the following endpoints:
- `POST /api/collections/<collection-id>/clone`
- `POST /api/collections/<collection-id>/export-to/<collection-id>`
- `GET /api/op/state/sse` 