### PR TITLE
Add updateAssetProps flag and UI for asset information updates

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1965,9 +1965,9 @@
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.clonedeep": {

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -657,7 +657,7 @@ paths:
               emptyDetail: 'replace',
               emptyComment: 'ignore',
               updateAssetProps: false,
-              allowCustom: true,
+              allowCustom: true
             }
         ```
       operationId: createCollection
@@ -6979,7 +6979,7 @@ components:
             - replace
         updateAssetProps:
           description: |
-            Flag indicating whether to update Asset information (IP, MAC, FQDN, noncomputing, metadata:(role and tech area)) when Asset already exists in the Collection.
+            Flag indicating whether to update Asset information (IP, MAC, FQDN, noncomputing, and metadata including role and tech area) when Asset already exists in the Collection.
           type: boolean
         allowCustom:
           description: |
@@ -6991,8 +6991,7 @@ components:
         - unreviewedCommented
         - emptyDetail
         - emptyComment
-        # - updateAssetProps not required yet. still in dev
-        - allowCustom      
+        - allowCustom
     CollectionImportAutoStatus:
       type: object
       additionalProperties: false

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -656,7 +656,7 @@ paths:
               unreviewedCommented: 'informational',
               emptyDetail: 'replace',
               emptyComment: 'ignore',
-              updateAssetProps: true,
+              updateAssetProps: false,
               allowCustom: true,
             }
         ```
@@ -6979,7 +6979,7 @@ components:
             - replace
         updateAssetProps:
           description: |
-            Flag indicating whether to update Asset information (IP, MAC, FQDN, noncomputing, role) when Asset already exists in the Collection.
+            Flag indicating whether to update Asset information (IP, MAC, FQDN, noncomputing, metadata:(role and tech area)) when Asset already exists in the Collection.
           type: boolean
         allowCustom:
           description: |

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -656,7 +656,8 @@ paths:
               unreviewedCommented: 'informational',
               emptyDetail: 'replace',
               emptyComment: 'ignore',
