### PR TITLE
Raise minimum MySQL to 8.4.0 and update alerted dependencies

### DIFF
--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -19,11 +19,11 @@ jobs:
       - name: Fetch MySQL Versions
         id: fetch-versions
         run: |
-          # Fetch latest 3 MySQL 8.4.x versions
-          MYSQL_8_4=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.4\\.\\d+$"))' | sort -V | tail -n3)
+          # Fetch latest 2 MySQL 8.4.x versions
+          MYSQL_8_4=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.4\\.\\d+$"))' | sort -V | tail -n2)
 
-          # Include 8.0.24 as a canary for the minimum bootstrap release, until support is removed
-          VERSIONS=$(echo "8.0.24" "$MYSQL_8_4" | tr ' ' '\n' | jq -Rnc '[inputs]')
+          # Include 8.4.0 as the minimum supported release (minMySqlVersion in api/source/service/utils.js)
+          VERSIONS=$(echo "8.4.0" "$MYSQL_8_4" | tr ' ' '\n' | jq -Rnc '[inputs]')
           echo "version_array=$VERSIONS" >> $GITHUB_OUTPUT
 
   test_api:

--- a/.github/workflows/api-container-tests.yml
+++ b/.github/workflows/api-container-tests.yml
@@ -22,6 +22,8 @@ jobs:
           # Fetch latest 2 MySQL 8.4.x versions
           MYSQL_8_4=$(curl -s "https://registry.hub.docker.com/v2/repositories/library/mysql/tags/?page_size=100" | jq -r '.results[].name | select(test("^8\\.4\\.\\d+$"))' | sort -V | tail -n2)
 
+          if [ -z "$MYSQL_8_4" ]; then echo "No MySQL 8.4.x tags returned from Docker Hub"; exit 1; fi
+
           # Include 8.4.0 as the minimum supported release (minMySqlVersion in api/source/service/utils.js)
           VERSIONS=$(echo "8.4.0" "$MYSQL_8_4" | tr ' ' '\n' | jq -Rnc '[inputs]')
           echo "version_array=$VERSIONS" >> $GITHUB_OUTPUT
@@ -31,6 +33,7 @@ jobs:
     name: ${{ matrix.container.name }} and MySQL ${{ matrix.mysql_version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         container:
             - name: "stig-manager-alpine"

--- a/api/source/package-lock.json
+++ b/api/source/package-lock.json
@@ -26,7 +26,7 @@
         "jszip": "^3.10.1",
         "jwks-rsa": "^3.1.0",
         "multer": "^2.2.0",
-        "mysql2": "^3.11.2",
+        "mysql2": "^3.24.3",
         "net-keepalive": "^4.0.17",
         "on-finished": "^2.4.1",
         "on-headers": "^1.1.0",
@@ -1060,15 +1060,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1168,9 +1159,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1315,9 +1306,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1559,9 +1550,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2073,9 +2064,9 @@
       }
     },
     "node_modules/lru.min": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
-      "integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.5.tgz",
+      "integrity": "sha512-5J9ysMYUpYIg9RF2vJpy9SinEmSviFSe0GyPpCQ4L5QSkLAgeLXlTAOu2ZwWUU5m+0SBl6gUU1R1ZQB3aKypfA==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -2200,29 +2191,30 @@
       }
     },
     "node_modules/mysql2": {
-      "version": "3.15.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
-      "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.24.3.tgz",
+      "integrity": "sha512-OKfWHkMAg9v06neq8FmSyhbxPQKABN9PAW5G9/bDTXzJBO5xXtkKL0V27vju7HQWk9UD4Od5BZsvCtBTB1CPEw==",
       "license": "MIT",
       "dependencies": {
-        "aws-ssl-profiles": "^1.1.1",
-        "denque": "^2.1.0",
+        "aws-ssl-profiles": "^1.1.2",
         "generate-function": "^2.3.1",
-        "iconv-lite": "^0.7.0",
-        "long": "^5.2.1",
-        "lru.min": "^1.0.0",
-        "named-placeholders": "^1.1.3",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.2"
+        "iconv-lite": "^0.7.3",
+        "long": "^5.3.2",
+        "lru.min": "^1.1.4",
+        "named-placeholders": "^1.1.6",
+        "sql-escaper": "^1.5.1"
       },
       "engines": {
         "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
       }
     },
     "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2236,24 +2228,15 @@
       }
     },
     "node_modules/named-placeholders": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
