### PR TITLE
refactor: optimize data fetching collection view 

### DIFF
--- a/clientV2/src/features/CollectionView/components/CollectionView.vue
+++ b/clientV2/src/features/CollectionView/components/CollectionView.vue
@@ -281,7 +281,7 @@ function toggleDashboardSidebar() {
                 <CollectionLabelsTab v-if="visitedTabs.has('labels')" :collection-id="collectionId" :selected-label-ids="selectedLabelIds" />
               </TabPanel>
               <TabPanel value="findings" :pt="tabPanelPt">
-                <Findings :collection-id="collectionId" :selected-label-ids="selectedLabelIds" />
+                <Findings v-if="visitedTabs.has('findings')" :collection-id="collectionId" :selected-label-ids="selectedLabelIds" />
               </TabPanel>
               <TabPanel v-if="canManage" value="management" :pt="tabPanelPt">
                 <Transition name="management-fade">

--- a/clientV2/src/features/CollectionView/components/CollectionView.vue
+++ b/clientV2/src/features/CollectionView/components/CollectionView.vue
@@ -15,9 +15,9 @@ import CollectionManage from '../../CollectionManage/components/CollectionManage
 import CollectionExportMetrics from '../../CollectionMetrics/components/CollectionExportMetrics.vue'
 import CollectionImportResults from '../../CollectionMetrics/components/CollectionImportResults.vue'
 import CollectionMetrics from '../../CollectionMetrics/components/CollectionMetrics.vue'
+import Findings from '../../Findings/components/Findings.vue'
 import { useRecentViews } from '../../NavRail/composables/useRecentViews.js'
 import { fetchCollection } from '../api/collectionApi.js'
-import Findings from '../../Findings/components/Findings.vue'
 import CollectionAssetsTab from './CollectionAssetsTab.vue'
 import CollectionLabelsTab from './CollectionLabelsTab.vue'
 import CollectionStigsTab from './CollectionStigsTab.vue'
@@ -126,12 +126,19 @@ const isManagement = computed(() => route.name === 'collection-management')
 const sidebarTransitioning = ref(false)
 watch(isManagement, () => {
   sidebarTransitioning.value = true
-  setTimeout(() => { sidebarTransitioning.value = false }, 300)
+  setTimeout(() => {
+    sidebarTransitioning.value = false
+  }, 300)
 })
 
-// Lazy-mount tab panels: only render a tab's content after it has been visited
+// Lazy-mount tab panels: only render a tab's content after it has been visited.
+// Reset on collection switch so tabs visited in a prior collection don't mount
+// (and fetch) unvisited in the new one.
 const visitedTabs = ref(new Set([activeTab.value]))
 watch(activeTab, tab => visitedTabs.value.add(tab))
+watch(() => props.collectionId, () => {
+  visitedTabs.value = new Set([activeTab.value])
+})
 
 const tabsPt = {
   root: {

--- a/clientV2/src/features/MenuBar/api/menuBarApi.js
+++ b/clientV2/src/features/MenuBar/api/menuBarApi.js
@@ -1,3 +1,0 @@
-export { fetchAsset, fetchAssetStigs } from '../../../shared/api/assetsApi.js'
-export { fetchCollectionStigs } from '../../../shared/api/collectionsApi.js'
-export { fetchStigRevisions } from '../../../shared/api/stigsApi.js'

--- a/clientV2/src/features/MenuBar/api/menuBarApi.js
+++ b/clientV2/src/features/MenuBar/api/menuBarApi.js
@@ -1,3 +1,3 @@
 export { fetchAsset, fetchAssetStigs } from '../../../shared/api/assetsApi.js'
-export { fetchCollectionStigSummary as fetchCollectionStigs } from '../../CollectionView/api/collectionApi.js'
+export { fetchCollectionStigs } from '../../../shared/api/collectionsApi.js'
 export { fetchStigRevisions } from '../../../shared/api/stigsApi.js'

--- a/clientV2/src/features/MenuBar/composables/useAppBreadcrumb.js
+++ b/clientV2/src/features/MenuBar/composables/useAppBreadcrumb.js
@@ -57,6 +57,12 @@ export function useAppBreadcrumb() {
   const assetId = computed(() => route.params.assetId)
   const benchmarkId = computed(() => route.params.benchmarkId)
 
+  // The STIG picker only renders on the review routes. Gate the STIG-list fetch
+  // on this so plain collection tab routes don't pull /stigs for a hidden dropdown.
+  const showsStigPicker = computed(() =>
+    route.name === 'collection-benchmark-review' || route.name === 'collection-asset-review',
+  )
+
   const { state: assetStigOptions, execute: loadAssetStigs } = useAsyncState(
     () => {
       if (assetId.value) {
@@ -80,9 +86,12 @@ export function useAppBreadcrumb() {
     { initialState: [], immediate: false },
   )
 
-  // Load STIGs when asset or collection changes
-  watch([assetId, collectionId], () => {
-    if (assetId.value || collectionId.value) {
+  // Load STIGs only when a route that shows the STIG picker becomes active.
+  // Watching showsStigPicker (not benchmarkId) means switching STIGs within a
+  // review route doesn't refetch the list, and entering a review from the same
+  // collection still triggers the fetch even though collectionId is unchanged.
+  watch([assetId, collectionId, showsStigPicker], () => {
+    if (showsStigPicker.value && (assetId.value || collectionId.value)) {
       loadAssetStigs()
     }
     if (assetId.value) {

--- a/clientV2/src/features/MenuBar/composables/useAppBreadcrumb.js
+++ b/clientV2/src/features/MenuBar/composables/useAppBreadcrumb.js
@@ -1,13 +1,10 @@
 import { computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { fetchAsset, fetchAssetStigs } from '../../../shared/api/assetsApi.js'
+import { fetchCollectionStigs } from '../../../shared/api/collectionsApi.js'
+import { fetchStigRevisions } from '../../../shared/api/stigsApi.js'
 import { useAsyncState } from '../../../shared/composables/useAsyncState.js'
 import { useCurrentUser } from '../../../shared/composables/useCurrentUser.js'
-import {
-  fetchAsset,
-  fetchAssetStigs,
-  fetchCollectionStigs,
-  fetchStigRevisions,
-} from '../api/menuBarApi.js'
 
 /**
  * Global breadcrumb composable. Watches the active route and builds
@@ -91,10 +88,18 @@ export function useAppBreadcrumb() {
   // review route doesn't refetch the list, and entering a review from the same
   // collection still triggers the fetch even though collectionId is unchanged.
   watch([assetId, collectionId, showsStigPicker], () => {
-    if (showsStigPicker.value && (assetId.value || collectionId.value)) {
+    if (showsStigPicker.value) {
+      // Clear first: options left over from a prior collection/asset would
+      // render the current benchmarkId as an invalid selection while the fetch
+      // is in flight, whereas empty options get the loading fallback.
+      assetStigOptions.value = []
       loadAssetStigs()
     }
-    if (assetId.value) {
+  }, { immediate: true })
+
+  // Load the asset (for breadcrumb labels) when the asset changes
+  watch(assetId, (id) => {
+    if (id) {
       loadAsset()
     }
   }, { immediate: true })


### PR DESCRIPTION
- Findings lazy-mount: Guarded <Findings> with visitedTabs so it no longer fetches on non-findings routes.
- Breadcrumb endpoint swap: Pointed the STIG dropdown at the cheap /stigs list instead of the duplicate /metrics/summary/stig.
- Breadcrumb fetch gating: Fetch the STIG list only on review routes where the picker actually shows, not on every collection tab.