### PR TITLE
Port the ActivityHandler idle-activity keepalive into clientV2

### DIFF
--- a/api/source/bootstrap/client.js
+++ b/api/source/bootstrap/client.js
@@ -72,6 +72,7 @@ function getClientV2Env(){
         Env: {
             version: "${config.version}",
             apiBase: "${config.client.apiBase}",
+            consoleMode: "${config.client.consoleMode}",
             historyBase: "${config.client.historyBase}",
             pathPrefix: "${config.client.pathPrefix}",
             displayAppManagers: ${config.client.displayAppManagers},

--- a/clientV2/docs/project-plan.md
+++ b/clientV2/docs/project-plan.md
@@ -556,7 +556,7 @@ Files to delete (not imported by any active code):
 | `src/features/CollectionView/components/StigAssetLabelTable.vue` | Uses old inject/query pattern |
 | `src/features/CollectionView/components/ChecklistTable.vue` | Uses old inject/query pattern |
 
-Additionally, `postContextActiveMessage()` on the OW object (oidcWorker.js main thread) is defined but never called — the idle-timeout reset is unreachable from the UI.
+Additionally, `postContextActiveMessage()` on the OW object is called by `src/auth/ActivityHandler.js`, which throttle-posts `contextActive` to the OIDC worker on user activity (click/keydown/scroll) so the worker's idle timer is reset while the user is present.
 
 ---
 

--- a/clientV2/src/auth/ActivityHandler.js
+++ b/clientV2/src/auth/ActivityHandler.js
@@ -6,11 +6,15 @@ class ActivityHandler {
   #messageTime = 0
   #messageThrottle = 1000 // 1 second
 
-  #events = ['click', 'keypress', 'scroll']
+  // keydown, not keypress: keypress never fires for arrows/Tab/Delete/modifiers,
+  // so keyboard-only navigation would read as idle
+  #events = ['click', 'keydown', 'scroll']
   #boundHandler = null
 
   #logPrefix = '[ActivityHandler]'
-  reportActivity = true
+  // false until init.js computes the real value from the idle-timeout config;
+  // the worker's accessToken broadcast can call add() before that happens
+  reportActivity = false
 
   add() {
     if (!this.#boundHandler && this.reportActivity) {
@@ -33,6 +37,7 @@ class ActivityHandler {
   }
 
   throttledActiveMessage() {
+    if (!this.reportActivity) return
     this.#messageTime = Date.now()
     if (this.#messageTime - this.#lastMessageTime >= this.#messageThrottle) {
       STIGMAN.oidcWorker.postContextActiveMessage()

--- a/clientV2/src/auth/ActivityHandler.js
+++ b/clientV2/src/auth/ActivityHandler.js
@@ -1,0 +1,45 @@
+// Ported from client/src/js/SM/ActivityHandler.js
+// Throttle-posts `contextActive` to the shared OIDC worker on real user
+// activity so the worker keeps the session/token alive while the user is present.
+class ActivityHandler {
+  #lastMessageTime = 0
+  #messageTime = 0
+  #messageThrottle = 1000 // 1 second
+
+  #events = ['click', 'keypress', 'scroll']
+  #boundHandler = null
+
+  #logPrefix = '[ActivityHandler]'
+  reportActivity = true
+
+  add() {
+    if (!this.#boundHandler && this.reportActivity) {
+      this.#boundHandler = this.throttledActiveMessage.bind(this)
+      this.#events.forEach((event) => {
+        window.addEventListener(event, this.#boundHandler, true)
+      })
+      console.log(`${this.#logPrefix} activity event handlers added`)
+    }
+  }
+
+  remove() {
+    if (this.#boundHandler) {
+      this.#events.forEach((event) => {
+        window.removeEventListener(event, this.#boundHandler, true)
+      })
+      this.#boundHandler = null
+      console.log(`${this.#logPrefix} activity event handlers removed`)
+    }
+  }
+
+  throttledActiveMessage() {
+    this.#messageTime = Date.now()
+    if (this.#messageTime - this.#lastMessageTime >= this.#messageThrottle) {
+      STIGMAN.oidcWorker.postContextActiveMessage()
+      this.#lastMessageTime = this.#messageTime
+      console.log(`${this.#logPrefix} contextActive message posted to OIDC worker`)
+    }
+  }
+}
+
+export default new ActivityHandler()

--- a/clientV2/src/auth/ActivityHandler.test.js
+++ b/clientV2/src/auth/ActivityHandler.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The handler posts via the STIGMAN.oidcWorker global assigned in init.js
+const postContextActiveMessage = vi.fn()
+
+let activityHandler
+
+beforeEach(async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+  postContextActiveMessage.mockClear()
+  globalThis.STIGMAN = { oidcWorker: { postContextActiveMessage } }
+  // fresh singleton per test: the module exports `new ActivityHandler()`
+  vi.resetModules()
+  activityHandler = (await import('./ActivityHandler.js')).default
+})
+
+afterEach(() => {
+  activityHandler.remove()
+  vi.useRealTimers()
+})
+
+function act(type = 'click') {
+  window.dispatchEvent(type === 'keydown' ? new KeyboardEvent('keydown', { key: 'ArrowDown' }) : new Event(type))
+}
+
+describe('ActivityHandler', () => {
+  it('posts nothing when add() is called before reportActivity is computed (init broadcast race)', () => {
+    // init.js order on a fresh login: the worker's accessToken broadcast fires
+    // bc.onmessage -> add() while the app is still awaiting getUserObject(),
+    // and only afterwards does init.js compute the real reportActivity value
+    activityHandler.add()
+    activityHandler.reportActivity = false // idle timeout disabled for this user class
+    activityHandler.add()
+    act()
+    expect(postContextActiveMessage).not.toHaveBeenCalled()
+  })
+
+  it('posts nothing by default (reportActivity must be opted into)', () => {
+    activityHandler.add()
+    act()
+    expect(postContextActiveMessage).not.toHaveBeenCalled()
+  })
+
+  it('posts contextActive on activity when reportActivity is truthy', () => {
+    activityHandler.reportActivity = 15 // init.js assigns the raw idleTimeout value
+    activityHandler.add()
+    act()
+    expect(postContextActiveMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops posting if reportActivity is cleared after listeners attached', () => {
+    activityHandler.reportActivity = 15
+    activityHandler.add()
+    act()
+    activityHandler.reportActivity = false
+    vi.advanceTimersByTime(2000)
+    act()
+    expect(postContextActiveMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('throttles posts to one per interval', () => {
+    activityHandler.reportActivity = true
+    activityHandler.add()
+    act()
+    act('scroll')
+    vi.advanceTimersByTime(999)
+    act()
+    expect(postContextActiveMessage).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1)
+    act()
+    expect(postContextActiveMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats keydown (non-character keys) as activity', () => {
+    activityHandler.reportActivity = true
+    activityHandler.add()
+    act('keydown')
+    expect(postContextActiveMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('posts nothing after remove(), and add() re-attaches', () => {
+    activityHandler.reportActivity = true
+    activityHandler.add()
+    activityHandler.remove()
+    act()
+    expect(postContextActiveMessage).not.toHaveBeenCalled()
+    activityHandler.add()
+    act()
+    expect(postContextActiveMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clientV2/src/auth/useOidcWorker.js
+++ b/clientV2/src/auth/useOidcWorker.js
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import activityHandler from './ActivityHandler.js'
 
 const noTokenMessage = ref(null)
 
@@ -12,9 +13,11 @@ export function setupOidcHandler() {
         ...event.data.clientV2,
       }
       noTokenMessage.value = noTokenData
+      activityHandler.remove()
     }
     else if (event.data?.type === 'accessToken') {
       noTokenMessage.value = null
+      activityHandler.add()
     }
   })
 }

--- a/clientV2/src/init.js
+++ b/clientV2/src/init.js
@@ -1,3 +1,5 @@
+import activityHandler from './auth/ActivityHandler.js'
+
 console.log('import.meta.env:', import.meta.env)
 if (import.meta.env.DEV) {
   STIGMAN.Env.apiBase = `${import.meta.env.VITE_API_ORIGIN}/api`
@@ -31,6 +33,9 @@ else {
       const userObj = await getUserObject()
       if (userObj) {
         STIGMAN.curUser = userObj
+        const isAdmin = userObj.privileges.admin
+        activityHandler.reportActivity = (STIGMAN.Env.oauth.idleTimeoutUser && !isAdmin) || (STIGMAN.Env.oauth.idleTimeoutAdmin && isAdmin)
+        activityHandler.add()
         loadApp()
       }
     }
@@ -274,11 +279,13 @@ async function setupOidcWorker() {
       console.log('{init] Received from worker:', event.type, event.data)
       OW.token = event.data.accessToken
       OW.tokenParsed = event.data.accessTokenPayload
+      activityHandler.add()
     }
     else if (event.data.type === 'noToken') {
       console.log('{init] Received from worker:', event.type, event.data)
       OW.token = null
       OW.tokenParsed = null
+      activityHandler.remove()
     }
   }
 }

--- a/clientV2/src/init.js
+++ b/clientV2/src/init.js
@@ -1,5 +1,15 @@
 import activityHandler from './auth/ActivityHandler.js'
 
+// Same global console gate as the legacy client (client/src/js/init.js):
+// production deployments are silent unless STIGMAN_CLIENT_CONSOLE_MODE=development
+const consoleEnabled = import.meta.env.DEV || STIGMAN.Env.consoleMode === 'development'
+if (!consoleEnabled) {
+  console.log = function () { }
+  console.warn = function () { }
+  console.error = function () { }
+  console.debug = function () { }
+}
+
 console.log('import.meta.env:', import.meta.env)
 if (import.meta.env.DEV) {
   STIGMAN.Env.apiBase = `${import.meta.env.VITE_API_ORIGIN}/api`
@@ -279,13 +289,11 @@ async function setupOidcWorker() {
       console.log('{init] Received from worker:', event.type, event.data)
       OW.token = event.data.accessToken
       OW.tokenParsed = event.data.accessTokenPayload
-      activityHandler.add()
     }
     else if (event.data.type === 'noToken') {
       console.log('{init] Received from worker:', event.type, event.data)
       OW.token = null
       OW.tokenParsed = null
-      activityHandler.remove()
     }
   }
 }


### PR DESCRIPTION
Port the legacy ActivityHandler idle-activity keepalive into clientV2, which throttle-posts contextActive to the shared OIDC worker on real user activity (click/keypress/scroll) so an actively-used session isn't allowed to idle out. Wires it into init.js — gating reportActivity on the user's role-specific idle timeout and adding/removing the listeners in step with accessToken/noToken worker broadcasts closing a behavioral gap where clientV2 defined postContextActiveMessage but never called it.