### PR TITLE
Merge main into new-client (js-yaml 4.3.1)

### DIFF
--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -1706,9 +1706,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/test/api/package-lock.json
+++ b/test/api/package-lock.json
@@ -633,9 +633,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/test/state/package-lock.json
+++ b/test/state/package-lock.json
@@ -594,9 +594,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/test/unit/package-lock.json
+++ b/test/unit/package-lock.json
@@ -561,9 +561,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Merges `main` into `new-client` to pick up the js-yaml security bump.

## Contents

A single commit from `main`: d2432e8b `chore(deps): bump js-yaml to 4.3.1 to resolve CVE-2026-59870 (#2133)`.

Only lockfiles change — 12 insertions, 12 deletions across four files:

- `api/source/package-lock.json`
- `test/api/package-lock.json`
- `test/state/package-lock.json`
- `test/unit/package-lock.json`

js-yaml resolves to 4.3.1 in all four after the merge.

## Merge method

Please use **Create a merge commit**, not Squash and merge — consistent with the
recent main-sync PRs (#2082, #2093, #2130). A real merge keeps each `main` commit
individually reachable from `new-client` and preserves the common ancestor for
subsequent merges.

## Verification

- Merged with no conflicts (`ort` strategy auto-merged the `test/api` and `test/state` lockfiles)
- `npm ci --dry-run` passes in all four affected packages
- clientV2 build succeeds
- clientV2 tests: 1057 passing, 18 failing — identical to the pre-merge baseline on `new-client`

The 18 failures are pre-existing and unrelated to this merge: all are in
`src/features/ImportWizard/tests/useImportOptions.test.js`, which fails on a
`localStorage` shim issue in the test environment.