-              allowCustom: true
+              updateAssetProps: true,
+              allowCustom: true,
             }
         ```
       operationId: createCollection
@@ -6976,6 +6977,10 @@ components:
             - ignore
             - import
             - replace
+        updateAssetProps:
+          description: |
+            Flag indicating whether to update Asset information (IP, MAC, FQDN, noncomputing, role) when Asset already exists in the Collection.
+          type: boolean
         allowCustom:
           description: |
             Flag indicating whether Clients may POST reviews that do not conform to importOptions specified.
@@ -6986,6 +6991,7 @@ components:
         - unreviewedCommented
         - emptyDetail
         - emptyComment
+        # - updateAssetProps not required yet. still in dev
         - allowCustom      
     CollectionImportAutoStatus:
       type: object

--- a/client/src/js/SM/CollectionPanel.js
+++ b/client/src/js/SM/CollectionPanel.js
@@ -1904,7 +1904,7 @@ SM.CollectionPanel.showCollectionTab = function (options) {
           text: 'Import CKL(B) or SCAP...',
           qtip: SM.TipContent.ImportFromCollectionPanel,
           handler: () => {
-            showImportResultFiles(collectionId, false)         
+            showImportResultFiles(collectionId, false, false)         
           }
         }
       ],

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -853,6 +853,26 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
             }
         })
 
+        this.updateAssetPropsCb = new SM.Global.HelperCheckbox({
+            boxLabel: 'Update existing Asset properties',
+            name: 'updateAssetProps',
+            checked: this.initialOptions.updateAssetProps ?? false,
+            helpText: SM.TipContent.ImportOptions.UpdateAssetProps,
+            hideLabel: true,
+            disabled: this.context === 'wizard',
+            listeners: {
+                check: function (cb, checked) {
+                    if (_this.localStorage) {
+                        localStorage.setItem('wizardImportOptions', JSON.stringify(_this.getOptions()))
+                    }
+                    _this.onOptionChanged?.(_this, cb, checked)
+                }
+            }
+        })
+        this.updateAssetPropsCb.setReadOnly = function (readOnly) {
+            _this.updateAssetPropsCb.setDisabled(readOnly)
+        }
+
         this.autoStatusFieldGroup = new Ext.form.FieldSet({
             title: 'Review Status Per Result',
             border: true,
@@ -879,7 +899,8 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
             this.unreviewedCombo,
             this.unreviewedCommentedCombo,
             this.emptyDetailCombo,
-            this.emptyCommentCombo
+            this.emptyCommentCombo,
+            this.updateAssetPropsCb
         ]
         this.allowCustomCb = new Ext.form.Checkbox({
             boxLabel: `Options can be customized for each import`,
@@ -952,6 +973,7 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
                 unreviewedCommented: _this.unreviewedCommentedCombo.value ,  
                 emptyDetail: _this.emptyDetailCombo.value,
                 emptyComment: _this.emptyCommentCombo.value,
+                updateAssetProps: _this.updateAssetPropsCb.checked,
                 allowCustom: _this.allowCustomCb.checked
             }
             return options

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -1346,7 +1346,7 @@ SM.ReviewsImport.MultiSelectPanel = Ext.extend(Ext.Panel, {
     initComponent: function () {
         const _this = this
         this.parseOptionsFieldSet = new SM.ReviewsImport.ParseOptionsFieldSet({
-            height: 300,
+            height: 330,
             context: this.optionsContext,
             canAccept: true,
             initialOptions: this.initialOptions,
@@ -1430,7 +1430,7 @@ SM.ReviewsImport.SelectFilesPanel = Ext.extend(Ext.Panel, {
         }
 
         this.parseOptionsFieldSet = new SM.ReviewsImport.ParseOptionsFieldSet({
-            height: 300,
+            height: 330,
             context: 'wizard',
             initialOptions: this.initialOptions,
             canAccept: this.canAccept

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -925,7 +925,9 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
                     for (const combo of _this.optionComboBoxes) {
                         combo.setReadOnly(!checked)
                     }
-                    _this.updateAssetPropsCb.setReadOnly(!checked)
+                    if (_this.canUpdateAssetProps) {
+                        _this.updateAssetPropsCb.setReadOnly(!checked)
+                    }
                     _this.localStorage = checked
                     if (_this.localStorage && localStorage.wizardImportOptions?.length) {
                         _this.restoreOptions(JSON.parse(localStorage.wizardImportOptions))
@@ -933,6 +935,12 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
                     _this.onOptionChanged?.(_this, cb, checked)
                 }
             }
+        })
+
+        this.noUpdateAssetPropsDisplay = new Ext.form.DisplayField({
+            value: '<i>Asset property updates are configured in the Manage Collection interface.</i>',
+            height: 22,
+            hideLabel: true
         })
 
         this.noCustomizeDisplay = new Ext.form.DisplayField({
@@ -988,11 +996,9 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
             items.push(this.initialOptions.allowCustom ? this.customizeCb : this.noCustomizeDisplay)
         }
         items.push(this.autoStatusFieldGroup, ...this.optionComboBoxes)
-        if (this.canUpdateAssetProps) {
-            items.push(this.updateAssetPropsCb)
-        }
+        items.push(this.canUpdateAssetProps ? this.updateAssetPropsCb : this.noUpdateAssetPropsDisplay)
         if (this.context !== 'wizard') {
-            items.push(this.updateAssetPropsCb, this.allowCustomCb)
+            items.push(this.allowCustomCb)
         }
         const config = {
             title: 'Import options',

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -995,7 +995,7 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
         if (this.context === 'wizard') {
             items.push(this.initialOptions.allowCustom ? this.customizeCb : this.noCustomizeDisplay)
         }
-        items.push(this.autoStatusFieldGroup, ...this.optionComboBoxes)
+        items.push(...this.optionComboBoxes)
         items.push(this.canUpdateAssetProps ? this.updateAssetPropsCb : this.noUpdateAssetPropsDisplay)
         if (this.context !== 'wizard') {
             items.push(this.allowCustomCb)

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -2373,14 +2373,15 @@ async function showImportResultFiles(collectionId, createObjects = true) {
                 fpwindow.add(progressPanel)
                 fpwindow.doLayout()
 
+                const { updateAssetProps } = fp.parseOptionsFieldSet.getOptions()
                 let processedCount = 0
                 for (const taskAsset of taskAssets.values()) {
                     try {
                         let assetId = taskAsset.assetProps.assetId
                         updateProgress(processedCount / taskAssets.size, taskAsset.assetProps.name)
                         let importAssetResult
-                        if (modifyAssets && (!taskAsset.knownAsset || taskAsset.hasNewAssignment)) {
-                            importAssetResult = await importAsset(taskAsset)
+                        if (modifyAssets && (!taskAsset.knownAsset || taskAsset.hasNewAssignment || (taskAsset.hasUpdatedAssetProps && updateAssetProps))) {
+                            importAssetResult = await importAsset(taskAsset, updateAssetProps)
                             updateStatusGrid(importAssetResult)
                             assetId = importAssetResult.assetId
                         }
@@ -2426,14 +2427,18 @@ async function showImportResultFiles(collectionId, createObjects = true) {
                 progressPanel.st.store.loadData(status, true)
             }
 
-            async function importAsset(taskAsset) {
+            async function importAsset(taskAsset, updateAssetProps) {
                 let url, method, jsonData
-                if (taskAsset.knownAsset && taskAsset.hasNewAssignment) {
+                if (taskAsset.knownAsset) {
                     url = `${STIGMAN.Env.apiBase}/assets/${taskAsset.assetProps.assetId}`
                     method = 'PATCH'
-                    jsonData = {
-                        collectionId: taskAsset.assetProps.collectionId,
-                        stigs: taskAsset.assetProps.stigs
+                    jsonData = { collectionId: taskAsset.assetProps.collectionId }
+                    if (taskAsset.hasNewAssignment) {
+                        jsonData.stigs = taskAsset.assetProps.stigs
+                    }
+                    if (taskAsset.hasUpdatedAssetProps && updateAssetProps) {
+                        const { ip, fqdn, mac, noncomputing, metadata } = taskAsset.assetProps
+                        Object.assign(jsonData, { ip, fqdn, mac, noncomputing, metadata })
                     }
                 }
                 else {

--- a/client/src/js/SM/ReviewsImport.js
+++ b/client/src/js/SM/ReviewsImport.js
@@ -786,6 +786,7 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
     initComponent: function () {
         const _this = this
         this.context = this.context ?? 'manage' // 'or 'wizard'
+        this.canUpdateAssetProps = this.canUpdateAssetProps ?? true
         this.autoStatusCombo = new SM.ReviewsImport.AutoStatusComboBox({
             value: this.initialOptions.autoStatus.fail,
             name: 'autoStatus.fail',
@@ -900,7 +901,6 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
             this.unreviewedCommentedCombo,
             this.emptyDetailCombo,
             this.emptyCommentCombo,
-            this.updateAssetPropsCb
         ]
         this.allowCustomCb = new Ext.form.Checkbox({
             boxLabel: `Options can be customized for each import`,
@@ -925,6 +925,7 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
                     for (const combo of _this.optionComboBoxes) {
                         combo.setReadOnly(!checked)
                     }
+                    _this.updateAssetPropsCb.setReadOnly(!checked)
                     _this.localStorage = checked
                     if (_this.localStorage && localStorage.wizardImportOptions?.length) {
                         _this.restoreOptions(JSON.parse(localStorage.wizardImportOptions))
@@ -960,6 +961,9 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
             _this.autoStatusCombo.setValue(options.autoStatus.fail)
             _this.autoStatusNotApplicable.setValue(options.autoStatus.notapplicable)
             _this.autoStatusPass.setValue(options.autoStatus.pass)
+            _this.updateAssetPropsCb.suspendEvents()
+            _this.updateAssetPropsCb.setValue(options.updateAssetProps ?? false)
+            _this.updateAssetPropsCb.resumeEvents()
         }
 
         this.getOptions = function () {
@@ -973,7 +977,7 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
                 unreviewedCommented: _this.unreviewedCommentedCombo.value ,  
                 emptyDetail: _this.emptyDetailCombo.value,
                 emptyComment: _this.emptyCommentCombo.value,
-                updateAssetProps: _this.updateAssetPropsCb.checked,
+                updateAssetProps: _this.canUpdateAssetProps ? _this.updateAssetPropsCb.checked : false,
                 allowCustom: _this.allowCustomCb.checked
             }
             return options
@@ -984,9 +988,11 @@ SM.ReviewsImport.ParseOptionsFieldSet = Ext.extend(Ext.form.FieldSet, {
             items.push(this.initialOptions.allowCustom ? this.customizeCb : this.noCustomizeDisplay)
         }
         items.push(this.autoStatusFieldGroup, ...this.optionComboBoxes)
-
+        if (this.canUpdateAssetProps) {
+            items.push(this.updateAssetPropsCb)
+        }
         if (this.context !== 'wizard') {
-            items.push(this.allowCustomCb)
+            items.push(this.updateAssetPropsCb, this.allowCustomCb)
         }
         const config = {
             title: 'Import options',
@@ -1350,6 +1356,7 @@ SM.ReviewsImport.MultiSelectPanel = Ext.extend(Ext.Panel, {
             context: this.optionsContext,
             canAccept: true,
             initialOptions: this.initialOptions,
+            canUpdateAssetProps: this.canUpdateAssetProps,
         })
         this.selectFilesGrid = new SM.ReviewsImport.SelectFilesGrid({
             flex: 3,
@@ -1430,10 +1437,12 @@ SM.ReviewsImport.SelectFilesPanel = Ext.extend(Ext.Panel, {
         }
 
         this.parseOptionsFieldSet = new SM.ReviewsImport.ParseOptionsFieldSet({
-            height: 330,
+            height: 300,
             context: 'wizard',
             initialOptions: this.initialOptions,
-            canAccept: this.canAccept
+            canAccept: this.canAccept,
+            canUpdateAssetProps: this.canUpdateAssetProps ?? false
+
         })
 
 
@@ -2060,7 +2069,7 @@ SM.ReviewsImport.ImportProgressPanel = Ext.extend(Ext.Panel, {
     }
 })
 
-async function showImportResultFiles(collectionId, createObjects = true) {
+async function showImportResultFiles(collectionId, createObjects = true, canUpdateAssetProps = true) {
     try {
         const cachedCollection = SM.Cache.CollectionMap.get(collectionId)
         const userGrant = curUser.collectionGrants.find( i => i.collection.collectionId === cachedCollection.collectionId )?.roleId
@@ -2081,6 +2090,7 @@ async function showImportResultFiles(collectionId, createObjects = true) {
             optionsContext: 'wizard',
             initialOptions,
             canAccept,
+            canUpdateAssetProps,
             listeners: {
                 continue: function(panel) {
                     const records = panel.selectFilesGrid.store.getRange()
@@ -2523,6 +2533,7 @@ async function showImportResultFile(params) {
             optionsContext: 'wizard',
             initialOptions,
             canAccept,
+            canUpdateAssetProps: false,
             onFileSelected,
             onFileDropped
         })

--- a/client/src/js/SM/TipContent.js
+++ b/client/src/js/SM/TipContent.js
@@ -28,7 +28,7 @@ SM.TipContent.ImportOptions.EmptyComment = `How to handle Reviews with empty com
 `
 
 SM.TipContent.ImportOptions.UpdateAssetProps = `Should Asset properties be updated from the import source when the Asset already exists in the Collection?
