### PR TITLE
Add API event framework foundation

### DIFF
--- a/api/source/bootstrap/extensionCheck.js
+++ b/api/source/bootstrap/extensionCheck.js
@@ -1,9 +1,18 @@
+const onFinished = require('on-finished')
 const SmError = require('../utils/error')
+const config = require('../utils/config')
+const eventBus = require('../utils/eventBus')
 
 function extensionCheck(req, res, next) {
   if (req.openapi?.schema['x-elevation-required'] && !req.query.elevate) {
     next(new SmError.ElevationError())
     return
+  }
+  // Register an event hook only for operations the spec annotates with
+  // x-event. No operation is annotated today, so this registers nothing; the
+  // cost for every request is one property read.
+  if (config.events.enabled && req.openapi?.schema['x-event']) {
+    onFinished(res, () => eventBus.finishHandler(req, res))
   }
   this(req, res, next)
 }

--- a/api/source/utils/config.js
+++ b/api/source/utils/config.js
@@ -115,6 +115,14 @@ const config = {
         mode: process.env.STIGMAN_LOG_MODE || 'combined',
         optStats: process.env.STIGMAN_DEV_LOG_OPT_STATS === "true"
     },
+    events: {
+        enabled: process.env.STIGMAN_EVENTS_ENABLED !== "false",
+        maxBody: (() => {
+            const val = parseInt(process.env.STIGMAN_EVENTS_MAX_BODY)
+            if (isNaN(val) || val < 0) return 65536
+            return val
+        })()
+    },
     experimental: {
         appData: process.env.STIGMAN_EXPERIMENTAL_APPDATA === "true",
         logStream: process.env.STIGMAN_EXPERIMENTAL_LOGSTREAM !== "false"

--- a/api/source/utils/eventBus.js
+++ b/api/source/utils/eventBus.js
@@ -1,0 +1,85 @@
+const { randomUUID } = require('node:crypto')
+const config = require('./config')
+
+// res.eventInfo keys the capture logic consumes itself; everything else on
+// eventInfo passes through verbatim to envelope.info (design §6).
+const RESERVED_EVENT_INFO_KEYS = ['success', 'params']
+
+/**
+ * Decide whether a finished request should emit an event.
+ * The x-event annotation and the kill switch are checked at hook-registration
+ * time in bootstrap/extensionCheck.js, so this evaluates outcome only.
+ */
+function shouldEmit (req, res) {
+  const eventInfo = res.eventInfo
+  if (eventInfo && typeof eventInfo.success === 'boolean') {
+    // A streaming handler commits a 200 header before its mutation finishes,
+    // so the handler's own verdict overrides the status code.
+    return eventInfo.success
+  }
+  return res.statusCode >= 200 && res.statusCode < 300
+}
+
+/**
+ * Build the JSON-serializable event envelope (design §3).
+ * options.maxBody exists so unit tests can exercise the cap without mutating
+ * process.env; production callers omit it and get the configured value.
+ */
+function buildEnvelope (req, res, options = {}) {
+  const maxBody = options.maxBody ?? config.events.maxBody
+  const xEvent = req.openapi?.schema?.['x-event'] ?? {}
+  const eventInfo = res.eventInfo
+
+  const envelope = {
+    eventId: randomUUID(),
+    date: new Date().toISOString(),
+    requestId: req.requestId,
+    actor: {
+      type: 'user',
+      userId: req.userObject?.userId,
+      username: req.userObject?.username,
+      clientId: req.access_token?.azp
+    },
+    resource: xEvent.resource,
+    action: xEvent.action,
+    operationId: req.openapi?.schema?.operationId,
+    params: { ...req.openapi?.pathParams, ...eventInfo?.params },
+    query: req.query,
+    status: res.statusCode
+  }
+
+  // Body: include under the cap, otherwise report only its size. Truncated
+  // JSON is useless to an audit reader, so omit rather than truncate (§3).
+  if (req.body !== undefined && req.body !== null) {
+    const serialized = JSON.stringify(req.body)
+    const bytes = serialized === undefined ? 0 : Buffer.byteLength(serialized)
+    if (bytes > 0) {
+      if (bytes <= maxBody) {
+        envelope.body = req.body
+      }
+      else {
+        envelope.bodyBytes = bytes
+      }
+    }
+  }
+
+  // Non-reserved eventInfo content passes through unschema'd.
+  if (eventInfo) {
+    const info = {}
+    let hasInfo = false
+    for (const key of Object.keys(eventInfo)) {
+      if (!RESERVED_EVENT_INFO_KEYS.includes(key)) {
+        info[key] = eventInfo[key]
+        hasInfo = true
+      }
+    }
+    if (hasInfo) envelope.info = info
+  }
+
+  return envelope
+}
+
+module.exports = {
+  shouldEmit,
+  buildEnvelope
+}

--- a/api/source/utils/eventBus.js
+++ b/api/source/utils/eventBus.js
@@ -1,5 +1,7 @@
 const { randomUUID } = require('node:crypto')
+const EventEmitter = require('node:events')
 const config = require('./config')
+const logger = require('./logger')
 
 // res.eventInfo keys the capture logic consumes itself; everything else on
 // eventInfo passes through verbatim to envelope.info (design §6).
@@ -79,7 +81,79 @@ function buildEnvelope (req, res, options = {}) {
   return envelope
 }
 
+const EVENT_NAME = 'event'
+
+const emitter = new EventEmitter()
+// SSE will eventually mean one listener per connected client, as logSocket
+// sessions do on loggerEvents today. Remove the warning threshold rather than
+// pick an arbitrary ceiling.
+emitter.setMaxListeners(0)
+
+// Maps a caller's handler to the isolating shim actually registered, so that
+// off() can remove the right listener.
+const shims = new Map()
+
+/**
+ * Subscribe to every event on the bus. Consumers filter on
+ * envelope.resource / action / ids themselves.
+ *
+ * The handler is wrapped rather than registered directly: EventEmitter calls
+ * listeners synchronously inside emit(), so a throwing listener would
+ * propagate into the onFinished callback and starve every later listener,
+ * and an async listener's rejection would become an unhandled rejection that
+ * terminates the process. The shim makes a consumer bug cost a log line.
+ */
+function on (handler) {
+  if (shims.has(handler)) return
+  const shim = async (envelope) => {
+    try {
+      await handler(envelope)
+    }
+    catch (e) {
+      logger.writeError('eventBus', 'consumer-error', {
+        message: e?.message,
+        stack: e?.stack
+      })
+    }
+  }
+  shims.set(handler, shim)
+  emitter.on(EVENT_NAME, shim)
+}
+
+function off (handler) {
+  const shim = shims.get(handler)
+  if (!shim) return
+  emitter.off(EVENT_NAME, shim)
+  shims.delete(handler)
+}
+
+/**
+ * Called by the onFinished hook that bootstrap/extensionCheck.js registers for
+ * x-event annotated operations. The response has already been sent by the time
+ * this runs, so nothing here may throw.
+ */
+function finishHandler (req, res) {
+  try {
+    if (!req || !res) return
+    if (res._eventEmitted) return
+    if (!shouldEmit(req, res)) return
+    res._eventEmitted = true
+    emitter.emit(EVENT_NAME, buildEnvelope(req, res))
+  }
+  catch (e) {
+    logger.writeError('eventBus', 'emit-error', {
+      message: e?.message,
+      stack: e?.stack,
+      requestId: req?.requestId
+    })
+  }
+}
+
 module.exports = {
+  finishHandler,
+  on,
+  off,
+  // exported for unit tests
   shouldEmit,
   buildEnvelope
 }

--- a/docs/installation-and-setup/envvars.csv
+++ b/docs/installation-and-setup/envvars.csv
@@ -83,6 +83,10 @@
 | The location of the documentation files, relative to the API source directory. Note that if running source from a clone of the GitHub repository, the docs are located at `../../docs/_build/html` relative to the API directory. ","API, Documentation"
 "STIGMAN_DOCS_DISABLED","| **Default** ``false``
 | Whether to *not* serve the project Documentation.  NOTE: If you choose to serve the Client from the API container but not the Documentation, the links do the Docs on the home page will not work. ","Documentation"
+"STIGMAN_EVENTS_ENABLED","| **Default** ``true``
+| Set to ``false`` to disable API event emission entirely. When disabled, no event hooks are registered and no events are emitted; nothing else about request handling changes. Note that no API operation currently emits events. The event framework is in place for future features and is inert until operations are annotated. ","API"
+"STIGMAN_EVENTS_MAX_BODY","| **Default** ``65536``
+| The maximum size in bytes of a serialized request body included in an API event. Bodies larger than this are omitted from the event and replaced by a byte count, rather than truncated. Set to ``0`` to never include request bodies in events. ","API"
 "STIGMAN_EXPERIMENTAL_APPDATA","| **Default**  ``false``
 | Set to ``true`` to enable the experimental AppData import/export API endpoints and User Interface. ","API, Client"
 "STIGMAN_EXPERIMENTAL_LOGSTREAM","| **Default**  ``true``

--- a/test/unit/mocha/eventBus.test.js
+++ b/test/unit/mocha/eventBus.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
 import eventBus from '../../../api/source/utils/eventBus.js'
 
-const { shouldEmit, buildEnvelope } = eventBus
+const { shouldEmit, buildEnvelope, finishHandler, on, off } = eventBus
 
 // A minimally realistic req/res pair, shaped as express-openapi-validator
 // leaves them by the time an operation handler runs. The x-event annotation
@@ -151,5 +151,129 @@ describe('eventBus.buildEnvelope', function () {
     const env = buildEnvelope(makeReq(), makeRes(), { maxBody: 0 })
     expect(env.body).to.equal(undefined)
     expect(env.bodyBytes).to.be.a('number').greaterThan(0)
+  })
+})
+
+describe('eventBus consumer subscription', function () {
+  let handlers = []
+
+  // The bus is a singleton shared across tests in this file, so every
+  // subscription must be torn down or later tests see stray events.
+  afterEach(function () {
+    for (const h of handlers) off(h)
+    handlers = []
+  })
+
+  function subscribe (fn) {
+    handlers.push(fn)
+    on(fn)
+    return fn
+  }
+
+  it('delivers an emitted envelope to a subscriber', function () {
+    const received = []
+    subscribe(env => received.push(env))
+    finishHandler(makeReq(), makeRes())
+    expect(received).to.have.lengthOf(1)
+    expect(received[0].operationId).to.equal('replaceCollection')
+    expect(received[0].resource).to.equal('collection')
+  })
+
+  it('delivers to every subscriber', function () {
+    const a = [], b = []
+    subscribe(env => a.push(env))
+    subscribe(env => b.push(env))
+    finishHandler(makeReq(), makeRes())
+    expect(a).to.have.lengthOf(1)
+    expect(b).to.have.lengthOf(1)
+  })
+
+  it('does not emit when shouldEmit is false', function () {
+    const received = []
+    subscribe(env => received.push(env))
+    finishHandler(makeReq(), makeRes({ statusCode: 400 }))
+    expect(received).to.have.lengthOf(0)
+  })
+
+  it('emits at most once per request even if the hook fires twice', function () {
+    const received = []
+    subscribe(env => received.push(env))
+    const req = makeReq()
+    const res = makeRes()
+    finishHandler(req, res)
+    finishHandler(req, res)
+    expect(received).to.have.lengthOf(1)
+  })
+
+  it('off() stops delivery to that handler only', function () {
+    const a = [], b = []
+    const handlerA = env => a.push(env)
+    const handlerB = env => b.push(env)
+    subscribe(handlerA)
+    subscribe(handlerB)
+    off(handlerA)
+    finishHandler(makeReq(), makeRes())
+    expect(a).to.have.lengthOf(0)
+    expect(b).to.have.lengthOf(1)
+  })
+
+  it('off() with an unknown handler is a no-op', function () {
+    expect(() => off(() => {})).to.not.throw()
+  })
+
+  it('subscribing the same handler twice delivers once and off() removes it', function () {
+    const received = []
+    const handler = env => received.push(env)
+    subscribe(handler)
+    on(handler)
+    finishHandler(makeReq(), makeRes())
+    expect(received).to.have.lengthOf(1)
+    off(handler)
+    finishHandler(makeReq(), makeRes({ statusCode: 200 }))
+    expect(received).to.have.lengthOf(1)
+  })
+})
+
+describe('eventBus consumer isolation', function () {
+  let handlers = []
+  afterEach(function () {
+    for (const h of handlers) off(h)
+    handlers = []
+  })
+  function subscribe (fn) {
+    handlers.push(fn)
+    on(fn)
+    return fn
+  }
+
+  it('a throwing sync consumer does not starve later consumers', function () {
+    const later = []
+    subscribe(() => { throw new Error('boom') })
+    subscribe(env => later.push(env))
+    expect(() => finishHandler(makeReq(), makeRes())).to.not.throw()
+    expect(later).to.have.lengthOf(1)
+  })
+
+  it('a rejecting async consumer does not starve later consumers or reject out', async function () {
+    const later = []
+    subscribe(async () => { throw new Error('async boom') })
+    subscribe(env => later.push(env))
+    expect(() => finishHandler(makeReq(), makeRes())).to.not.throw()
+    expect(later).to.have.lengthOf(1)
+    // Give the rejected promise a turn to settle; an unhandled rejection here
+    // would fail the process, which is exactly what the shim prevents.
+    await new Promise(resolve => setImmediate(resolve))
+  })
+
+  it('a consumer error does not propagate out of finishHandler', function () {
+    subscribe(() => { throw new Error('boom') })
+    expect(() => finishHandler(makeReq(), makeRes())).to.not.throw()
+  })
+})
+
+describe('eventBus.finishHandler error containment', function () {
+  it('never throws even when the request object is malformed', function () {
+    expect(() => finishHandler({}, {})).to.not.throw()
+    expect(() => finishHandler(null, null)).to.not.throw()
   })
 })

