### PR TITLE
fix: include job.js in build.sh

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -158,6 +158,7 @@ uglifyjs \
 'SM/UserGroup.js' \
 'SM/AppInfo.js' \
 'SM/AppData.js' \
+'SM/Job.js' \
 'library.js' \
 'collectionAdmin.js' \
 'collectionManager.js' \


### PR DESCRIPTION
Client build did not include the new `SM/Job.js` file.