### PR TITLE
chore: update @yao-pkg/pkg to 6.10 and target Node 24 for binaries

### DIFF
--- a/api/build.sh
+++ b/api/build.sh
@@ -2,7 +2,7 @@
 
 # This file is used to build API binaries on the team workstations. It is not tested elsewhere, yet.
 # Requires:
-# - Node.js and module "@yao-pkg/pkg" (npm install -g @yao-pkg/pkg@6.3.0)
+# - Node.js and module "@yao-pkg/pkg" (npm install -g @yao-pkg/pkg@6.10)
 # - zip
 # - tar
 
@@ -32,7 +32,7 @@ echo "Fetching node_modules"
 rm -rf ./source/node_modules
 cd ./source
 npm ci
-npm install -g @yao-pkg/pkg@6.3.0
+npm install -g @yao-pkg/pkg@6.10
 cd ..
 ../client/build.sh
 ../docs/build.sh

--- a/api/pkg.config.json
+++ b/api/pkg.config.json
@@ -11,7 +11,7 @@
             "./source/node_modules/axios/**/*",
             "./source/utils/*.xlsx"
         ],
-        "targets": ["node22-win", "node22-linuxstatic"],
+        "targets": ["node24-win", "node24-linuxstatic"],
         "outputPath": "./bin"
     }
 }


### PR DESCRIPTION
- Updated @yao-pkg/pkg from 6.3.0 to 6.10 in build.sh
- Changed binary targets from node22 to node24 in pkg.config.json