### PR TITLE
fix: preserve existing job

### DIFF
--- a/api/source/service/migrations/0046.js
+++ b/api/source/service/migrations/0046.js
@@ -313,14 +313,6 @@ const upMigration = [
         CALL task_output('info', 'task finished');
 
     END`,
-
-  `DROP EVENT IF EXISTS \`job-1-stigman\``,
-  `CREATE EVENT IF NOT EXISTS \`job-1-stigman\`
-    ON SCHEDULE EVERY 1 DAY
-    STARTS '2025-10-01 05:00:00'
-    DISABLE
-    DO
-      CALL run_job(1, NULL)`,
 ]
 
 const downMigration = []


### PR DESCRIPTION
This PR fixes migration 0046 so it does not delete and recreate the event that executes Job 1. This prevents reverting a deployment that scheduled and enabled Job 1.