--- a/test/unit/mocha/eventBus.test.js
+++ b/test/unit/mocha/eventBus.test.js
@@ -1,0 +1,155 @@
+import { expect } from 'chai'
+import eventBus from '../../../api/source/utils/eventBus.js'
+
+const { shouldEmit, buildEnvelope } = eventBus
+
+// A minimally realistic req/res pair, shaped as express-openapi-validator
+// leaves them by the time an operation handler runs. The x-event annotation
+// here is synthetic: no published operation carries one in this iteration,
+// and the framework only ever reads this runtime schema object.
+function makeReq (overrides = {}) {
+  return {
+    requestId: 'req-1',
+    userObject: { userId: '42', username: 'lvasquez' },
+    access_token: { azp: 'stig-manager' },
+    openapi: {
+      pathParams: { collectionId: '5' },
+      schema: {
+        operationId: 'replaceCollection',
+        'x-event': { resource: 'collection', action: 'update' }
+      }
+    },
+    query: { elevate: false },
+    body: { name: 'NCCM' },
+    ...overrides
+  }
+}
+
+function makeRes (overrides = {}) {
+  return { statusCode: 200, ...overrides }
+}
+
+describe('eventBus.shouldEmit', function () {
+  it('emits for a 2xx response with no eventInfo', function () {
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 200 }))).to.equal(true)
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 201 }))).to.equal(true)
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 204 }))).to.equal(true)
+  })
+
+  it('does not emit for 4xx or 5xx with no eventInfo', function () {
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 400 }))).to.equal(false)
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 403 }))).to.equal(false)
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 500 }))).to.equal(false)
+  })
+
+  it('lets eventInfo.success override the status code in both directions', function () {
+    // the case a streaming handler will need: headers committed 200, mutation failed
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 200, eventInfo: { success: false } }))).to.equal(false)
+    // explicit success wins even over a non-2xx status
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 500, eventInfo: { success: true } }))).to.equal(true)
+  })
+
+  it('falls back to the status check when eventInfo omits success', function () {
+    // an eventInfo carrying only params must not read as "success: undefined -> false"
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 200, eventInfo: { params: { a: 1 } } }))).to.equal(true)
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 400, eventInfo: { params: { a: 1 } } }))).to.equal(false)
+  })
+
+  it('ignores a non-boolean success', function () {
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 200, eventInfo: { success: 'yes' } }))).to.equal(true)
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 400, eventInfo: { success: 'yes' } }))).to.equal(false)
+  })
+
+  it('emits for a destroyed response when the outcome rule passes', function () {
+    expect(shouldEmit(makeReq(), makeRes({ statusCode: 200, destroyed: true }))).to.equal(true)
+  })
+})
+
+describe('eventBus.buildEnvelope', function () {
+  it('maps the mechanical fields from req and res', function () {
+    const env = buildEnvelope(makeReq(), makeRes())
+    expect(env.eventId).to.be.a('string').with.length.greaterThan(0)
+    expect(env.date).to.match(/^\d{4}-\d{2}-\d{2}T/)
+    expect(env.requestId).to.equal('req-1')
+    expect(env.actor).to.eql({
+      type: 'user',
+      userId: '42',
+      username: 'lvasquez',
+      clientId: 'stig-manager'
+    })
+    expect(env.resource).to.equal('collection')
+    expect(env.action).to.equal('update')
+    expect(env.operationId).to.equal('replaceCollection')
+    expect(env.params).to.eql({ collectionId: '5' })
+    expect(env.query).to.eql({ elevate: false })
+    expect(env.status).to.equal(200)
+    expect(env.body).to.eql({ name: 'NCCM' })
+  })
+
+  it('produces a unique eventId per call', function () {
+    const a = buildEnvelope(makeReq(), makeRes())
+    const b = buildEnvelope(makeReq(), makeRes())
+    expect(a.eventId).to.not.equal(b.eventId)
+  })
+
+  it('is JSON-serializable', function () {
+    const env = buildEnvelope(makeReq(), makeRes())
+    expect(() => JSON.stringify(env)).to.not.throw()
+  })
+
+  it('tolerates an absent userObject and access_token', function () {
+    const req = makeReq({ userObject: undefined, access_token: undefined })
+    const env = buildEnvelope(req, makeRes())
+    expect(env.actor.type).to.equal('user')
+    expect(env.actor.userId).to.equal(undefined)
+    expect(env.actor.clientId).to.equal(undefined)
+  })
+
+  it('merges eventInfo.params over the path params', function () {
+    const res = makeRes({ eventInfo: { success: true, params: { destCollectionId: '9' } } })
+    const env = buildEnvelope(makeReq(), res)
+    expect(env.params).to.eql({ collectionId: '5', destCollectionId: '9' })
+  })
+
+  it('passes non-reserved eventInfo content through to info', function () {
+    const res = makeRes({
+      eventInfo: { success: true, params: { a: 1 }, grantsAdded: ['u1'], grantsRemoved: [] }
+    })
+    const env = buildEnvelope(makeReq(), res)
+    expect(env.info).to.eql({ grantsAdded: ['u1'], grantsRemoved: [] })
+    expect(env.info).to.not.have.property('success')
+    expect(env.info).to.not.have.property('params')
+  })
+
+  it('omits info when the handler supplied nothing beyond reserved keys', function () {
+    expect(buildEnvelope(makeReq(), makeRes()).info).to.equal(undefined)
+    const res = makeRes({ eventInfo: { success: true, params: { a: 1 } } })
+    expect(buildEnvelope(makeReq(), res).info).to.equal(undefined)
+  })
+
+  it('includes a body under the size cap', function () {
+    const env = buildEnvelope(makeReq({ body: { name: 'small' } }), makeRes())
+    expect(env.body).to.eql({ name: 'small' })
+    expect(env.bodyBytes).to.equal(undefined)
+  })
+
+  it('omits an over-cap body and reports bodyBytes instead', function () {
+    const big = { blob: 'x'.repeat(70000) }
+    const env = buildEnvelope(makeReq({ body: big }), makeRes())
+    expect(env.body).to.equal(undefined)
+    expect(env.bodyBytes).to.be.a('number').greaterThan(65536)
+  })
+
+  it('omits an absent body without setting bodyBytes', function () {
+    const env = buildEnvelope(makeReq({ body: undefined }), makeRes())
+    expect(env.body).to.equal(undefined)
+    expect(env.bodyBytes).to.equal(undefined)
+  })
+
+  it('never includes a body when the cap is 0', function () {
+    // maxBody is read at call time through an injectable default
+    const env = buildEnvelope(makeReq(), makeRes(), { maxBody: 0 })
+    expect(env.body).to.equal(undefined)
+    expect(env.bodyBytes).to.be.a('number').greaterThan(0)
+  })
+})