-<br><br>When <b>checked</b>, the import will update Asset information (IP, MAC, FQDN, noncomputing, metadata:(role and tech area)) from the import source, if present.
+<br><br>When <b>checked</b>, the import will update Asset information (IP, MAC, FQDN, noncomputing, and metadata including role and tech area) from the import source, if present.
 <br><br>When <b>unchecked</b>, existing Asset properties will be preserved.
 `
 

--- a/client/src/js/SM/TipContent.js
+++ b/client/src/js/SM/TipContent.js
@@ -28,7 +28,7 @@ SM.TipContent.ImportOptions.EmptyComment = `How to handle Reviews with empty com
 `
 
 SM.TipContent.ImportOptions.UpdateAssetProps = `Should Asset properties be updated from the import source when the Asset already exists in the Collection?
-<br><br>When <b>checked</b>, the import will update Asset information (IP, MAC, FQDN, noncomputing, role) from the import source.
+<br><br>When <b>checked</b>, the import will update Asset information (IP, MAC, FQDN, noncomputing, metadata:(role and tech area)) from the import source, if present.
 <br><br>When <b>unchecked</b>, existing Asset properties will be preserved.
 `
 

--- a/client/src/js/SM/TipContent.js
+++ b/client/src/js/SM/TipContent.js
@@ -22,11 +22,15 @@ SM.TipContent.ImportOptions.UnreviewedCommented = `The result to be imported for
 `
 
 SM.TipContent.ImportOptions.EmptyComment = `How to handle Reviews with empty commentary text:
