### PR TITLE
feat: Label filtering for Collection Reviews

### DIFF
--- a/api/source/controllers/Review.js
+++ b/api/source/controllers/Review.js
@@ -112,6 +112,9 @@ module.exports.getReviewsByCollection = async function getReviewsByCollection (r
         userId: req.query.userId,
         assetId: req.query.assetId,
         benchmarkId: req.query.benchmarkId,
+        labelIds: req.query.labelId,
+        labelNames: req.query.labelName,
+        labelMatch: req.query.labelMatch,
         metadata: req.query.metadata
       },
       grant,

--- a/api/source/service/ReviewService.js
+++ b/api/source/service/ReviewService.js
@@ -789,6 +789,16 @@ exports.getReviews = async function ({projections = [], filter = {}, grant}) {
       predicates.statements.push(`revision.benchmarkId = ?`)
       predicates.binds.push(filter.benchmarkId)
   }
+  if (filter.labelIds || filter.labelNames || filter.labelMatch) {
+    const labelFilter = dbUtils.sqlLabelAssetIds({
+      collectionId: filter.collectionId,
+      labelIds: filter.labelIds,
+      labelNames: filter.labelNames,
+      labelMatch: filter.labelMatch
+    })
+    predicates.statements.push(labelFilter.statement)
+    predicates.binds.push(...labelFilter.binds)
+  }
   if ( filter.metadata ) {
     for (const pair of filter.metadata) {
       const [key, value] = pair.split(/:(.*)/s)

--- a/api/source/specification/stig-manager.yaml
+++ b/api/source/specification/stig-manager.yaml
@@ -1321,6 +1321,9 @@ paths:
         - $ref: '#/components/parameters/UserIdQuery'
         - $ref: '#/components/parameters/AssetIdQuery'
         - $ref: '#/components/parameters/BenchmarkIdQuery'
+        - $ref: '#/components/parameters/LabelIdQuery'
+        - $ref: '#/components/parameters/LabelNameQuery'
+        - $ref: '#/components/parameters/LabelMatchQuery'
         - $ref: '#/components/parameters/MetadataQuery'
         - $ref: '#/components/parameters/ReviewsProjectionQuery'
       responses:

--- a/test/api/mocha/data/review/expectations.js
+++ b/test/api/mocha/data/review/expectations.js
@@ -20,7 +20,15 @@ export const expectations = {
         reviewsForResultPass: 4,
         reviewsForTestGroup: 3,
         reviewsForRulesAll: 17,
-        reviewsDefaultMapped: 0
+        reviewsDefaultMapped: 0,
+        reviewsByLabelFullCnt: 12,
+        reviewsByLabelLvl1Cnt: 9,
+        reviewsByLabelBothCnt: 12,
+        reviewsByLabelIdFullCnt: 12,
+        reviewsByLabelMatchNullCnt: 5,
+        labelFullAssetIds: ["42", "62"],
+        labelLvl1AssetIds: ["42"],
+        labelMatchNullAssetIds: ["154"],
       },
       postReviews:{
         targetAssetsWholeStig:{
@@ -182,7 +190,15 @@ export const expectations = {
         reviewsForResultPass: 2,
         reviewsForTestGroup: 3,
         reviewsForRulesAll: 14,
-        reviewsDefaultMapped: 0
+        reviewsDefaultMapped: 0,
+        reviewsByLabelFullCnt: 9,
+        reviewsByLabelLvl1Cnt: 6,
+        reviewsByLabelBothCnt: 9,
+        reviewsByLabelIdFullCnt: 9,
+        reviewsByLabelMatchNullCnt: 5,
+        labelFullAssetIds: ["42", "62"],
+        labelLvl1AssetIds: ["42"],
+        labelMatchNullAssetIds: ["154"],
       },
       roleId:1
     },
@@ -279,7 +295,15 @@ export const expectations = {
         reviewsForResultPass: 4,
         reviewsForTestGroup: 3,
         reviewsForRulesAll: 17,
-        reviewsDefaultMapped: 0
+        reviewsDefaultMapped: 0,
+        reviewsByLabelFullCnt: 12,
+        reviewsByLabelLvl1Cnt: 9,
+        reviewsByLabelBothCnt: 12,
+        reviewsByLabelIdFullCnt: 12,
+        reviewsByLabelMatchNullCnt: 5,
+        labelFullAssetIds: ["42", "62"],
+        labelLvl1AssetIds: ["42"],
+        labelMatchNullAssetIds: ["154"],
       },
       roleId:2
     },
@@ -309,7 +333,15 @@ export const expectations = {
         reviewsForResultPass: 4,
         reviewsForTestGroup: 3,
         reviewsForRulesAll: 17,
-        reviewsDefaultMapped: 0
+        reviewsDefaultMapped: 0,
+        reviewsByLabelFullCnt: 12,
+        reviewsByLabelLvl1Cnt: 9,
+        reviewsByLabelBothCnt: 12,
+        reviewsByLabelIdFullCnt: 12,
+        reviewsByLabelMatchNullCnt: 5,
+        labelFullAssetIds: ["42", "62"],
+        labelLvl1AssetIds: ["42"],
+        labelMatchNullAssetIds: ["154"],
       },
       postReviews:{
         targetAssetsWholeStig:{
@@ -404,8 +436,15 @@ export const expectations = {
         reviewsForStigmanadmin: 14,
         reviewsForTestGroup: 3,
         reviewsForRulesAll: 17,
-        reviewsDefaultMapped: 0
-      
+        reviewsDefaultMapped: 0,
+        reviewsByLabelFullCnt: 12,
+        reviewsByLabelLvl1Cnt: 9,
+        reviewsByLabelBothCnt: 12,
+        reviewsByLabelIdFullCnt: 12,
+        reviewsByLabelMatchNullCnt: 5,
+        labelFullAssetIds: ["42", "62"],
+        labelLvl1AssetIds: ["42"],
+        labelMatchNullAssetIds: ["154"],
       },
       postReviews:{
         targetAssetsWholeStig:{

--- a/test/api/mocha/data/review/reviewGet.test.js
+++ b/test/api/mocha/data/review/reviewGet.test.js
@@ -99,6 +99,83 @@ describe('GET - Review', () => {
             }        
           }
         })
+        it('Return a list of reviews accessible to the requester, filtered by labelName.', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelName=${reference.testCollection.fullLabelName}`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          expect(res.body).to.be.lengthOf(distinct.testCollection.reviewsByLabelFullCnt)
+
+          const returnedAssetIds = [...new Set(res.body.map(review => review.assetId))]
+          expect(returnedAssetIds.sort()).to.eql([...distinct.testCollection.labelFullAssetIds].sort())
+
+          for(const review of res.body){
+            expect(review.assetLabelIds).to.include(reference.testCollection.fullLabel)
+          }
+        })
+
+        it('Return a list of reviews accessible to the requester, filtered by labelId.', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelId=${reference.testCollection.fullLabel}`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          // labelId and labelName identify the same Label, so they must select the same Assets
+          expect(res.body).to.be.lengthOf(distinct.testCollection.reviewsByLabelIdFullCnt)
+
+          const returnedAssetIds = [...new Set(res.body.map(review => review.assetId))]
+          expect(returnedAssetIds.sort()).to.eql([...distinct.testCollection.labelFullAssetIds].sort())
+        })
+
+        it('Return a list of reviews accessible to the requester, filtered by a Label on a single Asset.', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelName=${reference.testCollection.lvl1LabelName}`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          expect(res.body).to.be.lengthOf(distinct.testCollection.reviewsByLabelLvl1Cnt)
+
+          const returnedAssetIds = [...new Set(res.body.map(review => review.assetId))]
+          expect(returnedAssetIds.sort()).to.eql([...distinct.testCollection.labelLvl1AssetIds].sort())
+        })
+
+        it('Return a list of reviews accessible to the requester, filtered by multiple labelNames.', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelName=${reference.testCollection.fullLabelName}&labelName=${reference.testCollection.lvl1LabelName}`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          // the Labels are OR'd, and the Asset carrying both must not be counted twice
+          expect(res.body).to.be.lengthOf(distinct.testCollection.reviewsByLabelBothCnt)
+
+          // a Review is identified by its Asset and Rule, so no pair may repeat
+          const reviewKeys = res.body.map(review => `${review.assetId}:${review.ruleId}`)
+          expect(reviewKeys).to.eql([...new Set(reviewKeys)])
+
+          // every returned Review must belong to an Asset carrying one of the requested Labels
+          for(const review of res.body){
+            expect(review.assetLabelIds).to.include.oneOf([reference.testCollection.fullLabel, reference.testCollection.lvl1Label])
+          }
+        })
+
+        it('Return a list of reviews accessible to the requester, for Assets without Labels.', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelMatch=null`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          expect(res.body).to.be.lengthOf(distinct.testCollection.reviewsByLabelMatchNullCnt)
+
+          const returnedAssetIds = [...new Set(res.body.map(review => review.assetId))]
+          expect(returnedAssetIds.sort()).to.eql([...distinct.testCollection.labelMatchNullAssetIds].sort())
+        })
+
+        it('Return no reviews when the labelName matches no Label.', async () => {
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelName=no-such-label`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          expect(res.body).to.be.an('array').of.length(0)
+        })
+
+        it('Return a list of reviews when a labelName contains a "?" alongside another filter.', async () => {
+          // the "?" must not be consumed as a bind placeholder by the query formatter
+          const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?labelName=${encodeURIComponent('no?match')}&benchmarkId=${reference.benchmark}`, 'GET', iteration.token)
+
+          expect(res.status).to.eql(200)
+          expect(res.body).to.be.an('array').of.length(0)
+        })
+
         it('Return a list of reviews accessible to the requester, metadata Projection.', async () => {
           const res = await utils.executeRequest(`${config.baseUrl}/collections/${reference.testCollection.collectionId}/reviews?projection=rule&projection=stigs&metadata=${reference.reviewMetadataKey}%3A${reference.reviewMetadataValue}&projection=metadata`, 'GET', iteration.token)
          


### PR DESCRIPTION
This pull request adds Label filtering to the Collection Reviews endpoint, completing item 2 of the clientV2 pending API enhancements. `getFindingsByCollection` gained `labelName`, `labelId`, and `labelMatch` in #2146; without the same parameters here, the Findings report's individual-Reviews pane still returned records for Assets outside the active Label filter, so drilling into an aggregated row contradicted the grid above it.

**Label Filtering:**

* Added the `labelName`, `labelId`, and `labelMatch` query parameters to `getReviewsByCollection`, reusing the existing `LabelIdQuery` / `LabelNameQuery` / `LabelMatchQuery` spec components.
* Applied the filter with `dbUtils.sqlLabelAssetIds`. `getReviews` already filters on `a.collectionId` using the `enabled_asset` alias the helper expects, and all six of its callers supply a `collectionId`, so the subquery is always scoped.

**Testing:**

* Added label filtering cases to `reviewGet.test.js` across all iteration personas, covering each parameter, multiple OR'd `labelName`s, a `labelName` matching no Label, and a `labelName` containing `?` alongside another filter. Assertions check the returned Asset sets and each Review's `assetLabelIds`, not row counts alone.
