### PR TITLE
security: XSS escaping, redirectUri validation, and logout availability

### DIFF
--- a/clientV2/public/reauth.html
+++ b/clientV2/public/reauth.html
@@ -114,9 +114,15 @@
         statusEl.innerHTML += `${statusEl.innerHTML ? '<br/><br/>' : ''}${html}`
       }
 
+      function escHtml(s) {
+        return String(s ?? '')
+          .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+      }
+
       function appendError(message) {
         const cleanHref = window.location.origin + window.location.pathname
-        statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${message}</span><br><br><a href="${cleanHref}">Retry authorization.</a>`
+        statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${escHtml(message)}</span><br><br><a href="${cleanHref}">Retry authorization.</a>`
         hideSpinner()
       }
       function hideSpinner() {

--- a/clientV2/public/workers/oidc-worker.js
+++ b/clientV2/public/workers/oidc-worker.js
@@ -100,6 +100,10 @@ async function exchangeCodeForToken({ code, codeVerifier, clientId = ENV.clientI
 async function initialize(options) {
   if (!initialized) {
     initialized = true
+    const parsedRedirectUri = new URL(options.redirectUri)
+    if (!parsedRedirectUri.protocol.startsWith('http')) {
+      return { success: false, error: `Invalid redirectUri scheme: ${parsedRedirectUri.protocol}` }
+    }
     ENV = options.env || null
     reauthUri = options.reauthUri || null
 
@@ -116,7 +120,7 @@ async function initialize(options) {
       return { success: false, error: validation.error }
     }
   }
-  return { success: true, env: ENV, channelName }
+  return { success: true, env: ENV, channelName, logoutAvailable: !!oidcConfiguration.end_session_endpoint }
 }
 
 async function getStatus() {
@@ -129,10 +133,10 @@ async function getStatus() {
 }
 
 function logout() {
-  return {
-    success: true,
-    redirect: oidcConfiguration.end_session_endpoint,
+  if (!oidcConfiguration.end_session_endpoint) {
+    return { success: false, error: 'Logout not available' }
   }
+  return { success: true, redirect: oidcConfiguration.end_session_endpoint }
 }
 
 async function onMessage(e) {
@@ -228,6 +232,19 @@ function validateOidcConfiguration() {
   else if (ENV.strictPkce && !oidcConfiguration.code_challenge_methods_supported?.includes('S256')) {
     result.success = false
     result.error = 'OP does not advertise PKCE and STIGMAN_CLIENT_STRICT_PKCE=true'
+  }
+  else if (oidcConfiguration.end_session_endpoint) {
+    try {
+      const parsed = new URL(oidcConfiguration.end_session_endpoint)
+      if (!parsed.protocol.startsWith('http')) {
+        console.warn(logPrefix, 'end_session_endpoint has invalid scheme, logout will be unavailable:', oidcConfiguration.end_session_endpoint)
+        oidcConfiguration.end_session_endpoint = null
+      }
+    }
+    catch {
+      console.warn(logPrefix, 'end_session_endpoint is not a valid URL, logout will be unavailable:', oidcConfiguration.end_session_endpoint)
+      oidcConfiguration.end_session_endpoint = null
+    }
   }
   return result
 }

--- a/clientV2/src/features/MenuBar/components/MenuBar.vue
+++ b/clientV2/src/features/MenuBar/components/MenuBar.vue
@@ -69,11 +69,11 @@ const items = computed(() => {
         {
           separator: true,
         },
-        {
+        ...(oidcWorker.logoutAvailable ? [{
           label: 'Sign out',
           icon: 'pi pi-sign-out',
           command: handleLogout,
-        },
+        }] : []),
       ],
     })
   }

--- a/clientV2/src/init.js
+++ b/clientV2/src/init.js
@@ -179,13 +179,19 @@ function setStatus(html) {
   statusEl.innerHTML = html
 }
 
+function escHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
 function appendError(message, showReauth = true) {
   if (showReauth) {
     const reauthHref = window.location.origin + window.location.pathname
-    statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${message}</span><br><br><a href="${reauthHref}">Retry authorization.</a>`
+    statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${escHtml(message)}</span><br><br><a href="${reauthHref}">Retry authorization.</a>`
   }
   else {
-    statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${message}</span>`
+    statusEl.innerHTML += `<br/><br/><span style="color:#ff5757">Error: ${escHtml(message)}</span>`
   }
   hideSpinner()
 }
@@ -229,6 +235,7 @@ async function setupOidcWorker() {
       this.worker.port.postMessage({ requestId: 'contextActive' })
     },
     channelName: null,
+    logoutAvailable: true,
     token: null,
     tokenParsed: null,
     worker: new SharedWorker(`${import.meta.env.BASE_URL}workers/oidc-worker.js`, { name: 'stigman-oidc-worker', type: 'module' }),
@@ -242,6 +249,7 @@ async function setupOidcWorker() {
     return
   }
   OW.channelName = response.channelName
+  OW.logoutAvailable = response.logoutAvailable ?? true
   const bc = new BroadcastChannel(STIGMAN.oidcWorker.channelName)
   bc.onmessage = (event) => {
     if (event.data.type === 'accessToken') {


### PR DESCRIPTION
- init.js, reauth.html: add escHtml() and apply to appendError() to prevent reflected XSS from OAuth error/error_description params and other non-literal error strings inserted into innerHTML
- oidc-worker.js: validate redirectUri scheme in initialize(); null out malformed end_session_endpoint in validateOidcConfiguration() with a warning rather than failing init; logout() returns success:false when no valid endpoint is present; initialize() response includes logoutAvailable flag
- init.js: store logoutAvailable on oidcWorker object from initialize response
- MenuBar.vue: omit Sign out menu item when logoutAvailable is false