-<br><br><b>Ignored:</b> Retain any existing text already stored. 
+<br><br><b>Ignored:</b> Retain any existing text already stored.
 <br><br><b>Replaced:</b> Create a static message. This message will become the text for the purposes of meeting submission requirements.
 <br><br><b>Imported:</b> This will have the effect of clearing any existing text.
 `
 
+SM.TipContent.ImportOptions.UpdateAssetProps = `Should Asset properties be updated from the import source when the Asset already exists in the Collection?
+<br><br>When <b>checked</b>, the import will update Asset information (IP, MAC, FQDN, noncomputing, role) from the import source.
+<br><br>When <b>unchecked</b>, existing Asset properties will be preserved.
+`
 
 SM.TipContent.Roles = `
 <b>Roles</b> <br>

--- a/client/src/js/modules/package-lock.json
+++ b/client/src/js/modules/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.4",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.5",
         "chart.js": "^4.4.2",
         "serialize-error": "^11.0.0"
       }
@@ -16,9 +16,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.4.tgz",
-      "integrity": "sha512-/tdMSF4w5G/b37GpYylPGIeLRD8sj41VVvWeKgXhNypXTTTRJqUA6TGG+cDkOcYfSpqBjlkXFbWGkbCfYHHISg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.5.tgz",
+      "integrity": "sha512-KfjYnH4dgSx7maKFJUp4TyMGBTbVEKnDofZWz/rHKb6NAz0apPllPZUHejIxALQtacbbVGKjW0LHm4i2x8yVNQ==",
       "license": "MIT"
     },
     "node_modules/chart.js": {

--- a/client/src/js/modules/package-lock.json
+++ b/client/src/js/modules/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.5",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.6",
         "chart.js": "^4.4.2",
         "serialize-error": "^11.0.0"
       }
