### PR TITLE
Add browseable API Reference to the documentation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -13,7 +13,27 @@ jobs:
           ref: ${{ github.ref }}
       - name: run image, generating docs
         working-directory: ./docs
+        env:
+          SPHINXOPTS: "-W --keep-going"
         run: ./build.sh
+      - name: verify API Reference assets are in the build output
+        working-directory: ./docs
+        run: |
+          for f in index.html log-socket.html scalar.standalone.js stig-manager.yaml log-socket.yaml; do
+            if ! test -s "_build/html/api-reference/$f"; then
+              echo "::error ::_build/html/api-reference/$f is missing or empty"
+              exit 1
+            fi
+          done
+          size=$(stat -c%s _build/html/api-reference/scalar.standalone.js)
+          if [ "$size" -lt 1000000 ]; then
+            echo "::error ::scalar.standalone.js is only $size bytes; expected a bundle over 1MB"
+            exit 1
+          fi
+      - name: verify built API specifications match the source specifications
+        run: |
+          diff api/source/specification/stig-manager.yaml docs/_build/html/api-reference/stig-manager.yaml
+          diff api/source/specification/log-socket.yaml docs/_build/html/api-reference/log-socket.yaml
       - name: Upload docs
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ coverage/
 /docs/_build/doctrees/
 /docs/_extra/api-reference/scalar.standalone.js
 /docs/_extra/api-reference/stig-manager.yaml
+/docs/_extra/api-reference/log-socket.yaml
 
 # macOS file
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ clients/extjs/js/keycloak.json
 mochawesome-report/
 coverage/
 /docs/_build/doctrees/
+/docs/_extra/api-reference/scalar.standalone.js
+/docs/_extra/api-reference/stig-manager.yaml
 
 # macOS file
 .DS_Store

--- a/docs/_extra/api-reference/index.html
+++ b/docs/_extra/api-reference/index.html
@@ -32,6 +32,7 @@
         agent: { disabled: true },
         mcp: { disabled: true },
         hideClientButton: true,
+        modelsSectionLabel: 'Schemas',
         theme: 'deepSpace',
         // Preselect the oauth scheme. Do not configure flows here: in Scalar
         // (verified through 1.65.0) any flows entry makes an openIdConnect

--- a/docs/_extra/api-reference/index.html
+++ b/docs/_extra/api-reference/index.html
@@ -34,9 +34,9 @@
         hideClientButton: true,
         theme: 'deepSpace',
         // Preselect the oauth scheme. Do not configure flows here: in Scalar
