### PR TITLE
change default STIGMAN_CLIENT_RESPONSE_MODE to "query" and mark "fragment" support deprecated

### DIFF
--- a/api/launchers/stig-manager.sh
+++ b/api/launchers/stig-manager.sh
@@ -192,9 +192,11 @@
 #==============================================================================
 # STIGMAN_CLIENT_RESPONSE_MODE
 #
-#  | Default: "fragment" | The response_mode the web client should specify when
-#  requesting an authorization code from the OIDC provider. Available values:
-#  "fragment", "query"
+#  | Default: "query" | *Deprecated, will be removed in a future release.*
+#  The response_mode the web client should specify when requesting an 
+#  authorization code from the OIDC provider. 
+#  Available values: ``fragment``, ``query``. 
+#  Support for ``fragment`` response mode is deprecated."
 #
 #  Affects: Client
 #==============================================================================

--- a/api/source/bootstrap/bootstrapUtils.js
+++ b/api/source/bootstrap/bootstrapUtils.js
@@ -42,11 +42,20 @@ function logAppConfig(config) {
       cwd: process.cwd()
     })
     logger.writeInfo('bootstrapUtils', 'configuration', config)
-  
+
 }
-  
+
+function logAppConfigWarnings() {
+    if (process.env.STIGMAN_CLIENT_RESPONSE_MODE) {
+        logger.writeWarn('bootstrapUtils', 'deprecation', {
+            message: 'STIGMAN_CLIENT_RESPONSE_MODE is deprecated and will be removed in a future release, after which the client will always use the query response mode.'
+        })
+    }
+}
+
 module.exports = {
     modulePathResolver,
     buildResponseValidationConfig,
-    logAppConfig
+    logAppConfig,
+    logAppConfigWarnings
 }

--- a/api/source/index.js
+++ b/api/source/index.js
@@ -14,6 +14,7 @@ const startServer = require('./bootstrap/server')
 
 signals.setupSignalHandlers()
 bootstrapUtils.logAppConfig(config)
+bootstrapUtils.logAppConfigWarnings()
 
 //Catch unhandled errors. 
 process.on('uncaughtException', (err, origin) => {

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -40,7 +40,7 @@ const config = {
         directory: process.env.STIGMAN_CLIENT_DIRECTORY || '../../client/dist',
         extraScopes: process.env.STIGMAN_CLIENT_EXTRA_SCOPES,
         scopePrefix: process.env.STIGMAN_CLIENT_SCOPE_PREFIX,
-        responseMode: process.env.STIGMAN_CLIENT_RESPONSE_MODE || "fragment",
+        responseMode: process.env.STIGMAN_CLIENT_RESPONSE_MODE || "query",
         reauthAction: process.env.STIGMAN_CLIENT_REAUTH_ACTION || "popup",
         strictPkce: process.env.STIGMAN_CLIENT_STRICT_PKCE !== 'false',
         stateEvents: process.env.STIGMAN_CLIENT_STATE_EVENTS !== 'false',

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -35,8 +35,8 @@
 | Client override of the base URL of the OIDC provider issuing signed JWTs for the API.  The string ``/.well-known/openid-configuration`` will be appended by the client when fetching metadata.","Client "
 "STIGMAN_CLIENT_REAUTH_ACTION","| **Default** ``popup``
 | How to prompt for re-authentication when user credentials expire. Available values: ``popup``, ``iframe``, ``tab``, or ``reload``. See :ref:`stigman_client_reauth_action` in the Authentication document for details.","Client"
-"STIGMAN_CLIENT_RESPONSE_MODE","| **Default** ``fragment``
-| The response_mode the web client should specify when requesting an authorization code from the OIDC provider. Available values: ``fragment``, ``query`` ","Client"
+"STIGMAN_CLIENT_RESPONSE_MODE","| **Default** ``query``
+| *Deprecated, will be removed in a future release.* The response_mode the web client should specify when requesting an authorization code from the OIDC provider. Available values: ``fragment``, ``query``. Support for ``fragment`` response mode is deprecated.","Client"
 "STIGMAN_CLIENT_SCOPE_PREFIX","| **No default**
 | String used as a prefix for each scope when authenticating to the OIDC Provider. Some providers (Azure AD) expect scope requests in the format ``api://<application_id>/<scope>``, where ``api://<application_id>/`` is the required prefix.","Client"
 "STIGMAN_CLIENT_STATE_EVENTS","| **Default** ``true``

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,3 +1,12 @@
+1.6.13-latest
+--------------
+
+Changes:
+
+  - (API) Changed the default value of ``STIGMAN_CLIENT_RESPONSE_MODE`` from ``fragment`` to ``query``, and deprecated the variable.
+
+Note: The web client now requests the ``query`` response mode from the OIDC provider by default, instead of ``fragment``. Most deployments require no action — the client handles both response modes and no OIDC provider reconfiguration is needed. Deployments that explicitly set ``STIGMAN_CLIENT_RESPONSE_MODE`` should plan to remove it: the variable is deprecated, a warning is now logged at startup when it is set, and the variable and support for the ``fragment`` response mode will be removed in a future release.
+
 1.6.13
 -------
 


### PR DESCRIPTION
resolves: #2052 


- `STIGMAN_CLIENT_RESPONSE_MODE` now defaults to `query`, the OAuth2 default for authorization code flow and the recommended practice for PKCE public clients. `fragment` interferes with hash-based client routing and is deprecated.
- The API logs a startup warning when `STIGMAN_CLIENT_RESPONSE_MODE` is explicitly set, stating the variable is deprecated and will be removed in a future release, after which the client will always use the `query` response mode.
- Most deployments require no action: the client handles both response modes and no OIDC provider reconfiguration is needed.
- Environment variable docs updated to mark the variable deprecated and reflect the new default.
- Release notes entry added, with a note describing the ops impact.