@@ -16,9 +16,9 @@
       "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.5.tgz",
-      "integrity": "sha512-KfjYnH4dgSx7maKFJUp4TyMGBTbVEKnDofZWz/rHKb6NAz0apPllPZUHejIxALQtacbbVGKjW0LHm4i2x8yVNQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.6.tgz",
+      "integrity": "sha512-gqiHLeblktGkJLEnUxBhcfWLeKQ23jFaua+hIMPLINf4MwOIzECshgBlHB8IcK+YqphiK5wuplNS/2glPWLeNw==",
       "license": "MIT"
     },
     "node_modules/chart.js": {

--- a/client/src/js/modules/package.json
+++ b/client/src/js/modules/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.4",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.5",
     "chart.js": "^4.4.2",
     "serialize-error": "^11.0.0"
   }

--- a/client/src/js/modules/package.json
+++ b/client/src/js/modules/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.5",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.6",
     "chart.js": "^4.4.2",
     "serialize-error": "^11.0.0"
   }

--- a/test/api/package-lock.json
+++ b/test/api/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.4",
+        "@nuwcdivnpt/stig-manager-client-modules": "^1.6.6",
         "chai": "^5.1.2",
         "chai-datetime": "^1.8.1",
         "deep-equal-in-any-order": "^2.0.6",
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@nuwcdivnpt/stig-manager-client-modules": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.4.tgz",
-      "integrity": "sha512-/tdMSF4w5G/b37GpYylPGIeLRD8sj41VVvWeKgXhNypXTTTRJqUA6TGG+cDkOcYfSpqBjlkXFbWGkbCfYHHISg==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@nuwcdivnpt/stig-manager-client-modules/-/stig-manager-client-modules-1.6.6.tgz",
+      "integrity": "sha512-gqiHLeblktGkJLEnUxBhcfWLeKQ23jFaua+hIMPLINf4MwOIzECshgBlHB8IcK+YqphiK5wuplNS/2glPWLeNw==",
       "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {

