### PR TITLE
feat: handle state mismatch by auto redirecting

### DIFF
--- a/client/src/js/init.js
+++ b/client/src/js/init.js
@@ -131,7 +131,9 @@ import { stylesheets, scripts, isMinimizedSource } from './resources.js'
       return
     }
     if (!params.state || params.state !== sessionStorage.getItem('oidcState')) {
-      appendError('State mismatch. The state parameter does not match the expected value.')
+      const reauthHref = window.location.origin + window.location.pathname
+      console.log(`[init] State mismatch. Redirecting to ${reauthHref}.`)
+      window.location.href = reauthHref
       return
     }
     const response = await OW.sendWorkerRequest({


### PR DESCRIPTION
Resolves #1802

When a user instructs their browser to replay a previous OIDC Authorization Code Flow (often by navigating back in history), our code detects the OIDC state mismatch and correctly refuses to bootstrap. However, it displays an error which is alarming to some users and requires they manually select "Retry authorization" to resolve the condition.

This PR changes our behavior by automatically restarting the OIDC Authorization Code Flow when a state mismatch is detected, eliminating the potentially alarming error display.