### PR TITLE
Findings label filter bind fix

### DIFF
--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -865,8 +865,9 @@ exports.getFindingsByCollection = async function( {collectionId, aggregator, ben
     predicates.binds.push( benchmarkId )
   }
   if (labelIds || labelNames || labelMatch) {
-    // the returned clause arrives already formatted, so it contributes no binds of its own
-    predicates.statements.push(dbUtils.sqlLabelAssetIds({collectionId, labelIds, labelNames, labelMatch}))
+    const labelFilter = dbUtils.sqlLabelAssetIds({collectionId, labelIds, labelNames, labelMatch})
+    predicates.statements.push(labelFilter.statement)
+    predicates.binds.push(...labelFilter.binds)
   }
 
   const sql = dbUtils.makeQueryString({ctes, columns, joins, predicates, groupBy, orderBy, format: true})

--- a/api/source/service/MetricsService.js
+++ b/api/source/service/MetricsService.js
@@ -33,12 +33,14 @@ module.exports.queryMetrics = async function ({
 
   // FILTERS
   if (filter.labelNames || filter.labelIds || filter.labelMatch) {
-    predicates.statements.push(dbUtils.sqlLabelAssetIds({
+    const labelFilter = dbUtils.sqlLabelAssetIds({
       collectionId,
       labelNames: filter.labelNames,
       labelIds: filter.labelIds,
       labelMatch: filter.labelMatch
-    }))
+    })
+    predicates.statements.push(labelFilter.statement)
+    predicates.binds.push(...labelFilter.binds)
   }
   if (filter.assetIds) {
     predicates.statements.push(

--- a/api/source/service/utils.js
+++ b/api/source/service/utils.js
@@ -601,12 +601,14 @@ module.exports.sqlLabelAssetIds = function ({collectionId, labelNames, labelIds,
     collectionLabelTableAlias: 'clPred'
   })
   // nothing to match on, so impose no restriction rather than emit an empty IN ()
-  if (!statement) return 'true'
+  if (!statement) return {statement: 'true', binds: []}
+  // returned unformatted: escaped label values can contain characters the formatter
+  // would treat as placeholders, so the query must be formatted exactly once
   const sql = `select distinct assetId from enabled_asset
     left join collection_label_asset_map using (assetId)
     left join collection_label clPred using (clId)
     where enabled_asset.collectionId = ? and ${statement}`
-  return `${assetTableAlias}.assetId IN (${module.exports.pool.format(sql, [collectionId, ...binds])})`
+  return {statement: `${assetTableAlias}.assetId IN (${sql})`, binds: [collectionId, ...binds]}
 }
 
 module.exports.makeQueryString = function ({ctes = [], hints= [], columns, joins, predicates, groupBy, orderBy, format = false}) {

--- a/test/api/mocha/data/metrics/metricsGet.test.js
+++ b/test/api/mocha/data/metrics/metricsGet.test.js
@@ -67,6 +67,16 @@ describe('GET - Metrics', function () {
                     expect(res.body).to.deep.equalInAnyOrder(expectedData['stigmanadmin'])
                 }
             })
+            it('Return detailed metrics - labelName containing "?" with other bind params', async function () {
+                const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/metrics/detail?labelName=${encodeURIComponent('no?match')}&benchmarkId=${reference.benchmark}`, 'GET', iteration.token)
+                if(iteration.name === "collectioncreator"){
+                    expect(res.status).to.eql(403)
+                    return
+                }
+                // the "?" inside the label value must not be consumed as a bind placeholder; no label matches, so no rows
+                expect(res.status).to.eql(200)
+                expect(res.body).to.eql([])
+            })
             it("test metrics on empty collection", async function () {
 
                 const res = await utils.executeRequest(`${config.baseUrl}/collections/${'84'}/metrics/detail`, 'GET', iteration.token)


### PR DESCRIPTION
Follow-up to #2146, targeting `findings-label-filter`. Fixes a bind-alignment hazard in the shared Label-filter helper that PR extracts — the bug itself pre-exists on `main` in the metrics queries; #2146 only centralizes the pattern.

## Problem

`sqlLabelAssetIds` returns a clause pre-formatted with `pool.format`, and `makeQueryString` then formats the assembled query a second time. `sqlstring`'s placeholder scan is not quote-aware, so a literal `?` inside an escaped `labelName` value is treated as a bind placeholder on the second pass and consumes the next bind. `LabelName` is an unrestricted 1–16 character string, so this is reachable with ordinary user input.

- **Metrics (live today, including on `main`):** in `queryMetrics` the Label clause renders before the `assetId`/`benchmarkId` binds, so e.g. `GET /collections/{id}/metrics/detail?labelName=no%3Fmatch&benchmarkId=...` returns 500 — the `?` in the escaped literal eats the benchmark bind array and the real `IN ?` reaches MySQL unformatted. With more than one `?` in the value, the query can instead run with silently shifted binds.
- **Findings (latent):** `getFindingsByCollection` avoids this only because its Label clause happens to be pushed as the last predicate, after every bind-bearing placeholder. Nothing enforces that ordering.

## Fix

`sqlLabelAssetIds` now returns `{statement, binds}` (matching `genLabelPredicates`) instead of a pre-formatted string, and both callers push the statement and merge the binds. The assembled query is formatted exactly once, so escaped values are never re-scanned, and the Label clause is safe in any predicate position. The empty-input `'true'` fallback keeps its existing semantics, shape-adjusted only.

## Commits

1. `test(api)` — adds a metrics test (`labelName` containing `?` combined with `benchmarkId`) that fails at that commit with 500 in every access-granted iteration.
2. `fix(api)` — the change above; the test passes from this commit on.

## Verification

- New test: 6/6 iterations passing
- `metricsGet.test.js`: 367 passing, 0 failing
- `collectionGet.test.js -p getFindingsByCollection` (including this PR's new Label-filter tests): 90 passing, 0 failing
