### PR TITLE
feat(tests): Stabilizes two integration test files that depend on asynchronous server behavior.

### DIFF
--- a/test/api/mocha/integration/job.test.js
+++ b/test/api/mocha/integration/job.test.js
@@ -390,7 +390,7 @@ describe('Job endpoint tests', function () {
       await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second between runs to ensure different timestamps
       await runImmediateJob(jobId)
 
-      const runsRes = await utils.executeRequest(`${config.baseUrl}/jobs/${jobId}/runs?elevate=true`, 'GET', user.token)
+      const runsRes = await pollUntil(`${config.baseUrl}/jobs/${jobId}/runs?elevate=true`, res => res.body.length >= 2)
       expect(runsRes.status).to.eql(200)
       expect(runsRes.body).to.be.an('array')
       expect(runsRes.body.length).to.be.at.least(2)
@@ -409,6 +409,7 @@ describe('Job endpoint tests', function () {
 
   describe('GET - getRunById - /jobs/runs/{runId}', function () {
     it('should get a specific run by ID', async function () {
+      this.timeout(60_000)
       const createJobRes = await utils.executeRequest(`${config.baseUrl}/jobs?elevate=true`, 'POST', user.token, {
         name: "Test Job to Get Specific Run",
         tasks: ["1"],
@@ -418,7 +419,7 @@ describe('Job endpoint tests', function () {
 
       const runId = await runImmediateJob(jobId)
 
-      const runRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'GET', user.token)
+      const runRes = await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, res => res.status === 200)
       expect(runRes.status).to.eql(200)
       expect(runRes.body).to.be.an('object')
       expect(runRes.body).to.have.property('runId', runId)
@@ -434,6 +435,7 @@ describe('Job endpoint tests', function () {
 
   describe('DELETE - deleteRunById - /jobs/runs/{runId}', function () {
     it('should delete a specific run by ID', async function () {
+      this.timeout(60_000)
       const createJobRes = await utils.executeRequest(`${config.baseUrl}/jobs?elevate=true`, 'POST', user.token, {
         name: "Test Job to Delete Specific Run",
         tasks: ["1"],
@@ -442,7 +444,8 @@ describe('Job endpoint tests', function () {
       const jobId = createJobRes.body.jobId
 
       const runId = await runImmediateJob(jobId)
-      await new Promise(resolve => setTimeout(resolve, 1000)) // wait a second to ensure run is created before attempting delete
+      // wait for the run to finish so the delete does not race the still-executing run_job procedure
+      await waitForRunFinish(runId)
 
       // Now delete the run
       const deleteRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'DELETE', user.token)
@@ -461,6 +464,7 @@ describe('Job endpoint tests', function () {
 }) 
 
 describe('Task tests', function () {
+  this.timeout(60_000)
   beforeEach(async function () {
       await utils.loadAppData()
   })
@@ -938,17 +942,23 @@ async function deleteTestJobs() {
   }
 }
 
-async function waitForRunFinish(runId, timeoutSeconds = 30) {
-  let attempts = 0
-  await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second before checking again
-  while (attempts < timeoutSeconds) {
-    const runRes = await utils.executeRequest(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, 'GET', user.token)
-    expect(runRes.status).to.eql(200)
-    if (['completed', 'failed'].includes(runRes.body.state)) {
-      return runRes.body.state
+// Job runs are created and advanced asynchronously by the MySQL event scheduler.
+// Polls `url` once per second until `done(res)` is truthy and returns that response.
+// Throws if timeoutSeconds elapses first, reporting the last response.
+async function pollUntil(url, done, timeoutSeconds = 30) {
+  const deadline = Date.now() + timeoutSeconds * 1000
+  for (;;) {
+    const res = await utils.executeRequest(url, 'GET', user.token)
+    if (done(res)) return res
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutSeconds}s polling ${url}; last response ${res.status} ${JSON.stringify(res.body)}`)
     }
-    await new Promise(resolve => setTimeout(resolve, 1000)) // wait 1 second before checking again
-    attempts++
+    await utils.wait(1000)
   }
-  return 'timeout'
+}
+
+async function waitForRunFinish(runId, timeoutSeconds = 30) {
+  const isFinished = res => res.status === 200 && ['completed', 'failed'].includes(res.body.state)
+  const runRes = await pollUntil(`${config.baseUrl}/jobs/runs/${runId}?elevate=true`, isFinished, timeoutSeconds)
+  return runRes.body.state
 }

--- a/test/api/mocha/integration/logStream.test.js
+++ b/test/api/mocha/integration/logStream.test.js
@@ -2,6 +2,7 @@
 import MockOidc from '../../../utils/mockOidc.js'
 import WebSocket from 'ws';
 import { expect } from 'chai'
+import { config } from '../testConfig.js'
 
 const oidc = new MockOidc({ keyCount: 0, includeInsecureKid: true })
 
@@ -118,19 +119,24 @@ describe('LogStream authorization', async function () {
   });
 
   it('should error when token expires', async function () {
+    this.timeout(10000);
     const socket = await openSocket()
     await new Promise(r => setTimeout(r, 500)); // wait for socket to be ready
     expect(socket.messages).to.have.lengthOf(1);
     expect(socket.messages[0]).to.have.property('type', 'authorize');
 
-    const token = oidc.getToken({ sub: 'test-user', privileges: ['admin'], expiresIn: 1 })
+    // exp has one-second resolution (exp = floor(now) + expiresIn), so expiresIn: 2 guarantees at least 1s of validity
+    const token = oidc.getToken({ sub: 'test-user', privileges: ['admin'], expiresIn: 2 })
     socket.ws.send(JSON.stringify({ type: 'authorize', data: { token } }));
     await new Promise(r => setTimeout(r, 500));
     expect(socket.messages).to.have.lengthOf(2);
     expect(socket.messages[1]).to.have.property('type', 'authorize');
     expect(socket.messages[1].data).to.have.property('state', 'authorized');
 
-    await new Promise(r => setTimeout(r, 2000)); // wait for token to expire
+    // wait for token to expire
+    for (let i = 0; i < 30 && socket.messages.length < 3; i++) {
+      await new Promise(r => setTimeout(r, 100));
+    }
     expect(socket.messages).to.have.lengthOf(3);
     expect(socket.messages[2]).to.have.property('type', 'authorize');
     expect(socket.messages[2].data).to.have.property('state', 'unauthorized');
@@ -193,7 +199,7 @@ describe('LogStream authorization', async function () {
 
 async function openSocket() {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket('ws://localhost:64001/socket/log-socket')
+    const ws = new WebSocket(`ws://${new URL(config.baseUrl).host}/socket/log-socket`)
     const resolution = {
       ws,
       messages: [],

--- a/test/api/package.json
+++ b/test/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "testing",
   "scripts": {
-    "test": "mocha --reporter mochawesome --timeout 10000 --showFailed --exit './mocha/**/*.test.js'",
+    "test": "mocha --reporter mochawesome --timeout 15000 --showFailed --exit './mocha/**/*.test.js'",
     "update-appdata": "node ../utils/appdata-update.mjs"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary

Stabilizes two integration test files that depend on asynchronous server behavior.

### job.test.js
- Job runs are created and advanced by the MySQL event scheduler, so a GET immediately after `POST /jobs/{jobId}/runs` can miss the run row. Adds `pollUntil(url, done, timeoutSeconds)`, which polls once per second and throws on timeout with the last status and body.
- `waitForRunFinish` is rebuilt on `pollUntil` and returns the terminal state directly.
- The delete-run test waits for a terminal state before issuing the DELETE, so it no longer races the still-executing `run_job` procedure.
- The two polling tests and the Task tests describe set a 60s timeout, since CI runs mocha with a 10s default.

### logStream.test.js
- Token `exp` has one-second resolution, so `expiresIn: 1` could yield a token that is already expired on arrival. Uses `expiresIn: 2` and polls for the unauthorized message instead of a fixed sleep.
- The expiry test gets the same 10s budget as its sibling.
- `openSocket()` derives the socket host from the configured base URL instead of a hardcoded port 64001.

### Verification
Both files run green against a fresh MySQL 8.4.10 and throwaway API. Addresses the two job test failures seen in the post-merge run of #2159.
