### PR TITLE
fix: use conditional chain within error handler for showAssetProps

### DIFF
--- a/client/src/js/SM/Manage.js
+++ b/client/src/js/SM/Manage.js
@@ -2930,7 +2930,7 @@ SM.Manage.Asset.showAssetProps = async function (assetId, initialCollectionId) {
         catch (e) {
           if (e.responseText) {
             const response = SM.safeJSONParse(e.responseText)
-            if (response?.detail[0].failure === 'name exists') {
+            if (response?.detail?.[0]?.failure === 'name exists') {
               Ext.Msg.alert('Name unavailable', 'The Asset name is already used in this Collection. Please try a different name.')
             }
             else {


### PR DESCRIPTION
Adds conditional chaining to avoid an error in the error handler for the `btnHandler` in `SM.Manage.Asset.showAssetProps`.

This should aid in troubleshooting #1790 