-        // 1.64.1 any flows entry makes an openIdConnect scheme lose its
-        // discovery UI (the editable configuration URL and its Fetch
-        // Configuration button) and breaks Authorize. After the discovery
+        // (verified through 1.65.0) any flows entry makes an openIdConnect
+        // scheme lose its discovery UI (the editable configuration URL and its
+        // Fetch Configuration button) and breaks Authorize. After the discovery
         // document is fetched, PKCE is enabled automatically when the
         // provider advertises S256; the client id must be entered manually.
         authentication: {

--- a/docs/_extra/api-reference/index.html
+++ b/docs/_extra/api-reference/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <title>STIG Manager API Reference</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+        background-color: #1a1a1a;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <!-- scalar.standalone.js and stig-manager.yaml are placed here at build time by conf.py -->
+    <script src="./scalar.standalone.js"></script>
+    <script>
+      Scalar.createApiReference('#app', {
+        url: './stig-manager.yaml',
+        operationTitleSource: 'path',
+        showOperationId: true,
+        darkMode: true,
+        withDefaultFonts: false,
+        telemetry: false,
+        // No hooks into Scalar cloud services: suppress the Ask AI buttons,
+        // the Generate MCP link, and the Open API Client links to
+        // client.scalar.com. The embedded Test Request client remains
+        // available and is fully local. The developer toolbar keeps its
+        // default behavior of appearing on localhost only.
+        showDeveloperTools: 'localhost',
+        agent: { disabled: true },
+        mcp: { disabled: true },
+        hideClientButton: true,
+        theme: 'deepSpace',
+        // Preselect the oauth scheme. Do not configure flows here: in Scalar
+        // 1.64.1 any flows entry makes an openIdConnect scheme lose its
+        // discovery UI (the editable configuration URL and its Fetch
+        // Configuration button) and breaks Authorize. After the discovery
+        // document is fetched, PKCE is enabled automatically when the
+        // provider advertises S256; the client id must be entered manually.
+        authentication: {
+          preferredSecurityScheme: 'oauth'
+        }
+      })
+    </script>
+  </body>
+</html>

--- a/docs/_extra/api-reference/log-socket.html
+++ b/docs/_extra/api-reference/log-socket.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>STIG Manager Log Stream API Reference</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        margin: 0;
+        background-color: #1a1a1a;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <!-- scalar.standalone.js and log-socket.yaml are placed here at build time by conf.py -->
+    <script src="./scalar.standalone.js"></script>
+    <script>
+      Scalar.createApiReference('#app', {
+        url: './log-socket.yaml',
+        darkMode: true,
+        withDefaultFonts: false,
+        telemetry: false,
+        // No hooks into Scalar cloud services; see index.html for details.
+        showDeveloperTools: 'localhost',
+        agent: { disabled: true },
+        mcp: { disabled: true },
+        hideClientButton: true,
+        theme: 'deepSpace'
+      })
+    </script>
+  </body>
+</html>

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -10,4 +10,5 @@ find _build -type d -empty -delete
 
 docker build -t $SPHINX_IMAGE_W_REQUIREMENTS .
 
-docker run --rm -v $(pwd):/docs $SPHINX_IMAGE_W_REQUIREMENTS
+# Mount the repo root so conf.py can copy the API specification into the build
+docker run --rm -v "$(realpath ..)":/stig-manager -w /stig-manager/docs $SPHINX_IMAGE_W_REQUIREMENTS make html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,8 +22,9 @@ import sphinx_rtd_theme
 
 
 # -- API Reference browser assets --------------------------------------------
-# The standalone API Reference browser page (_extra/api-reference/index.html)
-# requires two files that are generated at build time and not committed:
+# The standalone API Reference browser pages (_extra/api-reference/index.html
+# and log-socket.html) require files that are generated at build time and not
+# committed:
 #
 #   _extra/api-reference/scalar.standalone.js
 #       The Scalar API Reference bundle, downloaded from the jsDelivr CDN,
@@ -32,11 +33,12 @@ import sphinx_rtd_theme
 #       fetched copy allows fully offline builds.
 #
 #   _extra/api-reference/stig-manager.yaml
+#   _extra/api-reference/log-socket.yaml
 #       Copied from api/source/specification/ so each documentation build
-#       presents the API specification it was built alongside.
+#       presents the API specifications it was built alongside.
 
-scalar_version = '1.64.1'
-scalar_sha256 = '397f33ac357dd4de28ea124499e97e315db98251015ea7e2b9870b575a4a1c3d'
+scalar_version = '1.65.0'
+scalar_sha256 = 'b239df03d69061d849814ee8349c7bdec56441d00aa836ede64dd94b2ef1ded0'
 
 docs_dir = Path(__file__).resolve().parent
 api_reference_dir = docs_dir / '_extra' / 'api-reference'
@@ -62,20 +64,21 @@ def fetch_scalar_bundle():
     dest.write_bytes(data)
 
 
-def copy_api_specification():
-    src = docs_dir.parent / 'api' / 'source' / 'specification' / 'stig-manager.yaml'
-    dest = api_reference_dir / 'stig-manager.yaml'
-    if src.exists():
-        shutil.copyfile(src, dest)
-    elif not dest.exists():
-        raise RuntimeError(
-            f'API specification not found at {src} and no existing copy at {dest}. '
-            f'When building outside the repository, place a copy of the specification at {dest}.'
-        )
+def copy_api_specifications():
+    for filename in ('stig-manager.yaml', 'log-socket.yaml'):
+        src = docs_dir.parent / 'api' / 'source' / 'specification' / filename
+        dest = api_reference_dir / filename
+        if src.exists():
+            shutil.copyfile(src, dest)
+        elif not dest.exists():
+            raise RuntimeError(
+                f'API specification not found at {src} and no existing copy at {dest}. '
+                f'When building outside the repository, place a copy of the specification at {dest}.'
+            )
 
 
 fetch_scalar_bundle()
-copy_api_specification()
+copy_api_specifications()
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,69 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import hashlib
+import shutil
+import urllib.request
+from pathlib import Path
+
 import sphinx_rtd_theme
+
+
+# -- API Reference browser assets --------------------------------------------
+# The standalone API Reference browser page (_extra/api-reference/index.html)
+# requires two files that are generated at build time and not committed:
+#
+#   _extra/api-reference/scalar.standalone.js
+#       The Scalar API Reference bundle, downloaded from the jsDelivr CDN,
+#       pinned to a specific version and verified against a checksum. The
+#       download is skipped if the file already exists, so a previously
+#       fetched copy allows fully offline builds.
+#
+#   _extra/api-reference/stig-manager.yaml
+#       Copied from api/source/specification/ so each documentation build
+#       presents the API specification it was built alongside.
+
+scalar_version = '1.64.1'
+scalar_sha256 = '397f33ac357dd4de28ea124499e97e315db98251015ea7e2b9870b575a4a1c3d'
+
+docs_dir = Path(__file__).resolve().parent
+api_reference_dir = docs_dir / '_extra' / 'api-reference'
+
+
+def fetch_scalar_bundle():
+    dest = api_reference_dir / 'scalar.standalone.js'
+    if dest.exists():
+        return
+    url = f'https://cdn.jsdelivr.net/npm/@scalar/api-reference@{scalar_version}/dist/browser/standalone.js'
+    try:
+        data = urllib.request.urlopen(url).read()
+    except OSError as e:
+        raise RuntimeError(
+            f'Could not download the Scalar bundle from {url} ({e}). '
+            f'For offline builds, place a copy of the file at {dest} before building.'
+        ) from e
+    digest = hashlib.sha256(data).hexdigest()
+    if digest != scalar_sha256:
+        raise RuntimeError(
+            f'Checksum mismatch for {url}: expected {scalar_sha256}, got {digest}'
+        )
+    dest.write_bytes(data)
+
+
+def copy_api_specification():
+    src = docs_dir.parent / 'api' / 'source' / 'specification' / 'stig-manager.yaml'
+    dest = api_reference_dir / 'stig-manager.yaml'
+    if src.exists():
+        shutil.copyfile(src, dest)
+    elif not dest.exists():
+        raise RuntimeError(
+            f'API specification not found at {src} and no existing copy at {dest}. '
+            f'When building outside the repository, place a copy of the specification at {dest}.'
+        )
+
+
+fetch_scalar_bundle()
+copy_api_specification()
 
 
 # -- Project information -----------------------------------------------------
@@ -80,6 +142,10 @@ github_doc_root = 'https://github.com/cd-rite/stig-manager/tree/readTheDocs/docs
 
 # html_logo = './_static/images\shield-green-check.svg'
 html_logo = 'assets/images/shield-green-check.svg'
+
+# Files copied verbatim to the output root after the built pages. Contains the
+# standalone API Reference browser page and its build-time generated assets.
+html_extra_path = ['_extra']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/the-project/api-reference.rst
+++ b/docs/the-project/api-reference.rst
@@ -1,0 +1,29 @@
+
+.. _api-reference:
+
+API Reference
+########################
+
+.. meta::
+  :description: A browseable reference for the STIG Manager API.
+
+
+The STIG Manager API is defined by an `OpenAPI 3.0 specification <https://github.com/NUWCDIVNPT/stig-manager/blob/main/api/source/specification/stig-manager.yaml>`_, which is the authoritative contract for the API.
+
+A browseable presentation of the specification is available here:
+
+`Open the API Reference Browser <../api-reference/index.html>`_
+
+The browser presents every endpoint with its method, path, and ``operationId``, along with request parameters, response schemas, and generated code samples. It is rendered by `Scalar <https://github.com/scalar/scalar>`_ from the same specification file used to build this documentation, so it always matches the documented release.
+
+Requests can be tested against a running API deployment from the browser. To authorize:
+
+#. In the Authentication panel, set the discovery URL to your OIDC provider's well-known configuration endpoint and click **Fetch Configuration**.
+#. Select the ``authorizationCode`` flow. 
+#. Enter your Client ID (``stig-manager`` in a default deployment) and click **Authorize**.
+
+When sending a request from the test client, make sure ``authorizationCode`` is selected.
+
+The specification file itself, as built with this documentation, can be downloaded here: `stig-manager.yaml <../api-reference/stig-manager.yaml>`_
+
+|

--- a/docs/the-project/api-reference.rst
+++ b/docs/the-project/api-reference.rst
@@ -26,4 +26,14 @@ When sending a request from the test client, make sure ``authorizationCode`` is 
 
 The specification file itself, as built with this documentation, can be downloaded here: `stig-manager.yaml <../api-reference/stig-manager.yaml>`_
 
+
+Log Stream WebSocket API
+=========================
+
+The API also provides a WebSocket endpoint for streaming log messages in real time, defined by an `AsyncAPI 3.0 specification <https://github.com/NUWCDIVNPT/stig-manager/blob/main/api/source/specification/log-socket.yaml>`_. A browseable presentation is available here:
+
+`Open the Log Stream API Reference Browser <../api-reference/log-socket.html>`_
+
+The specification file can be downloaded here: `log-socket.yaml <../api-reference/log-socket.yaml>`_
+
 |

--- a/docs/the-project/index.rst
+++ b/docs/the-project/index.rst
@@ -20,6 +20,7 @@ These pages describe the STIG Manager project.
 	:caption: Contents:
 
 	project-description
+	api-reference
 	contributing
 	testing
 	documentation


### PR DESCRIPTION
Adds a Scalar-rendered, fully self-contained API spec browser to the Sphinx docs, covering both the OpenAPI and AsyncAPI specifications.

New pages

docs/_extra/api-reference/index.html — standalone Scalar viewer for stig-manager.yaml, with Swagger-style sidebar (method + path), visible operationIds, dark deepSpace theme, and all Scalar cloud hooks disabled (Ask AI, Generate MCP, Open API Client). The oauth scheme is preselected; flows are intentionally not configured (Scalar bug, verified through /1.65.0 — see scratch/scalar-openidconnect-issue-draft.md).

docs/_extra/api-reference/log-socket.html — same-bundle viewer for the AsyncAPI 3.0 Log Stream WebSocket spec.

docs/the-project/api-reference.rst — new docs page linking both viewers and downloadable specs, with the tested OIDC authorization workflow (Fetch Configuration → select authorizationCode → Client ID → Authorize).

Build integration

docs/conf.py fetches the Scalar bundle at build time (pinned 1.65.0, sha256-verified, skipped if present for offline builds) and copies both spec files from api/source/specification/, so every docs build ships the specs it was built alongside. Works unchanged across all three build paths: ReadTheDocs, docs/build.sh, and docker-build.

docs/build.sh mounts the repo root so conf.py can reach the specs.

.gitignore excludes the three generated assets — nothing vendored is committed.