### PR TITLE
Fix stale primevue 3 references that snuck in initially.

### DIFF
--- a/clientV2/src/components/common/MetadataEditor.vue
+++ b/clientV2/src/components/common/MetadataEditor.vue
@@ -59,7 +59,7 @@ function onDeleteConfirmed() {
             v-model="row.key"
             placeholder="Key"
             class="meta-input"
-            :class="{ 'p-invalid': !row.key?.trim() && row.value?.trim() }"
+            :invalid="!row.key?.trim() && !!row.value?.trim()"
             @blur="emit('save')"
           />
           <InputText v-model="row.value" placeholder="Value" class="meta-input" @blur="emit('save')" />

--- a/clientV2/src/components/common/ReviewEditPopover.vue
+++ b/clientV2/src/components/common/ReviewEditPopover.vue
@@ -225,7 +225,7 @@ function clampPopoverPosition() {
   container.style.marginLeft = `${offset}px`
 
   const arrowLeftEdge = targetX - (rect.left + offset) - 10
-  container.style.setProperty('--p-popover-arrow-left', `${arrowLeftEdge}px`)
+  container.style.setProperty('--sm-popover-arrow-left', `${arrowLeftEdge}px`)
 }
 
 function alignPopoverAnimated() {
@@ -756,25 +756,25 @@ defineExpose({ toggle, show, hide, reposition, isDirty, triggerUnsavedWarning })
 
 :global(.review-popover:not(.p-popover-flipped)::before) {
   border-bottom-color: var(--p-primary-color) !important;
-  left: var(--p-popover-arrow-left, calc(50% - 10px)) !important;
+  left: var(--sm-popover-arrow-left, calc(50% - 10px)) !important;
   transform: none !important;
 }
 
 :global(.review-popover:not(.p-popover-flipped)::after) {
   border-bottom-color: var(--color-background-dark) !important;
-  left: var(--p-popover-arrow-left, calc(50% - 10px)) !important;
+  left: var(--sm-popover-arrow-left, calc(50% - 10px)) !important;
   transform: none !important;
 }
 
 :global(.review-popover.p-popover-flipped::before) {
   border-top-color: var(--p-primary-color) !important;
-  left: var(--p-popover-arrow-left, calc(50% - 10px)) !important;
+  left: var(--sm-popover-arrow-left, calc(50% - 10px)) !important;
   transform: none !important;
 }
 
 :global(.review-popover.p-popover-flipped::after) {
   border-top-color: var(--color-background-dark) !important;
-  left: var(--p-popover-arrow-left, calc(50% - 10px)) !important;
+  left: var(--sm-popover-arrow-left, calc(50% - 10px)) !important;
   transform: none !important;
 }
 

--- a/clientV2/src/components/common/ReviewResources/ReviewHistoryTab.vue
+++ b/clientV2/src/components/common/ReviewResources/ReviewHistoryTab.vue
@@ -524,7 +524,7 @@ const historyTablePt = {
   table-layout: fixed;
 }
 
-:deep(.p-datatable-wrapper),
+:deep(.p-datatable-table-container),
 :deep(.p-virtualscroller) {
   overflow-x: auto !important;
 }

--- a/clientV2/src/components/common/ReviewResources/ReviewOtherAssetsTab.vue
+++ b/clientV2/src/components/common/ReviewResources/ReviewOtherAssetsTab.vue
@@ -533,7 +533,7 @@ const otherTablePt = {
   table-layout: fixed;
 }
 
-:deep(.p-datatable-wrapper),
+:deep(.p-datatable-table-container),
 :deep(.p-virtualscroller) {
   overflow-x: auto !important;
 }

--- a/clientV2/src/features/AppManagement/UserGroups/components/UserGroupList.vue
+++ b/clientV2/src/features/AppManagement/UserGroups/components/UserGroupList.vue
@@ -194,7 +194,7 @@ const { onFooterAction } = useTableFooterActions(dataTableRef, { onRefresh: () =
   gap: 0.25rem;
 }
 
-:deep(.center-header .p-column-header-content) {
+:deep(.center-header .p-datatable-column-header-content) {
   justify-content: center;
 }
 </style>

--- a/clientV2/src/features/AppManagement/Users/components/UserList.vue
+++ b/clientV2/src/features/AppManagement/Users/components/UserList.vue
@@ -314,11 +314,11 @@ const { onFooterAction } = useTableFooterActions(dataTableRef, { onRefresh: () =
   color: var(--color-action-green);
 }
 
-:deep(.center-header .p-column-header-content) {
+:deep(.center-header .p-datatable-column-header-content) {
   justify-content: center;
 }
 
-:deep(.wrapped-header .p-column-header-content) {
+:deep(.wrapped-header .p-datatable-column-header-content) {
   flex-wrap: wrap;
 }
 </style>

--- a/clientV2/src/features/AssetReview/components/AssetChecklistGridTable.vue
+++ b/clientV2/src/features/AssetReview/components/AssetChecklistGridTable.vue
@@ -617,22 +617,11 @@ const dataTablePt = {
   background: color-mix(in srgb, var(--color-background-light) 10%, var(--color-background-dark));
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight) {
-  background: color-mix(in srgb, var(--color-primary, #3b82f6) 12%, var(--color-background-light)) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, #3b82f6) 25%, transparent);
-  outline: 1px inset color-mix(in srgb, var(--color-primary) 20%, transparent);
-}
-
 :deep(.p-datatable-tbody > tr:hover) {
   background: var(--color-background-light) !important;
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight .cell-text) {
-  color: var(--color-text-bright);
-  font-weight: 500;
-}
-
-:deep(.p-column-resizer-helper) {
+:deep(.p-datatable-column-resize-indicator) {
   background: var(--color-primary);
 }
 
@@ -658,32 +647,32 @@ const dataTablePt = {
 }
 
 /* Custom scrollbars for the table */
-:deep(.p-datatable-wrapper::-webkit-scrollbar),
+:deep(.p-datatable-table-container::-webkit-scrollbar),
 :deep(.p-virtualscroller::-webkit-scrollbar) {
   width: 6px;
 }
-:deep(.p-datatable-wrapper::-webkit-scrollbar-track),
+:deep(.p-datatable-table-container::-webkit-scrollbar-track),
 :deep(.p-virtualscroller::-webkit-scrollbar-track) {
   background: transparent;
 }
-:deep(.p-datatable-wrapper::-webkit-scrollbar-button),
+:deep(.p-datatable-table-container::-webkit-scrollbar-button),
 :deep(.p-virtualscroller::-webkit-scrollbar-button) {
   display: none;
   width: 0;
   height: 0;
 }
-:deep(.p-datatable-wrapper::-webkit-scrollbar-thumb),
+:deep(.p-datatable-table-container::-webkit-scrollbar-thumb),
 :deep(.p-virtualscroller::-webkit-scrollbar-thumb) {
   background-color: var(--color-border-default);
   border-radius: 999px;
   border: none;
   min-height: 28px;
 }
-:deep(.p-datatable-wrapper::-webkit-scrollbar-thumb:hover),
+:deep(.p-datatable-table-container::-webkit-scrollbar-thumb:hover),
 :deep(.p-virtualscroller::-webkit-scrollbar-thumb:hover) {
   background-color: var(--color-border-hover);
 }
-:deep(.p-datatable-wrapper),
+:deep(.p-datatable-table-container),
 :deep(.p-virtualscroller) {
   scrollbar-width: thin;
   scrollbar-color: var(--color-border-default) transparent;

--- a/clientV2/src/features/AssetReview/components/ReviewTabTable.vue
+++ b/clientV2/src/features/AssetReview/components/ReviewTabTable.vue
@@ -252,7 +252,7 @@ const sharedPt = {
   table-layout: fixed;
 }
 
-:deep(.p-datatable-wrapper),
+:deep(.p-datatable-table-container),
 :deep(.p-virtualscroller) {
   overflow-x: auto !important;
 }

--- a/clientV2/src/features/CollectionReview/components/CollectionChecklistGridTable.vue
+++ b/clientV2/src/features/CollectionReview/components/CollectionChecklistGridTable.vue
@@ -439,19 +439,8 @@ const dataTablePt = {
   background: color-mix(in srgb, var(--color-background-light) 10%, var(--color-background-dark));
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight) {
-  background: color-mix(in srgb, var(--color-primary, #3b82f6) 12%, var(--color-background-light)) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, #3b82f6) 25%, transparent);
-  outline: 1px inset color-mix(in srgb, var(--color-primary) 20%, transparent);
-}
-
 :deep(.p-datatable-tbody > tr:hover) {
   background: var(--color-background-light) !important;
-}
-
-:deep(.p-datatable-tbody > tr.p-highlight .cell-text) {
-  color: var(--color-text-bright);
-  font-weight: 500;
 }
 
 .cell--match {

--- a/clientV2/src/features/Findings/components/AggregatedFindingsGrid.vue
+++ b/clientV2/src/features/Findings/components/AggregatedFindingsGrid.vue
@@ -596,11 +596,6 @@ const flexCellPt = {
   border-bottom: 1px solid var(--color-border-default);
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight) {
-  background: color-mix(in srgb, var(--color-primary) 14%, var(--color-background-light)) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 28%, transparent);
-}
-
 :deep(.p-datatable-tbody > tr:hover) {
   background: var(--color-background-light) !important;
 }

--- a/clientV2/src/features/STIGLibrary/components/BenchmarksTable.vue
+++ b/clientV2/src/features/STIGLibrary/components/BenchmarksTable.vue
@@ -363,12 +363,6 @@ function clearFilter() {
   border-right: none;
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight) {
-  background: color-mix(in srgb, var(--color-primary, #3b82f6) 12%, var(--color-background-light)) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, #3b82f6) 25%, transparent);
-  outline: 1px inset color-mix(in srgb, var(--color-primary) 20%, transparent);
-}
-
 :deep(.p-datatable-tbody > tr:hover) {
   background: var(--color-background-light) !important;
 }

--- a/clientV2/src/features/STIGLibrary/components/DiffRuleTable.vue
+++ b/clientV2/src/features/STIGLibrary/components/DiffRuleTable.vue
@@ -209,19 +209,8 @@ function onFooterAction(key) {
   border-right: none;
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight) {
-  background: color-mix(in srgb, var(--color-primary, #3b82f6) 12%, var(--color-background-light)) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, #3b82f6) 25%, transparent);
-  outline: 1px inset color-mix(in srgb, var(--color-primary) 20%, transparent);
-}
-
 :deep(.p-datatable-tbody > tr:hover) {
   background: var(--color-background-light) !important;
-}
-
-:deep(.p-datatable-tbody > tr.p-highlight .cell-text) {
-  color: var(--color-text-bright);
-  font-weight: 500;
 }
 
 :deep(.p-datatable-footer) {

--- a/clientV2/src/features/STIGLibrary/components/ViewRuleTable.vue
+++ b/clientV2/src/features/STIGLibrary/components/ViewRuleTable.vue
@@ -193,19 +193,8 @@ function onFooterAction(key) {
   border-right: none;
 }
 
-:deep(.p-datatable-tbody > tr.p-highlight) {
-  background: color-mix(in srgb, var(--color-primary, #3b82f6) 12%, var(--color-background-light)) !important;
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary, #3b82f6) 25%, transparent);
-  outline: 1px inset color-mix(in srgb, var(--color-primary) 20%, transparent);
-}
-
 :deep(.p-datatable-tbody > tr:hover) {
   background: var(--color-background-light) !important;
-}
-
-:deep(.p-datatable-tbody > tr.p-highlight .cell-text) {
-  color: var(--color-text-bright);
-  font-weight: 500;
 }
 
 :deep(.p-datatable-footer) {

--- a/clientV2/src/style.css
+++ b/clientV2/src/style.css
@@ -236,7 +236,7 @@ textarea {
 
 /* Global form field focus color (light blue) */
 .p-inputtext:focus,
-.p-inputtextarea:focus,
+.p-textarea:focus,
 input[type="text"]:focus,
 input[type="search"]:focus,
 input[type="number"]:focus,


### PR DESCRIPTION
## Fix stale PrimeVue 3 references

An audit of every `p-*` class and `--p-*` CSS variable used in clientV2, validated against the class names and design tokens actually shipped in the installed PrimeVue 4.4.1 packages, turned up a handful of v3-era references that don't exist in v4. Since the selectors never matched anything, the styling attached to them was silently dead.

### Renamed to v4 equivalents (dead selectors that now apply)

- `.p-column-header-content` → `.p-datatable-column-header-content` (`UserList.vue`, `UserGroupList.vue`) — header text in columns marked `center-header` now actually centers, and the privilege column headers wrap as intended
- `.p-datatable-wrapper` → `.p-datatable-table-container` (`AssetChecklistGridTable.vue`, `ReviewTabTable.vue`, `ReviewHistoryTab.vue`, `ReviewOtherAssetsTab.vue`) — thin-scrollbar/overflow rules; no visible change since these tables virtual-scroll and the paired `.p-virtualscroller` selector was already applying
- `.p-column-resizer-helper` → `.p-datatable-column-resize-indicator` (`AssetChecklistGridTable.vue`) — column-resize drag indicator now uses the primary color
- `.p-inputtextarea` → `.p-textarea` (`style.css`) — textareas now get the same light-blue focus border as text inputs

### Removed rather than renamed

- Custom selected-row rules on `tr.p-highlight` in six single-selection grids (Benchmarks, View/Diff Rule tables, Asset Review and Collection Review checklist grids, aggregated Findings grid). These never rendered in v4; rather than activate them, they are deleted so row selection keeps the theme-default highlight the app has always shown.

### Modernized v3 idioms

- `MetadataEditor.vue`: manual `:class="{ 'p-invalid': ... }"` binding replaced with the v4 `:invalid` prop (same rendered class, same red-border behavior)
- `ReviewEditPopover.vue`: custom arrow-positioning variable `--p-popover-arrow-left` renamed to `--sm-popover-arrow-left` to stay out of PrimeVue's reserved `--p-` token namespace

### Verified clean (no changes needed)

No v3 component imports/tags, v3 theme variables, `primevue/resources` imports, PrimeFlex classes, or v3 button-styling classes remain. All `--p-*` token usages (`--p-highlight-background`, `--p-datatable-row-background`, `--p-button-secondary-*`) were confirmed as valid v4 tokens against the Material preset.

### Testing

All Vitest suites covering the touched components pass (Users, UserGroups, AssetChecklistGridTable, AssetChecklistGrid, ReviewEditPopover, RuleTableGrid — 46 tests).
