### PR TITLE
fix: config express app to use built-in Node query parser which handles large benchmarkId arrays instead of `qs`

### DIFF
--- a/api/source/bootstrap/middlewares.js
+++ b/api/source/bootstrap/middlewares.js
@@ -2,7 +2,6 @@
 const path = require('node:path')
 const multer  = require('multer')
 const express = require('express')
-const qs = require('qs')
 const cors = require('cors')
 const { middleware: openApiMiddleware } = require('express-openapi-validator')
 const config = require('../utils/config')
@@ -17,10 +16,8 @@ function configureMiddleware(app) {
 
     // Must run before any app.use() call: Express's lazyrouter binds the query
     // parser at the moment the first middleware is registered and ignores
-    // later changes. qs >=6.14 enforces arrayLimit on repeated bare keys, which
-    // would otherwise corrupt type:array+explode params (e.g., benchmarkId,
-    // assetId) once they exceed 20 values.
-    app.set('query parser', str => qs.parse(str, { arrayLimit: 5000, allowPrototypes: true }))
+    // later changes.
+    app.set('query parser', 'simple')
 
     const middlewareConfigFunctions = [
       configureMulter,

--- a/api/source/bootstrap/middlewares.js
+++ b/api/source/bootstrap/middlewares.js
@@ -2,6 +2,7 @@
 const path = require('node:path')
 const multer  = require('multer')
 const express = require('express')
+const qs = require('qs')
 const cors = require('cors')
 const { middleware: openApiMiddleware } = require('express-openapi-validator')
 const config = require('../utils/config')
@@ -13,6 +14,13 @@ const state = require('../utils/state')
 const logger = require('../utils/logger')
 
 function configureMiddleware(app) {
+
+    // Must run before any app.use() call: Express's lazyrouter binds the query
+    // parser at the moment the first middleware is registered and ignores
+    // later changes. qs >=6.14 enforces arrayLimit on repeated bare keys, which
+    // would otherwise corrupt type:array+explode params (e.g., benchmarkId,
+    // assetId) once they exceed 20 values.
+    app.set('query parser', str => qs.parse(str, { arrayLimit: 5000, allowPrototypes: true }))
 
     const middlewareConfigFunctions = [
       configureMulter,

--- a/test/api/mocha/data/metrics/metricsGet.test.js
+++ b/test/api/mocha/data/metrics/metricsGet.test.js
@@ -1227,5 +1227,18 @@ describe('GET - Metrics', function () {
         })
     })
   }
+
+  describe('GET - getMetricsSummaryByCollection - large benchmarkId array', function () {
+    // Regression: qs default arrayLimit (20) collapses repeated bare keys into an
+    // object, which the OpenAPI validator then wraps in [] and rejects with
+    // "request/query/benchmarkId/0 must be string". The api configures a custom
+    // query parser to keep array semantics for any reasonable count.
+    it('accepts > 20 benchmarkId query values without a 400 from the validator', async function () {
+      const adminToken = iterations.find(i => i.name === 'stigmanadmin').token
+      const params = Array.from({length: 25}, (_, i) => `benchmarkId=Synthetic_Stig_${i}`).join('&')
+      const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/metrics/summary?${params}`, 'GET', adminToken)
+      expect(res.status).to.not.eql(400)
+    })
+  })
 })
 

--- a/test/api/mocha/data/metrics/metricsGet.test.js
+++ b/test/api/mocha/data/metrics/metricsGet.test.js
@@ -1229,13 +1229,13 @@ describe('GET - Metrics', function () {
   }
 
   describe('GET - getMetricsSummaryByCollection - large benchmarkId array', function () {
-    // Regression: qs default arrayLimit (20) collapses repeated bare keys into an
+    // Regression: express query parser defaults to `qs`. whose default arrayLimit (20) collapses repeated bare keys into an
     // object, which the OpenAPI validator then wraps in [] and rejects with
-    // "request/query/benchmarkId/0 must be string". The api configures a custom
-    // query parser to keep array semantics for any reasonable count.
-    it('accepts > 20 benchmarkId query values without a 400 from the validator', async function () {
+    // "request/query/benchmarkId/0 must be string". The api sets the query parser to `simple`
+    // and uses the built-in Node query parser which does not have this behavior
+    it('accepts 100 benchmarkId query values without a 400 from the validator', async function () {
       const adminToken = iterations.find(i => i.name === 'stigmanadmin').token
-      const params = Array.from({length: 25}, (_, i) => `benchmarkId=Synthetic_Stig_${i}`).join('&')
+      const params = Array.from({length: 100}, (_, i) => `benchmarkId=Synthetic_Stig_${i}`).join('&')
       const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/metrics/summary?${params}`, 'GET', adminToken)
       expect(res.status).to.not.eql(400)
     })


### PR DESCRIPTION
Restores array semantics for repeated query params after qs ≥ 6.14
Resolves: #2034 

## Summary

- Install a custom Express query parser that raises qs's `arrayLimit` so that endpoints accepting `array + explode` query parameters (e.g. `benchmarkId`, `assetId`) keep their array semantics for any realistic count.
- Add a regression test that exercises `GET /collections/{id}/metrics/summary` with > 20 `benchmarkId` values.

## Issue

Starting in 1.6.1 (a dependency-only release), requests to the metrics endpoints fail with HTTP 400 once the caller passes more than 20 repeated `benchmarkId` query parameters:

The export-checklist dialog builds this URL with **every** STIG in the collection by default, so any installation with more than 20 STIGs hits the error as soon as that dialog opens. Endpoints accepting `AssetIdArrayQuery` are affected by the same ceiling.



## Fix

`app.set('query parser', fn)` is Express's documented mechanism for swapping in a custom parser ([api docs](https://expressjs.com/en/api.html)) — the function receives the raw query string and returns the parsed object. Express forwards the function verbatim to its internal `query()` middleware, so a thin wrapper around `qs.parse` with `arrayLimit` raised is sufficient.

```js
app.set('query parser', str => qs.parse(str, { arrayLimit: 5000, allowPrototypes: true }))
```

- arrayLimit: 5000 restores effectively-unbounded array behaviour while keeping a defensive ceiling. The practical bound is the URL/header byte limit.
- allowPrototypes: true matches what Express's built-in 'extended' parser was doing for back-compat, so the override doesn't introduce an unrelated behaviour change.
- qs is already on disk as a transitive dep of express; no new top-level dependency.

The call must run before any app.use() on the app: Express's lazyrouter() binds the query parser to the router on the first middleware registration and ignores later changes. configureMulter is the first item in the bootstrap list, so the app.set is hoisted to the top of configureMiddleware (above the middleware loop) with a comment explaining the ordering requirement.