### PR TITLE
Use github's dependency-review action instead of `npm audit`

### DIFF
--- a/.github/workflows/api-audit-test-coverage-response.yml
+++ b/.github/workflows/api-audit-test-coverage-response.yml
@@ -38,21 +38,6 @@ permissions:
   pull-requests: read # allows SonarCloud to decorate PRs with analysis results
 
 jobs:
-  npm_audit:
-    name: npm audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: install dependencies
-        run: npm ci
-        working-directory: ./api/source/
-      - name: Audit Dependencies and Create PR Comment if needed
-        uses: oke-py/npm-audit-action@2c6b2da234031fbf72af81a04c76b3a152bb2222 # pin@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          create_issues: false
-          create_pr_comments: true
-          working_directory: ./api/source/
   test_api:
     name: Run tests with coverage
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: Dependency review
+# Scans the dependency manifests a pull request changes and fails only on
+# vulnerabilities the PR introduces (high severity or above). Pre-existing
+# advisories and being behind the base branch do not fail the check. Runs on
+# every PR to a long-lived branch regardless of which paths change, so it
+# covers the api/source, test, and clientV2 manifests alike. Findings are
+# written to the job summary.
+on:
+  pull_request:
+    branches:
+      - main
+      - new-client
+
+permissions:
+  contents: read # dependency-review-action reads the dependency graph diff
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,6 +1,6 @@
 name: Dependency review
-# Scans the dependency manifests a pull request changes and fails only on
-# vulnerabilities the PR introduces (high severity or above). Pre-existing
+# Scans the dependency manifests a pull request changes and fails on any
+# vulnerability the PR introduces (severity low and above). Pre-existing
 # advisories and being behind the base branch do not fail the check. Runs on
 # every PR to a long-lived branch regardless of which paths change, so it
 # covers the api/source, test, and clientV2 manifests alike. Findings are
@@ -23,4 +23,4 @@ jobs:
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
-          fail-on-severity: high
+          fail-on-severity: low


### PR DESCRIPTION
remove npm audit from test workflow, add new dependency-review workflow that uses github-published action.