--- a/test/unit/mocha/extensionCheck.test.js
+++ b/test/unit/mocha/extensionCheck.test.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai'
+import { EventEmitter } from 'node:events'
+import extensionCheck from '../../../api/source/bootstrap/extensionCheck.js'
+import eventBus from '../../../api/source/utils/eventBus.js'
+import config from '../../../api/source/utils/config.js'
+
+// on-finished recognizes a response as finished when it is a stream that has
+// emitted 'finish', or when res.finished/writableEnded is already true. A
+// minimal EventEmitter with the right shape is enough to drive it.
+//
+// finish() is async because on-finished does not invoke its callback during
+// the 'finish' emit — it defers so the response is fully settled first. A
+// synchronous assertion after finish() would always see zero events, so tests
+// await it and let the pending callback run.
+function makeRes (statusCode = 200) {
+  const res = new EventEmitter()
+  res.statusCode = statusCode
+  res.finished = false
+  res.writableEnded = false
+  res.socket = new EventEmitter()
+  res.finish = async function () {
+    res.finished = true
+    res.writableEnded = true
+    res.emit('finish')
+    await new Promise(resolve => setImmediate(resolve))
+  }
+  return res
+}
+
+// xEvent is synthetic — no published operation carries one in this iteration.
+function makeReq (xEvent) {
+  const schema = { operationId: 'replaceCollection' }
+  if (xEvent) schema['x-event'] = xEvent
+  return {
+    requestId: 'req-1',
+    userObject: { userId: '42', username: 'lvasquez' },
+    access_token: { azp: 'stig-manager' },
+    openapi: { pathParams: { collectionId: '5' }, schema },
+    query: {},
+    body: { name: 'NCCM' }
+  }
+}
+
+// A stand-in operation handler; extensionCheck is invoked bound to it.
+function controller (req, res, next) { res.controllerRan = true }
+
+describe('extensionCheck event hook registration', function () {
+  let received = []
+  const handler = env => received.push(env)
+
+  beforeEach(function () {
+    received = []
+    eventBus.on(handler)
+  })
+  afterEach(function () {
+    eventBus.off(handler)
+    config.events.enabled = true
+  })
+
+  it('emits an event for an annotated operation when the response finishes', async function () {
+    const req = makeReq({ resource: 'collection', action: 'update' })
+    const res = makeRes(200)
+    extensionCheck.call(controller, req, res, () => {})
+    expect(res.controllerRan).to.equal(true)
+    expect(received).to.have.lengthOf(0) // nothing until the response finishes
+    await res.finish()
+    expect(received).to.have.lengthOf(1)
+    expect(received[0].resource).to.equal('collection')
+    expect(received[0].action).to.equal('update')
+  })
+
+  it('registers no hook for an unannotated operation', async function () {
+    const res = makeRes(200)
+    extensionCheck.call(controller, makeReq(null), res, () => {})
+    expect(res.controllerRan).to.equal(true)
+    await res.finish()
+    expect(received).to.have.lengthOf(0)
+  })
+
+  it('registers no hook when events are disabled', async function () {
+    config.events.enabled = false
+    const res = makeRes(200)
+    extensionCheck.call(controller, makeReq({ resource: 'collection', action: 'update' }), res, () => {})
+    expect(res.controllerRan).to.equal(true)
+    await res.finish()
+    expect(received).to.have.lengthOf(0)
+  })
+
+  it('does not emit for a failed annotated request', async function () {
+    const res = makeRes(403)
+    extensionCheck.call(controller, makeReq({ resource: 'collection', action: 'update' }), res, () => {})
+    await res.finish()
+    expect(received).to.have.lengthOf(0)
+  })
+})
+
+describe('extensionCheck elevation behavior is unchanged', function () {
+  it('rejects an elevation-required operation without elevate', function () {
+    const req = makeReq(null)
+    req.openapi.schema['x-elevation-required'] = true
+    req.query = { elevate: false }
+    const res = makeRes()
+    let err
+    extensionCheck.call(controller, req, res, e => { err = e })
+    expect(err).to.exist
+    expect(err.name).to.equal('ElevationError')
+    expect(res.controllerRan).to.equal(undefined)
+  })
+
+  it('invokes the handler for an elevation-required operation with elevate', function () {
+    const req = makeReq(null)
+    req.openapi.schema['x-elevation-required'] = true
+    req.query = { elevate: true }
+    const res = makeRes()
+    extensionCheck.call(controller, req, res, () => {})
+    expect(res.controllerRan).to.equal(true)
+  })
+
+  it('does not register an event hook when elevation is rejected', async function () {
+    const received = []
+    const handler = env => received.push(env)
+    eventBus.on(handler)
+    const req = makeReq({ resource: 'job', action: 'create' })
+    req.openapi.schema['x-elevation-required'] = true
+    req.query = { elevate: false }
+    const res = makeRes(403)
+    extensionCheck.call(controller, req, res, () => {})
+    await res.finish()
+    eventBus.off(handler)
+    expect(received).to.have.lengthOf(0)
+  })
+})


