### PR TITLE
Scope default_rev recalculation to the affected Collection in Asset write operations

### DIFF
--- a/api/source/controllers/Asset.js
+++ b/api/source/controllers/Asset.js
@@ -103,7 +103,7 @@ module.exports.deleteAsset = async function deleteAsset (req, res, next) {
     let projections = req.query.projection
     const { assetId, grant } = await getAssetInfoAndVerifyAccess(req)
     const response = await AssetService.getAsset({assetId, projections, grant})
-    await AssetService.deleteAsset(assetId, req.userObject.userId, res.svcStatus)
+    await AssetService.deleteAsset(assetId, req.userObject.userId, grant.collectionId, res.svcStatus)
     res.json(response)
   }
   catch (err) {
@@ -358,6 +358,7 @@ module.exports.replaceAsset = async function replaceAsset (req, res, next) {
       assetId,
       body,
       transferring,
+      currentCollectionId: currentAsset.collection.collectionId,
       svcStatus: res.svcStatus
     })
     const asset = await AssetService.getAsset({assetId, projections, grant})
@@ -560,7 +561,7 @@ module.exports.patchAssets = async function (req, res, next) {
     if (!patchRequest.assetIds.every( a => collectionAssets.includes(a))) {
       throw new SmError.PrivilegeError('One or more assetId is not a Collection member.')
     }
-    await AssetService.deleteAssets(patchRequest.assetIds, req.userObject.userId, res.svcStatus)
+    await AssetService.deleteAssets(patchRequest.assetIds, req.userObject.userId, collectionId, res.svcStatus)
     res.json({
       operation: 'deleted',
       assetIds: patchRequest.assetIds

--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -1146,7 +1146,7 @@ exports.createAssets = async function({ assets, collectionId, svcStatus = {} }) 
   return insertedAssetIds
 }
 
-exports.deleteAsset = async function(assetId, userId, svcStatus) {
+exports.deleteAsset = async function(assetId, userId, collectionId, svcStatus) {
   let connection
   try {
     connection = await dbUtils.pool.getConnection()
@@ -1156,7 +1156,7 @@ exports.deleteAsset = async function(assetId, userId, svcStatus) {
       await connection.query(sqlDelete, [userId, assetId])
       // changes above might have affected need for records in collection_rev_map
       await dbUtils.pruneCollectionRevMap(connection)
-      await dbUtils.updateDefaultRev(connection, {})
+      await dbUtils.updateDefaultRev(connection, {collectionId})
       await connection.commit()
     }
     await dbUtils.retryOnDeadlock(transaction, svcStatus)
@@ -1175,7 +1175,7 @@ exports.deleteAsset = async function(assetId, userId, svcStatus) {
   }
 }
 
-exports.deleteAssets = async function(assetIds, userId, svcStatus) {
+exports.deleteAssets = async function(assetIds, userId, collectionId, svcStatus) {
   let connection
   try{
     connection = await dbUtils.pool.getConnection()
@@ -1183,9 +1183,9 @@ exports.deleteAssets = async function(assetIds, userId, svcStatus) {
       await connection.query('START TRANSACTION')
       const sqlDelete = `UPDATE asset SET state = "disabled", stateDate = NOW(), stateUserId = ? where assetId IN ?`
       await connection.query(sqlDelete, [userId, [assetIds]])
-      // changes above might have affected need for records in collection_rev_map 
+      // changes above might have affected need for records in collection_rev_map
       await dbUtils.pruneCollectionRevMap(connection)
-      await dbUtils.updateDefaultRev(connection, {})
+      await dbUtils.updateDefaultRev(connection, {collectionId})
       await connection.commit()
     }
     await dbUtils.retryOnDeadlock(transaction, svcStatus)
@@ -1246,12 +1246,12 @@ exports.removeStigFromAsset = async function ({assetId, benchmarkId, grant, svcS
   try{
     connection = await dbUtils.pool.getConnection()
     async function transaction () {
-      connection.query('START TRANSACTION')
+      await connection.query('START TRANSACTION')
       const sqlDelete = `DELETE FROM stig_asset_map where assetId = ? and benchmarkId = ?`
       await connection.query(sqlDelete, [assetId, benchmarkId])
       // changes above might have affected need for records in collection_rev_map
       await dbUtils.pruneCollectionRevMap(connection)
-      await dbUtils.updateDefaultRev(connection, {})
+      await dbUtils.updateDefaultRev(connection, {collectionId: grant.collectionId, benchmarkId})
       await connection.commit()
       return true
     }


### PR DESCRIPTION
Resolves: #2122 

- `removeStigFromAsset`: recalc scoped to `{collectionId, benchmarkId}`; also adds a missing
  `await` on `START TRANSACTION`
- `deleteAsset` / `deleteAssets`: recalc scoped to `{collectionId}`, passed from the
  controllers (matching `removeStigsFromAsset`)
- `replaceAsset`: controller now passes `currentCollectionId`, activating the collection
  scoping already implemented in `updateAsset()` — previously the parameter was undefined
  and the recalc ran unscoped

Each operation can only affect `default_rev` rows for its own Collection (and benchmark,
for the single-STIG operation), so the scoped recalc covers every row the operation can
change. With this change, every `updateDefaultRev` call site is scoped.
