### PR TITLE
Update dependencies

### DIFF
--- a/test/state/package-lock.json
+++ b/test/state/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "state",
       "dependencies": {
         "chai": "^5.2.0",
         "chai-datetime": "^1.8.1",
@@ -581,9 +582,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
This pull request makes minor updates to the `test/state/package-lock.json` file, including updating the package metadata and bumping a dependency version.

Dependency and metadata updates:

* Upgraded the `brace-expansion` dependency (under `node_modules/glob/node_modules/brace-expansion`) from version 5.0.5 to 5.0.6, updating its resolved URL and integrity hash.