### PR DESCRIPTION
Adds the in-process event framework that a future SSE-push or audit-history consumer will subscribe to.

## This ships deliberately inert

**Zero operations are annotated, zero events are emitted in any environment, and no controller is modified.** `specification/stig-manager.yaml` is unchanged by this branch. A reviewer who misses this will wonder why nothing happens — that is the intended state, not an omission.

The reasoning: a consumer is what proves the framework works, and none exists yet. Annotating an endpoint now would demonstrate only that emission does not crash, while forcing endpoint-design questions this iteration deliberately defers — what shape a net-effect report takes for a declarative array like `grants`, whether a handler may issue an extra query purely to populate an event, and what naming generalizes across resources. Those are endpoint-design questions, not framework questions. A framework with zero annotations has an unambiguous seam; one with two carries a precedent the follow-on design would inherit without having chosen it.

## What the framework provides

- **`utils/eventBus.js`** — singleton emitter, envelope construction, `shouldEmit`, `finishHandler`, and an `on`/`off` subscription API.
- **The `x-event` OpenAPI vendor extension** — `{resource, action}`, honored by the runtime but applied to no operation. Follows the naming precedent of the existing `x-elevation-required`.
- **The response hook** — `bootstrap/extensionCheck.js` registers an `on-finished` callback for annotated operations only. With zero annotations it registers nothing; the per-request cost is one property read. The elevation guard returns before hook registration, so a rejected elevation registers nothing at all.
- **The `res.eventInfo` channel** — two reserved keys (`success`, `params`); every other property passes through verbatim to `envelope.info` with no imposed schema. No handler uses it yet.
- **Two config variables** — `STIGMAN_EVENTS_ENABLED` (kill switch, default `true`) and `STIGMAN_EVENTS_MAX_BODY` (default `65536`; `0` means never include bodies). Over-cap bodies are omitted with a `bodyBytes` count rather than truncated, since truncated JSON is useless to an audit reader.

