### PR TITLE
Inherit font-family on form controls in clientV2

### DIFF
--- a/clientV2/src/features/Findings/components/AggregatedFindingsGrid.vue
+++ b/clientV2/src/features/Findings/components/AggregatedFindingsGrid.vue
@@ -432,7 +432,6 @@ const flexCellPt = {
   border-radius: 5px;
   padding: 0.25rem 0.55rem 0.25rem 0.7rem;
   cursor: pointer;
-  font-family: inherit;
   line-height: 1.2;
   max-width: 100%;
   transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease, box-shadow 120ms ease;

--- a/clientV2/src/features/Findings/components/StigSelectorPanel.vue
+++ b/clientV2/src/features/Findings/components/StigSelectorPanel.vue
@@ -314,7 +314,6 @@ function onSelect(row) {
 
 .stig-list__id {
   grid-area: id;
-  font-family: inherit;
   font-size: 1.2rem;
   color: var(--color-text-primary);
   overflow: hidden;
@@ -323,7 +322,6 @@ function onSelect(row) {
 }
 
 .stig-list__id--all {
-  font-family: inherit;
   font-style: italic;
   font-size: 1.2rem;
   color: var(--color-text-bright);

--- a/clientV2/src/features/NavRail/components/style.css
+++ b/clientV2/src/features/NavRail/components/style.css
@@ -45,7 +45,6 @@
   border: none;
   width: 100%;
   font-size: inherit;
-  font-family: inherit;
 }
 
 .nav-rail-item:hover {

--- a/clientV2/src/style.css
+++ b/clientV2/src/style.css
@@ -216,6 +216,18 @@ body {
   font-weight: 400;
 }
 
+/* Form controls don't inherit font-family: every UA stylesheet sets an explicit
+   `font: ... Arial` on them, and an explicit UA declaration beats inheritance.
+   Without this, any button/input/select/textarea silently renders in Arial
+   instead of Open Sans. font-family only (not the `font` shorthand) so
+   component-level font-size/font-weight keep working. */
+button,
+input,
+select,
+textarea {
+  font-family: inherit;
+}
+
 #app {
   height: 100vh;
   overflow: hidden;


### PR DESCRIPTION
Buttons and other form controls were rendering in Arial instead of the `:root` Open Sans.

`font-family` is an inherited property, but form controls are an exception: every browser's UA stylesheet sets an explicit `font: ... Arial` on `button`, `input`, `select`, and `textarea`. An explicit UA declaration beats inheritance, which has no specificity, so `:root { font-family: 'Open Sans' }` never reached them.

## Changes

- Add a global `font-family: inherit` reset for `button, input, select, textarea` in `clientV2/src/style.css`, next to the existing `body` typography rules.
- Drop three per-component workarounds the reset makes redundant:
  - `AggregatedFindingsGrid.vue` — `.agg-grid-panel__scope-trigger` is a `<button>`
  - `NavRail/components/style.css` — `.nav-rail-item` is a `<button>` in one component, a `router-link` (`<a>`) in the other; the button is now covered and the anchor never needed it
  - `StigSelectorPanel.vue` — `.stig-list__id` / `--all` are plain `<div>`s, so these were always no-ops

Uses `font-family` rather than the `font` shorthand so component-level `font-size` / `font-weight` continue to apply.

## Scope

This reaches every form control in clientV2. PrimeVue's styled theme declares no `font-family` of its own — there is not a single `.p-*` rule setting it in the built stylesheet — so nothing is overridden; PrimeVue controls were relying on inheritance and had the same latent bug. They now render in Open Sans as intended.

Icon fonts are unaffected: `.pi` sets `font-family: primeicons` via a class selector, which outranks a bare element selector.

Two `font-family: inherit` declarations are intentionally kept, as the reset does not cover them:

- `RuleInfo.vue` — a `<pre>`, which UA stylesheets style as monospace
- `ColumnFilter.vue` — an `::after` on a PrimeVue checkbox, not a plain form control

## Testing

Verified visually across dropdown- and dialog-heavy views. `npm run build` passes and the reset is present in the emitted CSS.