--- a/test/api/package.json
+++ b/test/api/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.4",
+    "@nuwcdivnpt/stig-manager-client-modules": "^1.6.6",
     "chai": "^5.1.2",
     "chai-datetime": "^1.8.1",
     "deep-equal-in-any-order": "^2.0.6",


### PR DESCRIPTION
Resolves: #2009 
This pull request introduces support for updating existing Asset properties during import operations, adds related UI controls and help text, and updates the API specification to document this new option. The changes ensure that users can choose whether to update Asset information (such as IP, MAC, FQDN, etc.) when importing data, and that this choice is respected throughout the import workflow.

**API and Documentation Updates:**

* Added a new `updateAssetProps` boolean flag to the API specification (`stig-manager.yaml`) for import options, including a description of its behavior. [[1]](diffhunk://#diff-9f0f1a173ef69bcbd3ddc0f420c723f60b94a56abbcba8b71f13bffe1c7b8788L659-R660) [[2]](diffhunk://#diff-9f0f1a173ef69bcbd3ddc0f420c723f60b94a56abbcba8b71f13bffe1c7b8788R6980-R6983)
* Noted in the API that `updateAssetProps` is in development and not yet required.

**Client UI Enhancements:**

* Added an "Update existing Asset properties" checkbox (with help tooltip) to the import options form in Collection Settings (`SM.ReviewsImport.ParseOptionsFieldSet`), including logic to enable/disable and persist the setting. [[1]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR857-R876) [[2]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR928-R930) [[3]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR972-R974) [[4]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR988) [[5]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dL965-R999) [[6]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dL1327-R1365) [[7]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dL1414-R1451)
* Added a new help text entry explaining the `updateAssetProps` option.

- Import checklist(s) UI:
  - Collection Management UI invocation: Update Asset Properties option available (consistent with implied CreateObjects behavior, which only creates Assets or assigns STIGs when invoked from collection management interface)
  - Collection Dashboard or Asset Review  invocation: Update Asset Properties Option replaced with informational message "_Asset property updates are configured in the Manage Collection interface._" 


**Import Workflow Logic:**

* Updated the import workflow (`showImportResultFiles` and related functions) to pass and respect the `updateAssetProps` flag, ensuring that Asset properties are updated only when the option is enabled and the relevant conditions are met. [[1]](diffhunk://#diff-128b58d5c10fc54480691296c4469159224b26deee2dd8cdc6709e561502495eL1907-R1907) [[2]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dL2041-R2078) [[3]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR2099) [[4]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR2392-R2400) [[5]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dL2407-R2457) [[6]](diffhunk://#diff-4200a3594021d7edc8d183650a73d5f57f7012800b4e0767c5b8c6a1ec1cb25dR2542)