### PR TITLE
feat: remove compression middleware

### DIFF
--- a/api/source/bootstrap/middlewares.js
+++ b/api/source/bootstrap/middlewares.js
@@ -3,7 +3,6 @@ const path = require('node:path')
 const multer  = require('multer')
 const express = require('express')
 const cors = require('cors')
-const compression = require('compression')
 const { middleware: openApiMiddleware } = require('express-openapi-validator')
 const config = require('../utils/config')
 const { modulePathResolver, buildResponseValidationConfig } = require('./bootstrapUtils')
@@ -20,7 +19,6 @@ function configureMiddleware(app) {
       configureExpress,
       configureCors,
       configureLogging,
-      configureCompression,
       configureServiceCheck,
       configureAuth,
       configureOpenApi,
@@ -53,18 +51,6 @@ function configureCors(app) {
 
 function configureLogging(app) {
   app.use(requestLogger)
-}
-
-function configureCompression(app) {  
-  // compress responses
-  app.use(compression({
-    filter: (req, res) => {
-      if (req.noCompression) {
-        return false
-      }
-      return compression.filter(req, res)
-    }
-  }))
 }
 
 function configureServiceCheck(app) {

--- a/api/source/controllers/Collection.js
+++ b/api/source/controllers/Collection.js
@@ -708,7 +708,6 @@ module.exports.postXccdfArchiveByCollection = async function (req, res, next) {
 }
 
 async function postArchiveByCollection ({format = 'ckl-mono', req, res, parsedRequest}) {
-  req.noCompression = true
   const builder = new XMLBuilder({
     attributeNamePrefix : "@_",
     textNodeName : "#text",
@@ -1051,8 +1050,6 @@ module.exports.cloneCollection = async function (req, res, next) {
       res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
       res.setHeader('X-Accel-Buffering', 'no'); // Disable buffering for nginx
 
-      req.noCompression = true
-
       const cloned = await CollectionService.cloneCollection({
         collectionId, 
         userObject: req.userObject, 
@@ -1098,8 +1095,6 @@ module.exports.exportToCollection = async function (req, res, next) {
     
     res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
     res.setHeader('X-Accel-Buffering', 'no'); // Disable buffering for nginx
-
-    req.noCompression = true
 
     await CollectionService.exportToCollection({
       srcCollectionId,

--- a/api/source/controllers/Operation.js
+++ b/api/source/controllers/Operation.js
@@ -32,7 +32,6 @@ module.exports.getAppData = async function getAppData (req, res, next) {
     const format = req.query.format || 'gzip'
     res.attachment(`appdata-v${config.lastMigration}_${escape.filenameComponentFromDate()}.jsonl${format==='gzip'?'.gz':''}`)
     if (format === 'jsonl') res.type('application/jsonl')
-    req.noCompression = true
 
     // the service method will stream the appdata file to the response object
     OperationService.getAppData(res, format)
@@ -70,7 +69,6 @@ module.exports.replaceAppData = async function replaceAppData (req, res, next) {
     const buffer = Buffer.concat(chunks)
     res.setHeader('Content-Type', 'application/jsonl; charset=utf-8')
     res.setHeader('Transfer-Encoding', 'chunked')
-    req.noCompression = true
     await OperationService.replaceAppData(buffer, req.headers['content-type'], progressCb )
     res.end()
   }
@@ -173,7 +171,6 @@ module.exports.cancelScheduledModeChange = function (req, res, next) {
 
 module.exports.streamStateSse = function (req, res, next) {
   try {
-    req.noCompression = true
     res.setHeader('Content-Type', 'text/event-stream');
     res.setHeader('Cache-Control', 'no-cache');
     res.setHeader('Connection', 'keep-alive');


### PR DESCRIPTION
Resolves #1755 

This pull request removes response compression middleware from the API and refactors related logic for handling compression flags and response length tracking. The main goals are to simplify middleware setup, clean up controller logic, and improve accuracy in response statistics.

**Middleware and Compression Removal:**
- Removed the `compression` middleware and all related configuration from `middlewares.js`, including the `configureCompression` function and its use in the middleware stack. [[1]](diffhunk://#diff-9291379b6b19c7a95da1d03c05ad4082a4716f3c9471c82d19d0df7e9c7b6c1dL6) [[2]](diffhunk://#diff-9291379b6b19c7a95da1d03c05ad4082a4716f3c9471c82d19d0df7e9c7b6c1dL23) [[3]](diffhunk://#diff-9291379b6b19c7a95da1d03c05ad4082a4716f3c9471c82d19d0df7e9c7b6c1dL58-L69)

**Controller Cleanup:**
- Removed all usage of the `req.noCompression` flag from controllers in `Collection.js` and `Operation.js`, since compression is no longer being handled at this layer. [[1]](diffhunk://#diff-3e666b5e980454449d5dea44ebfd918c9b3946b4291852542ee8596412223e29L711) [[2]](diffhunk://#diff-3e666b5e980454449d5dea44ebfd918c9b3946b4291852542ee8596412223e29L1054-L1055) [[3]](diffhunk://#diff-3e666b5e980454449d5dea44ebfd918c9b3946b4291852542ee8596412223e29L1102-L1103) [[4]](diffhunk://#diff-67f3cb16d8c5d57fb87bfc37f671c5e447b043c9311b5df67efd23dbcb7eead4L35) [[5]](diffhunk://#diff-67f3cb16d8c5d57fb87bfc37f671c5e447b043c9311b5df67efd23dbcb7eead4L73) [[6]](diffhunk://#diff-67f3cb16d8c5d57fb87bfc37f671c5e447b043c9311b5df67efd23dbcb7eead4L176)

**Logging and Statistics Improvements:**
- Refactored response body length tracking in `logger.js` to use the `content-length` header instead of a custom `sm_responseLength` property, improving accuracy and simplifying the code.
- Updated the request logger to only capture response bodies for elevated requests and removed unnecessary logic for tracking response length.