### PR TITLE
feat: handle cross-origin OIDC with mTLS

### DIFF
--- a/client/src/js/workers/oidc-worker.js
+++ b/client/src/js/workers/oidc-worker.js
@@ -30,6 +30,7 @@ const messageHandlers = {
   getAccessToken,
   exchangeCodeForToken,
   initialize,
+  getStatus,
   logout
 }
 
@@ -82,7 +83,7 @@ async function initialize(options) {
     ENV = options.env || null
 
     try {
-      oidcConfiguration = await fetchOpenIdConfiguration()
+      oidcConfiguration = options.oidcConfiguration || await fetchOpenIdConfiguration()
     }
     catch (e) {
       console.error(logPrefix, 'Failed to fetch OIDC configuration', e)
@@ -95,6 +96,15 @@ async function initialize(options) {
     }
   }
   return { success: true, env: ENV, channelName }
+}
+
+async function getStatus() {
+  return {
+    initialized,
+    redirectUri,
+    env: ENV,
+    channelName
+  }
 }
 
 function logout() {

--- a/client/src/reauth.html
+++ b/client/src/reauth.html
@@ -20,8 +20,13 @@
     const statusEl = document.getElementById("loading-text")
     const OW = new SharedWorker("js/workers/oidc-worker.js", { name: 'stigman-oidc-worker', type: "module" })
     OW.port.start()
-    const init = await sendWorkerRequest({ request: 'initialize' })
-    await run()
+    const init = await sendWorkerRequest({ request: 'getStatus' })
+    if (init.initialized) {
+      await run()
+    }
+    else {
+      appendError('OIDC Worker is not initialized.')
+    }
 
     // Helper functions
     function sendWorkerRequest(request) {


### PR DESCRIPTION
Targets an issue discussed in #1801 by moving the fetch of OIDC Metadata from the OIDC SharedWorker into the main thread.

Currently, if:
* a deployment serves the OP and STIGMAN from different origins, and the OP is upstream of an nginx configured with `ssl_verify_client optional;` (as we've advertised [in our example orchestration](https://github.com/NUWCDIVNPT/stigman-orchestration/blob/main/nginx/nginx.conf)),

Then:
* the first TLS connection to the OP's origin is made by a Worker fetch.
* The OP TLS handshake will request a client certificate.
* In our lab, Firefox is okay with this and prompts the user for client cert and our process goes on.
* But Chrome is unwilling to prompt the user while handling a worker fetch, and the Worker errors.

This PR provides a workaround that makes the first request to the OP origin from the main thread, so in Chrome the user's choice of certificate is cached and available to subsequent Worker fetches.

The main changes include shifting OIDC metadata fetching to the main thread, adding a `getStatus` request for the worker, and updating the initialization logic in both the main app and reauth flow.

**OIDC Worker Initialization Improvements:**

* Moved OIDC metadata fetching from the worker to the main thread, and updated the initialization logic in `client/src/js/init.js` to use a new `initializeOidcWorker` function that first checks worker status before initializing with metadata. [[1]](diffhunk://#diff-75af7b3a7f8ec37674739ec6620a078dfb70db708d6800cbdf37e20b57f0756cL34-R35) [[2]](diffhunk://#diff-75af7b3a7f8ec37674739ec6620a078dfb70db708d6800cbdf37e20b57f0756cR63-R89)
* Updated the worker's `initialize` function to accept externally provided OIDC configuration, falling back to fetching if not provided.

**Worker Status Check Feature:**

* Added a new `getStatus` handler to the OIDC worker, allowing the main thread to check if the worker is already initialized and retrieve its state. [[1]](diffhunk://#diff-d5c8cd50f0334c04636c7107354e82e1087125fcce91399a6d25f4e0f7bfe020R33) [[2]](diffhunk://#diff-d5c8cd50f0334c04636c7107354e82e1087125fcce91399a6d25f4e0f7bfe020R101-R109)
* Updated the reauth flow in `client/src/reauth.html` to use `getStatus` instead of `initialize`, and to fail in cases where the worker is not yet initialized.






