### PR TITLE
Default an absent description to null on collection create

### DIFF
--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -464,6 +464,12 @@ exports.addOrUpdateCollection = async function(writeAction, collectionId, body, 
 
       // Process scalar properties
       if (writeAction === dbUtils.WRITE_ACTION.CREATE) {
+        // description is optional in the request body, but this named INSERT
+        // binds :description and mysql2 rejects an undefined bind parameter. The
+        // column is nullable (DEFAULT NULL), so default an absent description to
+        // null. The UPDATE/REPLACE path is unaffected because it uses SET ? and
+        // simply omits columns that are not present. See #1303.
+        collectionFields.description = collectionFields.description ?? null
         // INSERT into collections
         let sqlInsert =
         `INSERT INTO

--- a/test/api/mocha/data/collection/collectionPost.test.js
+++ b/test/api/mocha/data/collection/collectionPost.test.js
@@ -216,6 +216,28 @@ describe('POST - Collection - not all tests run for all iterations', function ()
 
 
         })
+
+        it("Create a Collection with no description, expect description to default to null (#1303)",async function () {
+          // Regression: omitting description from the body previously failed the
+          // named INSERT because mysql2 rejects an undefined bind parameter. The
+          // column is nullable, so an absent description defaults to null on create.
+          const post = JSON.parse(JSON.stringify(requestBodies.createCollection))
+          post.name = "testCollectionNoDesc" + utils.getUUIDSubString()
+          delete post.description
+          const res = await utils.executeRequest(`${config.baseUrl}/collections`, 'POST', iteration.token, post)
+          if(distinct.canCreateCollection === false){
+            expect(res.status).to.eql(403)
+            return
+          }
+          expect(res.status).to.eql(201)
+          if (distinct.grant === 'none') {
+            // grant = none iteration can create a collection, but does not give itself access to the collection
+            return
+          }
+          expect(res.body.name).to.equal(post.name)
+          expect(res.body.description).to.equal(null)
+        })
+
         it("Create A colleciton with grant to a user group",async function () {
 
           const post = requestBodies.createCollectionWithTestGroup


### PR DESCRIPTION
Creating a collection without a description blows up with `Bind parameters must not contain undefined`.

The create path binds `:description` in a named insert and mysql2 won't take undefined. metadata and settings get defaults right above it, but description doesn't, so leaving it out of the body breaks the insert. The column's nullable (DEFAULT NULL) so I just default a missing description to null on create. PUT already works since it uses `SET ?` and skips keys that aren't present, so I left that path alone - defaulting it there would wipe an existing description on update.

Couldn't stand up the full DB + OIDC stack to run the integration tests locally, but it's a one-line default that matches the column.

Fixes #1303