### PR TITLE
fix:  escape oidc error messages

### DIFF
--- a/client/src/js/init.js
+++ b/client/src/js/init.js
@@ -164,13 +164,18 @@ import { stylesheets, scripts, isMinimizedSource } from './resources.js'
     statusEl.innerHTML = html
   }
 
+  function escapeHtml(str) {
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+  }
+
   function appendError(message, showReauth = true) {
+    const safeMessage = escapeHtml(message)
     if (showReauth) {
       const reauthHref = window.location.origin + window.location.pathname
-      statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${message}</span><br><br><a href="${reauthHref}">Retry authorization.</a>`
+      statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${safeMessage}</span><br><br><a href="${reauthHref}">Retry authorization.</a>`
     }
     else {
-      statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${message}</span>`
+      statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${safeMessage}</span>`
     }
     hideSpinner()
   }

--- a/client/src/reauth.html
+++ b/client/src/reauth.html
@@ -108,9 +108,13 @@
       statusEl.innerHTML += `${statusEl.innerHTML ? '<br/><br/>' : ''}${html}`
     }
 
+    function escapeHtml(str) {
+      return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+    }
+
     function appendError(message) {
       const cleanHref = window.location.origin + window.location.pathname
-      statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${message}</span><br><br><a href="${cleanHref}">Retry authorization.</a>`
+      statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${escapeHtml(message)}</span><br><br><a href="${cleanHref}">Retry authorization.</a>`
       hideSpinner()
     }
     function hideSpinner() {


### PR DESCRIPTION
This pull request introduces improved security for error message rendering in the authentication flow by ensuring that error messages are properly escaped before being inserted into the DOM. This helps prevent potential cross-site scripting (XSS) vulnerabilities.

**Security improvements:**

* Added an `escapeHtml` utility function to both `client/src/js/init.js` and `client/src/reauth.html` to sanitize error messages before inserting them into `innerHTML`. [[1]](diffhunk://#diff-75af7b3a7f8ec37674739ec6620a078dfb70db708d6800cbdf37e20b57f0756cR167-R178) [[2]](diffhunk://#diff-cfc9c7ace92c86df67ba4743a0756e8d9581c455678a930ba432948c55d657f6R111-R117)
* Updated the `appendError` function in both files to use the new `escapeHtml` function, ensuring that error messages are safely displayed to users. [[1]](diffhunk://#diff-75af7b3a7f8ec37674739ec6620a078dfb70db708d6800cbdf37e20b57f0756cR167-R178) [[2]](diffhunk://#diff-cfc9c7ace92c86df67ba4743a0756e8d9581c455678a930ba432948c55d657f6R111-R117)