**Consumer isolation** is structural rather than by convention. `EventEmitter` invokes listeners synchronously inside `emit()`, so a throwing listener would propagate into the `onFinished` callback and starve every later listener, and an async listener's rejection would become an unhandled rejection that terminates the process. `on()` therefore registers an error-isolating shim; a consumer bug costs a log line.

`logger.js` and `logSocket.js` are untouched. The bus may call the logger; the logger never depends on the bus.

## Testing

68 unit tests pass, including the pre-existing `asyncApiValidator` suite.

With no operation annotated, unit tests are the only coverage this iteration can have — there is no live event anywhere to observe. They are the sole evidence the framework behaves as specified, so they cover the paths annotation will later activate: emission rules including the `eventInfo.success` override in both directions, envelope field mapping, the body cap boundary, `info` pass-through, consumer isolation for both sync throws and async rejections, at-most-once emission, and `finishHandler` never throwing on malformed input. Hook-registration tests use a **synthetic** `x-event` on a mocked `req.openapi.schema` — the framework never reads the published YAML, only the schema object handed to it at runtime, so this exercises the real path faithfully.

Inertness was verified rather than asserted: parsing the published spec reports `annotated operations: 0`.

**Boot check performed.** The API was started against a live MySQL 8.4 instance and Keycloak provider and reached its normal serving state (`state-changed → available`, both dependencies healthy, started in 0.59s). Live requests routed correctly through the modified `extensionCheck` — HTTP 200 for `/api/op/definition`, HTTP 401 for an unauthenticated `/api/op/appinfo`. No event-related errors and no events emitted, which is the correct inert behavior.

## Accepted trade

This framework merges without ever having emitted an event outside a unit test. The first annotation will also be its first real exercise. That is the deliberate trade for a clean seam, and it is why the unit coverage is thorough rather than nominal.

## What comes next

A follow-on design takes a real endpoint — `replaceCollection` is the expected first candidate, since its `grants` and `labels` are declarative arrays whose net effect the request body cannot express — and settles what a good event actually contains. Three streaming mutation handlers (`cloneCollection`, `exportToCollection`, `replaceAppData`) will need `res.eventInfo` for correctness once annotated, because their status codes commit before the mutation finishes; that analysis is recorded in the design so it is not rediscovered.