-      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+      "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
       "license": "MIT",
       "dependencies": {
-        "lru-cache": "^7.14.1"
+        "lru.min": "^1.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/named-placeholders/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/negotiator": {
@@ -2439,12 +2422,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2647,11 +2631,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -2701,14 +2680,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2720,13 +2699,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2784,13 +2763,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+    "node_modules/sql-escaper": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
     "node_modules/statuses": {

--- a/api/source/package.json
+++ b/api/source/package.json
@@ -30,7 +30,7 @@
     "jszip": "^3.10.1",
     "jwks-rsa": "^3.1.0",
     "multer": "^2.2.0",
-    "mysql2": "^3.11.2",
+    "mysql2": "^3.24.3",
     "net-keepalive": "^4.0.17",
     "on-finished": "^2.4.1",
     "on-headers": "^1.1.0",
@@ -40,5 +40,8 @@
     "undici": "^6.28.0",
     "ws": "^8.21.0",
     "xlsx-template": "file:utils/xlsx-template-js-zip-upgrade"
+  },
+  "overrides": {
+    "qs": "^6.16.0"
   }
 }

--- a/api/source/service/AssetService.js
+++ b/api/source/service/AssetService.js
@@ -317,9 +317,8 @@ exports.queryChecklist = async function (inPredicates, projections = []) {
 
     const sql = dbUtils.makeQueryString({columns, joins, predicates, groupBy, orderBy}) 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
 
-    let [rows] = await connection.query( sql, predicates.binds )
+    let [rows] = await connection.query({sql, namedPlaceholders: true}, predicates.binds)
     return (rows)
   }
   finally {
@@ -1583,7 +1582,6 @@ exports.updateAsset = async function( {assetId, body, currentCollectionId, trans
     }
 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
     async function transaction () {
       await connection.query('START TRANSACTION')
 

--- a/api/source/service/CollectionService.js
+++ b/api/source/service/CollectionService.js
@@ -458,7 +458,6 @@ exports.addOrUpdateCollection = async function(writeAction, collectionId, body, 
   
     // Connect to MySQL
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
     async function transaction () {
       await connection.query('START TRANSACTION');
 
@@ -473,7 +472,7 @@ exports.addOrUpdateCollection = async function(writeAction, collectionId, body, 
             (name, description, settings, metadata)
           VALUES
             (:name, :description, :settings, :metadata)`
-        let [rows] = await connection.execute(sqlInsert, collectionFields)
+        let [rows] = await connection.execute({sql: sqlInsert, namedPlaceholders: true}, collectionFields)
         collectionId = rows.insertId
       }
       else if (writeAction === dbUtils.WRITE_ACTION.UPDATE || writeAction === dbUtils.WRITE_ACTION.REPLACE) {
@@ -1106,7 +1105,7 @@ exports.deleteReviewHistoryByCollection = async function (collectionId, retentio
     assetId: assetId
   }  
 
-  let [rows] = await dbUtils.pool.query(sql, binds)
+  let [rows] = await dbUtils.pool.query({sql, namedPlaceholders: true}, binds)
   let result = {
     HistoryEntriesDeleted: rows.affectedRows
   }
@@ -1289,7 +1288,7 @@ exports.getReviewHistoryStatsByCollection = async function (collectionId, startD
 
   sql = sql.replace(/additionalPredicates/g, additionalPredicates)
 
-  let [rows] = await dbUtils.pool.query(sql, binds)
+  let [rows] = await dbUtils.pool.query({sql, namedPlaceholders: true}, binds)
   return (rows[0])
 }
 
@@ -1941,7 +1940,6 @@ exports.cloneCollection = async function ({collectionId, userObject, name, descr
     }
 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = false
     connection.query('set @srcCollectionId = ?, @userId = ?, @name = ?, @description = ?', [
       parseInt(collectionId),
       parseInt(userObject.userId),
@@ -2388,7 +2386,6 @@ exports.exportToCollection = async function ({srcCollectionId, dstCollectionId, 
       }
     }
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = false
     connection.query('set @srcCollectionId = ?, @dstCollectionId = ?, @userId = ?, @json = ?',
     [parseInt(srcCollectionId), parseInt(dstCollectionId), parseInt(userObject.userId), JSON.stringify(assetStigArguments)])
     const prepQueries = ['dropArg', 'createArg', 'dropCollectionSetting', 'createCollectionSetting', 'dropSrcReviewId', 'createSrcReviewId']

--- a/api/source/service/ReviewService.js
+++ b/api/source/service/ReviewService.js
@@ -483,7 +483,6 @@ from
   let connection
   try {
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = false
 
     const sqlVariables = `set @collectionId = ?, @userId = ?, @review = ?`
     await connection.query(sqlVariables, [parseInt(collectionId), parseInt(userId), JSON.stringify(source.review)])

--- a/api/source/service/STIGService.js
+++ b/api/source/service/STIGService.js
@@ -489,7 +489,6 @@ exports.insertManualBenchmark = async function (b, clobber, svcStatus = {}) {
     const {ddl, dml} = queriesFromBenchmarkData(b) // defined below
 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
 
     // check if this revision exists
     const [revision] = await connection.query('select revId from revision where `benchmarkId` = ? and `version` = ? and `release` = ?', [
@@ -552,7 +551,7 @@ exports.insertManualBenchmark = async function (b, clobber, svcStatus = {}) {
           ;[result] = await connection.query(dml[query].sql, [dml[query].binds])
         }
         else {
-          ;[result] = await connection.query(dml[query].sql, dml[query].binds)
+          ;[result] = await connection.query({sql: dml[query].sql, namedPlaceholders: true}, dml[query].binds)
         }
         hrend = process.hrtime(hrstart)
         stats[query] = `${result.affectedRows} in ${hrend[0]}s  ${hrend[1] / 1000000}ms`
@@ -937,16 +936,15 @@ exports.deleteRevisionByString = async function(benchmarkId, revisionStr, svcSta
     }
 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
     
     async function transaction () {
       await connection.query('START TRANSACTION')
 
       // note if this is the current revision
-      const [crRows] = await connection.query('SELECT * FROM current_rev WHERE benchmarkId = :benchmarkId and `version` = :version and `release` = :release', binds)
+      const [crRows] = await connection.query({sql: 'SELECT * FROM current_rev WHERE benchmarkId = :benchmarkId and `version` = :version and `release` = :release', namedPlaceholders: true}, binds)
       const wasCurrentRev = !!crRows.length
       // note if this revision is used to calculate stats
-      const [drRows] = await connection.query('SELECT collectionId FROM default_rev WHERE benchmarkId = :benchmarkId and revId = :revId', binds)
+      const [drRows] = await connection.query({sql: 'SELECT collectionId FROM default_rev WHERE benchmarkId = :benchmarkId and revId = :revId', namedPlaceholders: true}, binds)
       const wasDefaultRev = !!drRows.length
 
       // re-materialize current_rev if we're deleting the current revision
@@ -955,7 +953,7 @@ exports.deleteRevisionByString = async function(benchmarkId, revisionStr, svcSta
       }
   
       for (const sql of dmls) {
-       await connection.query(sql, binds)
+       await connection.query({sql, namedPlaceholders: true}, binds)
       }
 
       // re-calculate review statistics and repopulate default_rev from view if we've affected default_rev
@@ -1016,12 +1014,11 @@ exports.deleteStigById = async function(benchmarkId, userObject, svcStatus = {})
     }
 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
     async function transaction () {
       await connection.query('START TRANSACTION')
 
       for (const sql of dmls) {
-        await connection.query(sql, binds)
+        await connection.query({sql, namedPlaceholders: true}, binds)
       }
    
       await dbUtils.updateStatsAssetStig( connection, {benchmarkId})

--- a/api/source/service/UserService.js
+++ b/api/source/service/UserService.js
@@ -150,7 +150,6 @@ exports.addOrUpdateUser = async function (writeAction, userId, body, projection,
     let { collectionGrants, userGroups, ...userFields } = body
 
     connection = await dbUtils.pool.getConnection()
-    connection.config.namedPlaceholders = true
     async function transaction () {
       await connection.query('START TRANSACTION');
 
@@ -165,7 +164,7 @@ exports.addOrUpdateUser = async function (writeAction, userId, body, projection,
               ( username, status )
             VALUES
               (:username, :status )`
-        let [result] = await connection.query(sqlInsert, binds)
+        let [result] = await connection.query({sql: sqlInsert, namedPlaceholders: true}, binds)
         userId = result.insertId
       }
       else if (writeAction === dbUtils.WRITE_ACTION.UPDATE || writeAction === dbUtils.WRITE_ACTION.REPLACE) {
@@ -181,7 +180,7 @@ exports.addOrUpdateUser = async function (writeAction, userId, body, projection,
                 :values
               WHERE
                 userid = :userId`
-          await connection.query(sqlUpdate, binds)
+          await connection.query({sql: sqlUpdate, namedPlaceholders: true}, binds)
         }
       }
       else {

--- a/api/source/service/migrations/0048.js
+++ b/api/source/service/migrations/0048.js
@@ -249,9 +249,9 @@ module.exports = {
     try {
       logger.writeInfo('mysql', 'migration', {status: 'start', direction: 'up', name: migrationName})
       connection = await pool.getConnection()
-      // Defensive: a pool-borrowed connection may have namedPlaceholders left
-      // enabled from a prior service call, which breaks stored-procedure
-      // bodies containing `:label` syntax if a replay ever hits one.
+      // Named placeholders must stay off here so stored-procedure bodies containing
+      // `:label` syntax are not rewritten as placeholders. Since mysql2 3.23.3 each pooled
+      // connection has its own config and services set namedPlaceholders per query, so this is a guard.
       connection.config.namedPlaceholders = false
 
       // Snapshot pre-migration default_rev so we can identify which benchmarks

--- a/api/source/service/migrations/lib/MigrationHandler.js
+++ b/api/source/service/migrations/lib/MigrationHandler.js
@@ -15,8 +15,9 @@ module.exports = class MigrationHandler {
         try {
           logger.writeInfo('mysql', 'migration', {status: 'start', direction: 'up', name: migrationName })
           connection = await pool.getConnection()
-          // Pool connections may have namedPlaceholders enabled by prior callers.
-          // Disable it so MySQL label syntax (e.g. main:BEGIN) isn't parsed as placeholders.
+          // Named placeholders must stay off here so MySQL label syntax (e.g. main:BEGIN)
+          // is not rewritten as a placeholder. Since mysql2 3.23.3 each pooled connection
+          // has its own config and services set namedPlaceholders per query, so this is a guard.
           connection.config.namedPlaceholders = false
           for (const statement of this._upCommands) {
             logger.writeInfo('mysql', 'migration', {status: 'running', name: migrationName, statement })

--- a/api/source/service/utils.js
+++ b/api/source/service/utils.js
@@ -9,7 +9,7 @@ const semverGte = require('semver/functions/gte')
 const semverCoerce = require('semver/functions/coerce')
 const Importer = require('./migrations/lib/mysql-import.js')
 const state = require('../utils/state')
-const minMySqlVersion = '8.0.24'
+const minMySqlVersion = '8.4.0'
 const testedMySqlSeries = '8.4'
 let _this = this
 let initAttempt = 0
@@ -55,28 +55,6 @@ async function getTableCount () {
  */
 function isMinVersion(version) {
   return semverGte(semverCoerce(version), semverCoerce(minMySqlVersion))
-}
-
-/**
- * Checks if the provided MySQL version is from a release series tested with STIG Manager.
- * @param {string} version - The MySQL version to check.
- * @returns {boolean} True if the version is from a tested series, false otherwise.
- */
-function isTestedSeries(version) {
-  return semverGte(semverCoerce(version), semverCoerce(testedMySqlSeries))
-}
-
-/**
- * Logs a warning if the provided MySQL version is not from a tested release series.
- * @param {string} version - The MySQL version.
- */
-function warnUntestedVersion(version) {
-  if (!isTestedSeries(version)) {
-    logger.writeWarn('mysql', 'version', {
-      version,
-      message: `MySQL release ${version} is not tested with STIG Manager and support will be removed in a future release. Update to the latest MySQL ${testedMySqlSeries}.x release.`
-    })
-  }
 }
 
 /**
@@ -249,7 +227,6 @@ async function poolMonitorRetryFn () {
       connection.connection.destroy()
       throw new Error(`MySQL release ${version} is too old. Update to the latest MySQL ${testedMySqlSeries}.x release.`)
     }
-    warnUntestedVersion(version)
     await setupSchema()
     logger.writeInfo('mysql', 'restore', { success: true, version, message: 'pool connection restored' })
   }
@@ -328,7 +305,6 @@ module.exports.initializeDatabase = async function () {
       throw new Error('MySQL release is too old.')
     }
     logger.writeInfo('mysql', 'preflight', {success: true, version })
-    warnUntestedVersion(version)
 
     // Patch the pool to emit a 'remove' event when a connection is removed
     patchRemoveConnection(_this.pool)

--- a/docs/installation-and-setup/db.rst
+++ b/docs/installation-and-setup/db.rst
@@ -20,7 +20,7 @@ The STIG Manager API requires a dedicated MySQL database (equivalent to a schema
 Database - MySQL 8.4.x
 -----------------------------
 
-The STIG Manager API is tested with the latest 3 versions of the MySQL 8.4.x series, and requires MySQL 8.4.0 at minimum.
+The STIG Manager API is tested with MySQL 8.4.0 and the latest 2 versions of the MySQL 8.4.x series, and requires MySQL 8.4.0 at minimum.
 The API will not start when provided with a MySQL release older than 8.4.0. The MySQL 8.0.x series has reached end of life and is not supported. It is strongly recommended you use the latest version of MySQL 8.4.x available.
 
 The API requires knowledge of 1) the DB address/port, 2) which schema (database) is used for STIG Manager, and 3) User credentials with necessary privileges on that schema. `More information about MySQL. <https://dev.mysql.com/doc/>`_

--- a/docs/installation-and-setup/db.rst
+++ b/docs/installation-and-setup/db.rst
@@ -20,8 +20,8 @@ The STIG Manager API requires a dedicated MySQL database (equivalent to a schema
 Database - MySQL 8.4.x
 -----------------------------
 
-The STIG Manager API is tested with the latest 3 versions of the MySQL 8.4.x series, and requires MySQL 8.0.24 at minimum.
-The API will still bootstrap when provided with an 8.0.24+ MySQL database, but the MySQL 8.0.x series has reached end of life and is no longer tested with STIG Manager, and the API logs a warning at startup when the MySQL release is older than 8.4.x. Support for MySQL releases older than 8.4.x is deprecated and will be removed in a future release. It is strongly recommended you use the latest version of MySQL 8.4.x available.
+The STIG Manager API is tested with the latest 3 versions of the MySQL 8.4.x series, and requires MySQL 8.4.0 at minimum.
+The API will not start when provided with a MySQL release older than 8.4.0. The MySQL 8.0.x series has reached end of life and is not supported. It is strongly recommended you use the latest version of MySQL 8.4.x available.
 
 The API requires knowledge of 1) the DB address/port, 2) which schema (database) is used for STIG Manager, and 3) User credentials with necessary privileges on that schema. `More information about MySQL. <https://dev.mysql.com/doc/>`_
 

--- a/docs/installation-and-setup/installation-and-setup.rst
+++ b/docs/installation-and-setup/installation-and-setup.rst
@@ -45,7 +45,7 @@ Every STIG Manager deployment consists of:
 **MySQL Database** (Data Persistence, deployer-provided)
   - Stores all application data
   - Supports TLS and mutual TLS authentication
-  - Version 8.4+ recommended for optimal performance
+  - Version 8.4.0 or later required
   - Deployer responsible for backups and security
 
 .. important::

--- a/docs/the-project/requirements-and-dependencies.rst
+++ b/docs/the-project/requirements-and-dependencies.rst
@@ -13,7 +13,7 @@ Requirements
 Software Requirements
 ------------------------
 - Node.js LTS
-- MySQL 8.4.x (8.0.24 minimum)
+- MySQL 8.4.x (8.4.0 minimum)
 - OIDC Provider (Such as RedHat Keycloak 19+)
 
 

--- a/docs/the-project/requirements-and-dependencies.rst
+++ b/docs/the-project/requirements-and-dependencies.rst
@@ -21,7 +21,7 @@ Tested with:
 
 - Docker 20.10.2
 - NodeJs provided by node:lts-alpine image on Docker Hub
-- MySQL - latest 3 versions of the MySQL 8.4.x series available on Docker Hub.
+- MySQL - 8.4.0 and the latest 2 versions of the MySQL 8.4.x series available on Docker Hub.
 - RedHat Keycloak 19+
 
 .. note::

--- a/test/api/mocha/integration/job.test.js
+++ b/test/api/mocha/integration/job.test.js
@@ -390,7 +390,7 @@ describe('Job endpoint tests', function () {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second between runs to ensure different timestamps
       await runImmediateJob(jobId)
 
-      const runsRes = await utils.executeRequest(`${config.baseUrl}/jobs/${jobId}/runs?elevate=true`, 'GET', user.token)
+      const runsRes = await pollUntil(`${config.baseUrl}/jobs/${jobId}/runs?elevate=true`, res => res.body.length >= 2)
       expect(runsRes.status).to.eql(200)
       expect(runsRes.body).to.be.an('array')
       expect(runsRes.body.length).to.be.at.least(2)
@@ -418,7 +418,7 @@ describe('Job endpoint tests', function () {
 
       const runId = await runImmediateJob(jobId)
 
-      const runRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'GET', user.token)
+      const runRes = await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, res => res.status === 200)
       expect(runRes.status).to.eql(200)
       expect(runRes.body).to.be.an('object')
       expect(runRes.body).to.have.property('runId', runId)
@@ -442,7 +442,7 @@ describe('Job endpoint tests', function () {
       const jobId = createJobRes.body.jobId
 
       const runId = await runImmediateJob(jobId)
-      await new Promise(resolve => setTimeout(resolve, 1000)) // wait a second to ensure run is created before attempting delete
+      await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, res => res.status === 200)
 
       // Now delete the run
       const deleteRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'DELETE', user.token)
@@ -938,17 +938,20 @@ async function deleteTestJobs() {
   }
 }
 
-async function waitForRunFinish(runId, timeoutSeconds = 30) {
-  let attempts = 0
-  await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second before checking again
-  while (attempts < timeoutSeconds) {
-    const runRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'GET', user.token)
-    expect(runRes.status).to.eql(200)
-    if (['completed', 'failed'].includes(runRes.body.state)) {
-      return runRes.body.state
-    }
-    await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second before checking again
-    attempts++
+// Job runs are created and advanced asynchronously by the MySQL event scheduler.
+// Polls `url` once per second until `done(res)` is truthy or timeoutSeconds elapses; returns the last response.
+async function pollUntil(url, done, timeoutSeconds = 30) {
+  let res
+  for (let attempts = 0; attempts < timeoutSeconds; attempts++) {
+    res = await utils.executeRequest(url, 'GET', user.token)
+    if (done(res)) break
+    await new Promise(resolve => setTimeout(resolve, 1000))
   }
-  return 'timeout'
+  return res
+}
+
+async function waitForRunFinish(runId, timeoutSeconds = 30) {
+  const isFinished = res => res.status === 200 && ['completed', 'failed'].includes(res.body.state)
+  const runRes = await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, isFinished, timeoutSeconds)
+  return isFinished(runRes) ? runRes.body.state : 'timeout'
 }

--- a/test/api/mocha/integration/job.test.js
+++ b/test/api/mocha/integration/job.test.js
@@ -390,7 +390,7 @@ describe('Job endpoint tests', function () {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second between runs to ensure different timestamps
       await runImmediateJob(jobId)
 
-      const runsRes = await pollUntil(`${config.baseUrl}/jobs/${jobId}/runs?elevate=true`, res => res.body.length >= 2)
+      const runsRes = await utils.executeRequest(`${config.baseUrl}/jobs/${jobId}/runs?elevate=true`, 'GET', user.token)
       expect(runsRes.status).to.eql(200)
       expect(runsRes.body).to.be.an('array')
       expect(runsRes.body.length).to.be.at.least(2)
@@ -418,7 +418,7 @@ describe('Job endpoint tests', function () {
 
       const runId = await runImmediateJob(jobId)
 
-      const runRes = await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, res => res.status === 200)
+      const runRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'GET', user.token)
       expect(runRes.status).to.eql(200)
       expect(runRes.body).to.be.an('object')
       expect(runRes.body).to.have.property('runId', runId)
@@ -442,7 +442,7 @@ describe('Job endpoint tests', function () {
       const jobId = createJobRes.body.jobId
 
       const runId = await runImmediateJob(jobId)
-      await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, res => res.status === 200)
+      await new Promise(resolve => setTimeout(resolve, 1000)) // wait a second to ensure run is created before attempting delete
 
       // Now delete the run
       const deleteRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'DELETE', user.token)
@@ -938,20 +938,17 @@ async function deleteTestJobs() {
   }
 }
 
-// Job runs are created and advanced asynchronously by the MySQL event scheduler.
-// Polls `url` once per second until `done(res)` is truthy or timeoutSeconds elapses; returns the last response.
-async function pollUntil(url, done, timeoutSeconds = 30) {
-  let res
-  for (let attempts = 0; attempts < timeoutSeconds; attempts++) {
-    res = await utils.executeRequest(url, 'GET', user.token)
-    if (done(res)) break
-    await new Promise(resolve => setTimeout(resolve, 1000))
-  }
-  return res
-}
-
 async function waitForRunFinish(runId, timeoutSeconds = 30) {
-  const isFinished = res => res.status === 200 && ['completed', 'failed'].includes(res.body.state)
-  const runRes = await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, isFinished, timeoutSeconds)
-  return isFinished(runRes) ? runRes.body.state : 'timeout'
+  let attempts = 0
+  await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second before checking again
+  while (attempts < timeoutSeconds) {
+    const runRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'GET', user.token)
+    expect(runRes.status).to.eql(200)
+    if (['completed', 'failed'].includes(runRes.body.state)) {
+      return runRes.body.state
+    }
+    await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second before checking again
+    attempts++
+  }
+  return 'timeout'
 }

--- a/test/api/mocha/integration/logStream.test.js
+++ b/test/api/mocha/integration/logStream.test.js
@@ -123,14 +123,18 @@ describe('LogStream authorization', async function () {
     expect(socket.messages).to.have.lengthOf(1);
     expect(socket.messages[0]).to.have.property('type', 'authorize');
 
-    const token = oidc.getToken({ sub: 'test-user', privileges: ['admin'], expiresIn: 1 })
+    // exp has one-second resolution (exp = floor(now) + expiresIn), so expiresIn: 2 guarantees at least 1s of validity
+    const token = oidc.getToken({ sub: 'test-user', privileges: ['admin'], expiresIn: 2 })
     socket.ws.send(JSON.stringify({ type: 'authorize', data: { token } }));
     await new Promise(r => setTimeout(r, 500));
     expect(socket.messages).to.have.lengthOf(2);
     expect(socket.messages[1]).to.have.property('type', 'authorize');
     expect(socket.messages[1].data).to.have.property('state', 'authorized');
 
-    await new Promise(r => setTimeout(r, 2000)); // wait for token to expire
+    // wait for token to expire
+    for (let i = 0; i < 30 && socket.messages.length < 3; i++) {
+      await new Promise(r => setTimeout(r, 100));
+    }
     expect(socket.messages).to.have.lengthOf(3);
     expect(socket.messages[2]).to.have.property('type', 'authorize');
     expect(socket.messages[2].data).to.have.property('state', 'unauthorized');

--- a/test/api/mocha/integration/logStream.test.js
+++ b/test/api/mocha/integration/logStream.test.js
@@ -123,18 +123,14 @@ describe('LogStream authorization', async function () {
     expect(socket.messages).to.have.lengthOf(1);
     expect(socket.messages[0]).to.have.property('type', 'authorize');
 
-    // exp has one-second resolution (exp = floor(now) + expiresIn), so expiresIn: 2 guarantees at least 1s of validity
-    const token = oidc.getToken({ sub: 'test-user', privileges: ['admin'], expiresIn: 2 })
+    const token = oidc.getToken({ sub: 'test-user', privileges: ['admin'], expiresIn: 1 })
     socket.ws.send(JSON.stringify({ type: 'authorize', data: { token } }));
     await new Promise(r => setTimeout(r, 500));
     expect(socket.messages).to.have.lengthOf(2);
     expect(socket.messages[1]).to.have.property('type', 'authorize');
     expect(socket.messages[1].data).to.have.property('state', 'authorized');
 
-    // wait for token to expire
-    for (let i = 0; i < 30 && socket.messages.length < 3; i++) {
-      await new Promise(r => setTimeout(r, 100));
-    }
+    await new Promise(r => setTimeout(r, 2000)); // wait for token to expire
     expect(socket.messages).to.have.lengthOf(3);
     expect(socket.messages[2]).to.have.property('type', 'authorize');
     expect(socket.messages[2].data).to.have.property('state', 'unauthorized');

--- a/test/state/mocha/bootstrap.test.js
+++ b/test/state/mocha/bootstrap.test.js
@@ -177,7 +177,7 @@ describe('Boot with old mysql', function () {
     this.timeout(60000)
     oidc = new MockOidc({keyCount: 1, includeInsecureKid: false})
     await oidc.start({port: oidcPort})
-    mysql = await spawnMySQL({tag:'8.0.23', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
     api = await spawnApiPromise({
       resolveOnClose: true,
       env:{
@@ -208,7 +208,7 @@ describe('Boot with old mysql', function () {
     it('db, check message', function () {
       const failures = api.logRecords.filter(r => r.type === 'preflight' && r.component === 'mysql' && r.data.success === false)
       expect(failures).to.have.lengthOf(1)
-      expect(failures[0].data.message).to.equal('MySQL release 8.0.23 is too old. Update to the latest MySQL 8.4.x release.')
+      expect(failures[0].data.message).to.equal('MySQL release 8.0.24 is too old. Update to the latest MySQL 8.4.x release.')
     })
   })
 

--- a/test/state/mocha/bootstrap.test.js
+++ b/test/state/mocha/bootstrap.test.js
@@ -97,7 +97,7 @@ describe('Boot with both dependencies', function () {
     await oidc.start({port: oidcPort})
     console.log('    ✔ oidc started')
     console.log('    try mysql start')
-    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port:dbPort})
     console.log('    ✔ mysql started')
     console.log('    try api start')
     api = await spawnApiPromise({
@@ -228,7 +228,7 @@ describe('Boot with old mysql', function () {
   })
 })
 
-describe('Boot with untested mysql', function () {
+describe('Boot with minimum supported mysql', function () {
   let api
   let mysql
   let oidc
@@ -237,7 +237,7 @@ describe('Boot with untested mysql', function () {
     this.timeout(60000)
     oidc = new MockOidc({keyCount: 1, includeInsecureKid: false})
     await oidc.start({port: oidcPort})
-    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.4.0', port:dbPort})
     api = await spawnApiPromise({
       resolveOnType: 'started',
       env:{
@@ -256,14 +256,6 @@ describe('Boot with untested mysql', function () {
     if (mysql) await mysql.stop().catch(() => {})
     if (oidc) await oidc.stop().catch(() => {})
     if (api) addContext(this, {title: 'api-log', value: api.logRecords})
-  })
-
-  describe('untested version warning', function () {
-    it('db, check message', function () {
-      const warnings = api.logRecords.filter(r => r.type === 'version' && r.component === 'mysql')
-      expect(warnings).to.have.lengthOf(1)
-      expect(warnings[0].data.message).to.equal('MySQL release 8.0.24 is not tested with STIG Manager and support will be removed in a future release. Update to the latest MySQL 8.4.x release.')
-    })
   })
 
   describe('dependency success count', function () {
@@ -291,7 +283,7 @@ describe('Boot with insecure kid - allow insecure tokens false', function () {
     this.timeout(60000)
     oidc = new MockOidc({keyCount: 0, includeInsecureKid: true})
     await oidc.start({port: oidcPort})
-    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port:dbPort})
     api = await spawnApiPromise({
       resolveOnClose: true,
       env: {
@@ -355,7 +347,7 @@ describe('Boot without insecure kid - request with insecure token' , function ()
     insecureToken = oidc.getToken({username: 'insecure'})
     oidc.rotateKeys({keyCount: 1, includeInsecureKid: false})
     await oidc.start({port: oidcPort})
-    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port:dbPort})
     api = await spawnApiPromise({
       resolveOnType: 'started',
       env: {
@@ -416,7 +408,7 @@ describe('Boot with STIGMAN_JWKS_CACHE_MAX_AGE out of range', function () {
     this.timeout(60000)
     oidc = new MockOidc({keyCount: 1, includeInsecureKid: false})
     await oidc.start({port: oidcPort})
-    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port:dbPort})
   })
 
   after(async function () {

--- a/test/state/mocha/db.test.js
+++ b/test/state/mocha/db.test.js
@@ -18,7 +18,7 @@ describe('DB outage: shutdown', function () {
     await oidc.start({port: oidcPort})
     console.log('    ✔ oidc started')
     console.log('    try mysql start')
-    mysql = await spawnMySQL({tag:'8.0.24', port:dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port:dbPort})
     console.log('    ✔ mysql started')
     console.log('    try api start')
     api = await spawnApiPromise({
@@ -85,7 +85,7 @@ describe('DB outage: shutdown', function () {
       this.timeout(30000)
       console.log('      try mysql restart')
       logMark = api.logRecords.length
-      mysql = await spawnMySQL({tag: '8.0.24', port: dbPort})
+      mysql = await spawnMySQL({tag: '8.4', port: dbPort})
       console.log('      ✔ mysql restarted')
     })
 
@@ -115,7 +115,7 @@ describe('DB outage: network/host down', function () {
     await oidc.start({port: oidcPort})
     console.log('    ✔ oidc started')
     console.log('    try mysql start')
-    mysql = await spawnMySQL({tag:'8.0.24', port: dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port: dbPort})
     console.log('    ✔ mysql started')
     console.log('    try api start')
     api = await spawnApiPromise({

--- a/test/state/mocha/jwks.test.js
+++ b/test/state/mocha/jwks.test.js
@@ -24,7 +24,7 @@ describe('JWKS Tests', function () {
     await oidc.start({port: oidcPort})
     console.log('    ✔ oidc started')
     console.log('    try mysql start')
-    mysql = await spawnMySQL({tag:'8.0.24', port: dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port: dbPort})
     console.log('    ✔ mysql started')
     console.log('    try api start')
     api = await spawnApiPromise({

--- a/test/state/mocha/lib.js
+++ b/test/state/mocha/lib.js
@@ -217,13 +217,13 @@ export async function bearerRequest({url, method, token}) {
  * Spawns a MySQL container.
  * Returns a promise that resolves when the MySQL container is ready for connections.
  * @param {Object} options - Options for spawning the MySQL container.
- * @param {string} [options.tag='8.0.24'] - The MySQL image tag to use.
+ * @param {string} [options.tag='8.4'] - The MySQL image tag to use.
  * @param {string} [options.port='3306'] - The port to map to the MySQL container.
  * @param {number} [options.readyCount=2] - The number of "ready for connections" messages to wait for.
  * @returns {Promise<ChildProcess>} A promise that resolves with the MySQL container process.
  */
 export function spawnMySQL ({
-  tag = '8.0.24', 
+  tag = '8.4', 
   port = '3306',
   readyCount = 2
 } = {}) {

--- a/test/state/mocha/oidc.test.js
+++ b/test/state/mocha/oidc.test.js
@@ -18,7 +18,7 @@ describe('OIDC state', function () {
     await oidc.start({port: oidcPort})
     console.log('    ✔ oidc started')
     console.log('    try mysql start')
-    mysql = await spawnMySQL({tag:'8.0.24', port: dbPort})
+    mysql = await spawnMySQL({tag:'8.4', port: dbPort})
     console.log('    ✔ mysql started')
     console.log('    try api start')
     api = await spawnApiPromise({

--- a/test/state/mocha/tokenValidation.test.js
+++ b/test/state/mocha/tokenValidation.test.js
@@ -20,7 +20,7 @@ describe('Token validation', function () {
       await oidc.start({port: oidcPort})
       console.log('    ✔ oidc started')
       console.log('    try mysql start')
-      mysql = await spawnMySQL({tag:'8.0.24', port: dbPort})
+      mysql = await spawnMySQL({tag:'8.4', port: dbPort})
       console.log('    ✔ mysql started')
       console.log('    try api start')
       api = await spawnApiPromise({
@@ -120,7 +120,7 @@ describe('Token validation', function () {
       await oidc.start({port: oidcPort})
       console.log('    ✔ oidc started')
       console.log('    try mysql start')
-      mysql = await spawnMySQL({tag:'8.0.24', port: dbPort})
+      mysql = await spawnMySQL({tag:'8.4', port: dbPort})
       console.log('    ✔ mysql started')
       console.log('    try api start')
       api = await spawnApiPromise({


### PR DESCRIPTION
## Summary

Updates `mysql2` (3.15.3 → 3.24.3), `fast-uri` (→ 3.1.7), and `qs` (→ 6.16.0 via `overrides`) to clear the open dependabot alerts, and raises the minimum supported MySQL to **8.4.0**, both enforced at API startup and tested in CI.

## Why 8.4.0

`mysql2` 3.21+ enables `CLIENT_QUERY_ATTRIBUTES` by default. MySQL 8.0.23–8.0.25 misread the resulting `COM_STMT_EXECUTE` flags and open a server cursor, so every prepared-statement SELECT hangs (fixed in 8.0.26). MySQL 8.0 leaves premier support in 2026-04, so rather than work around it the floor moves to 8.4.0.

## Changes

- **API**: `minMySqlVersion` is `8.4.0`; startup refuses older releases with a clear message. Removed the "untested version" warning path.
- **Named placeholders**: `mysql2` 3.23.3 gives each pooled connection its own config, so the old pattern of toggling `connection.config.namedPlaceholders` no longer carries across queries. All service call sites now pass `{ sql, namedPlaceholders: true }` per query. Migration code keeps the option off so `label:` syntax in procedures is not rewritten.
- **CI**: matrix is 8.4.0 plus the two latest 8.4.x tags on Docker Hub, `fail-fast: false`, and the job fails if no tags are returned.
- **State tests**: boot tests use 8.4; the old-version test boots 8.0.24 and expects rejection.
- **Docs**: 8.4.0 minimum and tested-version wording.

