### PR TITLE
New client findings filters review

### DIFF
--- a/clientV2/docs/todos/dashboards.md
+++ b/clientV2/docs/todos/dashboards.md
@@ -84,4 +84,4 @@ These manifest across the assets/STIGs grids in both dashes and the Collection v
 
 ## See also
 
-- API gap that would back a cross-collection asset search in the meta-dash: `pending-api-enhancements.md` #4.
+- API gap that would back a cross-collection asset search in the meta-dash: `pending-api-enhancements.md` #2.

--- a/clientV2/docs/todos/findings-review.md
+++ b/clientV2/docs/todos/findings-review.md
@@ -11,11 +11,3 @@ Originated from the branch review of `new-client-findings-individual-row-tests` 
   "CAT 1/2/3") has no `white-space: nowrap`, and `.agg-grid-panel__totals` (`margin-left: auto`,
   no min-width) lets the pills shrink, so the label breaks. Keep each pill one line —
   `white-space: nowrap` on the label and/or `flex-shrink: 0` on `.header-cat-pill`.
-
-## Behavior / UX (decide, then do or close)
-
-- [ ] **Label-filter inconsistency hint.** Only the STIG summary metrics honor the
-  label filter; findings/reviews panes do not (server-side gap — see
-  `clientV2/docs/todos/pending-api-enhancements.md` #1/#2). Until the API catches up,
-  consider a small UI hint in the panes so users understand why counts disagree with
-  the header.

--- a/clientV2/docs/todos/pending-api-enhancements.md
+++ b/clientV2/docs/todos/pending-api-enhancements.md
@@ -2,7 +2,7 @@
 
 Tracks API gaps blocking — or partially compromising — clientV2 features. Each entry describes the endpoint(s) involved, the feature that needs the change, the current limitation, and a proposed shape for the enhancement. Add to the list as you encounter new gaps.
 
-These are **server-side** changes — the OpenAPI spec, the service layer, and the underlying SQL all need to be updated. The clientV2 code has `TODO`-style comments at the affected call sites that reference this document.
+These are **server-side** changes — the OpenAPI spec, the service layer, and the underlying SQL all need to be updated. When a gap has a client call site, leave a `TODO`-style comment there that references this document so the two can be reconciled when the API catches up.
 
 ---
 
@@ -118,3 +118,22 @@ Keying the path on `ruleId` (not `version`) matches what the client already hold
 ### Notes
 
 The STIG Library's revision diff ([`useRevisionDiff`](../../src/features/STIGLibrary/composables/useRevisionDiff.js)) already joins revisions by `rule.version` client-side — same mapping, so the server and client agree on what "same rule" means. `groupId` alone is not sufficient (DISA's group renumbering makes it less stable than the STIG ID) but could serve as a fallback when `version` is absent. Diff rendering itself stays client-side; the endpoint only needs to supply the per-revision text.
+
+---
+
+## 4. Label filtering on POA&M export (not a priority)
+
+**Operations:** `getPoamByCollection`
+**Feature:** Findings — POA&M export (`PoamExport.vue`)
+
+### Current behavior
+
+The endpoint accepts `aggregator`, `acceptedOnly`, `benchmarkId`, `assetId`, and the format/date/status fields. **No label parameters.** The controller calls `CollectionService.getFindingsByCollection` without `labelIds`/`labelNames`/`labelMatch`, even though the service accepts them (the findings and reviews endpoints already expose them).
+
+### Why it matters
+
+The Findings grid honors the orchestrator-level label filter, but the POA&M generated from that grid is always collection-wide. A user who narrows to a label, sees N rows, and exports gets a workbook covering every asset in the collection, with no hint that the scopes differ. The legacy client has no label filter on its Findings panel, so this is a clientV2-only inconsistency rather than a regression.
+
+### Proposed shape
+
+Add `LabelIdQuery` / `LabelNameQuery` / `LabelMatchQuery` to `getPoamByCollection` and pass them through the controller to `getFindingsByCollection`. Client side, thread the same label params `useFindings` builds into `downloadPoam`. `AssetIdQuery` on this endpoint is single-valued, so a client-side labelIds → assetIds pre-resolution does not generalize.

--- a/clientV2/src/features/CollectionView/api/collectionApi.js
+++ b/clientV2/src/features/CollectionView/api/collectionApi.js
@@ -4,11 +4,11 @@ export { fetchAssetStigs } from '../../../shared/api/assetsApi.js'
 export { fetchCollection, fetchCollectionLabels } from '../../../shared/api/collectionsApi.js'
 export { fetchStigRevisions } from '../../../shared/api/stigsApi.js'
 
-export function fetchCollectionStigSummary(collectionId, params = {}) {
+export function fetchCollectionStigSummary(collectionId, params = {}, opts = {}) {
   if (!collectionId) {
     throw new Error('A collectionId is required to fetch STIG metrics.')
   }
-  return apiCall('getMetricsSummaryByCollectionAggStig', { collectionId, ...params })
+  return apiCall('getMetricsSummaryByCollectionAggStig', { collectionId, ...params }, undefined, opts)
 }
 
 export function fetchCollectionLabelSummary(collectionId, params = {}) {

--- a/clientV2/src/features/CollectionView/components/CollectionView.vue
+++ b/clientV2/src/features/CollectionView/components/CollectionView.vue
@@ -131,13 +131,20 @@ watch(isManagement, () => {
   }, 300)
 })
 
+// Orchestrator-level label filter shared by the dashboard sidebar and every tab.
+const selectedLabelIds = ref([])
+
 // Lazy-mount tab panels: only render a tab's content after it has been visited.
 // Reset on collection switch so tabs visited in a prior collection don't mount
-// (and fetch) unvisited in the new one.
+// (and fetch) unvisited in the new one. The label filter is reset alongside:
+// label IDs are collection-scoped, and this ref outlives the `v-if="collection"`
+// remount, so without the reset the new collection would be queried with the
+// old collection's labels (empty panes, lingering clear icon in MetricsFilter).
 const visitedTabs = ref(new Set([activeTab.value]))
 watch(activeTab, tab => visitedTabs.value.add(tab))
 watch(() => props.collectionId, () => {
   visitedTabs.value = new Set([activeTab.value])
+  selectedLabelIds.value = []
 })
 
 const tabsPt = {
@@ -175,7 +182,6 @@ const tabPanelPt = {
 // Dashboard sidebar state (collapsed/expanded)
 const DASHBOARD_STORAGE_KEY = 'stigman:collectionDashboardCollapsed'
 const dashboardCollapsed = ref(localStorage.getItem(DASHBOARD_STORAGE_KEY) === 'true')
-const selectedLabelIds = ref([])
 const isAnimating = ref(false)
 const refreshKey = ref(0)
 

--- a/clientV2/src/features/Findings/api/findingsApi.js
+++ b/clientV2/src/features/Findings/api/findingsApi.js
@@ -6,7 +6,9 @@ export { fetchCollectionStigSummary } from '../../CollectionView/api/collectionA
 
 // labelParams: label filter params ({ labelId, labelMatch }) built by
 // buildLabelFilterParams; {} when no filter is active.
-export function fetchFindings(collectionId, { aggregator, benchmarkId, projection = ['stigs'], labelParams = {} } = {}) {
+// opts: fetch options forwarded to apiCall (e.g. { signal } from useAsyncState,
+// so a superseded request is aborted instead of running to completion).
+export function fetchFindings(collectionId, { aggregator, benchmarkId, projection = ['stigs'], labelParams = {} } = {}, opts = {}) {
   if (!collectionId) {
     throw new Error('A collectionId is required to fetch findings.')
   }
@@ -17,7 +19,7 @@ export function fetchFindings(collectionId, { aggregator, benchmarkId, projectio
   if (benchmarkId) {
     params.benchmarkId = benchmarkId
   }
-  return apiCall('getFindingsByCollection', params)
+  return apiCall('getFindingsByCollection', params, undefined, opts)
 }
 
 // POA&M/eMASS (or MCCAST) spreadsheet; we just stream the response and save it.
@@ -55,7 +57,7 @@ export async function downloadPoam(collectionId, params = {}) {
 // Returns the failed review records that back a single aggregated finding —
 // the user clicks an aggregated row in the middle pane, we fetch the per-asset
 // reviews for that row's dimension value here.
-export function fetchFailedReviews(collectionId, { aggregator, aggregatorValue, projection = ['stigs'], labelParams = {} } = {}) {
+export function fetchFailedReviews(collectionId, { aggregator, aggregatorValue, projection = ['stigs'], labelParams = {} } = {}, opts = {}) {
   if (!collectionId) {
     throw new Error('A collectionId is required to fetch reviews.')
   }
@@ -69,5 +71,5 @@ export function fetchFailedReviews(collectionId, { aggregator, aggregatorValue, 
     [aggregator]: aggregatorValue,
     ...labelParams,
   }
-  return apiCall('getReviewsByCollection', params)
+  return apiCall('getReviewsByCollection', params, undefined, opts)
 }

--- a/clientV2/src/features/Findings/api/findingsApi.js
+++ b/clientV2/src/features/Findings/api/findingsApi.js
@@ -4,22 +4,23 @@ import { filenameFromContentDisposition } from '../../../shared/lib/contentDispo
 
 export { fetchCollectionStigSummary } from '../../CollectionView/api/collectionApi.js'
 
-// labelParams: label filter params ({ labelId, labelMatch }) built by
-// buildLabelFilterParams; {} when no filter is active.
+// Any extra keys (e.g. labelId/labelMatch from buildLabelFilterParams) pass
+// through as query params, matching the flat-params convention of the other
+// API wrappers.
 // opts: fetch options forwarded to apiCall (e.g. { signal } from useAsyncState,
 // so a superseded request is aborted instead of running to completion).
-export function fetchFindings(collectionId, { aggregator, benchmarkId, projection = ['stigs'], labelParams = {} } = {}, opts = {}) {
+export function fetchFindings(collectionId, { aggregator, benchmarkId, projection = ['stigs'], ...params } = {}, opts = {}) {
   if (!collectionId) {
     throw new Error('A collectionId is required to fetch findings.')
   }
   if (!aggregator) {
     throw new Error('An aggregator is required to fetch findings.')
   }
-  const params = { collectionId, aggregator, projection, ...labelParams }
+  const query = { ...params, collectionId, aggregator, projection }
   if (benchmarkId) {
-    params.benchmarkId = benchmarkId
+    query.benchmarkId = benchmarkId
   }
-  return apiCall('getFindingsByCollection', params, undefined, opts)
+  return apiCall('getFindingsByCollection', query, undefined, opts)
 }
 
 // POA&M/eMASS (or MCCAST) spreadsheet; we just stream the response and save it.
@@ -57,19 +58,19 @@ export async function downloadPoam(collectionId, params = {}) {
 // Returns the failed review records that back a single aggregated finding —
 // the user clicks an aggregated row in the middle pane, we fetch the per-asset
 // reviews for that row's dimension value here.
-export function fetchFailedReviews(collectionId, { aggregator, aggregatorValue, projection = ['stigs'], labelParams = {} } = {}, opts = {}) {
+export function fetchFailedReviews(collectionId, { aggregator, aggregatorValue, projection = ['stigs'], ...params } = {}, opts = {}) {
   if (!collectionId) {
     throw new Error('A collectionId is required to fetch reviews.')
   }
   if (!aggregator || !aggregatorValue) {
     throw new Error('An aggregator and aggregatorValue are required to fetch failed reviews.')
   }
-  const params = {
+  const query = {
+    ...params,
     collectionId,
     result: 'fail',
     projection,
     [aggregator]: aggregatorValue,
-    ...labelParams,
   }
-  return apiCall('getReviewsByCollection', params, undefined, opts)
+  return apiCall('getReviewsByCollection', query, undefined, opts)
 }

--- a/clientV2/src/features/Findings/composables/useCollectionStigSummary.js
+++ b/clientV2/src/features/Findings/composables/useCollectionStigSummary.js
@@ -6,14 +6,14 @@ import { fetchCollectionStigSummary } from '../api/findingsApi.js'
 // Drives the per-STIG metrics shown in the AggregatedFindingsGrid header
 // dropdown (StigSelectorPanel) and the "Overall" CAT 1/2/3 totals badges.
 // `collectionId` and `labelIds` are Refs so the panel reacts to the
-// orchestrator-level label filter. The metrics endpoint (getCollectionStigs)
-// accepts label filter params server-side via labelId/labelMatch, so this view
-// honors the label filter natively.
+// orchestrator-level label filter, which getMetricsSummaryByCollectionAggStig
+// applies server-side via labelId/labelMatch.
 export function useCollectionStigSummary({ collectionId, labelIds }) {
   const { state: rawStigs, isLoading, error, execute } = useAsyncState(
-    () => fetchCollectionStigSummary(
+    ({ signal } = {}) => fetchCollectionStigSummary(
       collectionId.value,
       buildLabelFilterParams(labelIds.value),
+      { signal },
     ),
     { immediate: false, initialState: [], onError: null },
   )

--- a/clientV2/src/features/Findings/composables/useFindingReviews.js
+++ b/clientV2/src/features/Findings/composables/useFindingReviews.js
@@ -26,7 +26,7 @@ export function useFindingReviews({ collectionId, selectedFinding, aggregator, l
     ({ signal } = {}) => fetchFailedReviews(collectionId.value, {
       aggregator: aggregator.value,
       aggregatorValue: aggregatorValue.value,
-      labelParams: buildLabelFilterParams(labelIds.value),
+      ...buildLabelFilterParams(labelIds.value),
     }, { signal }),
     { immediate: false, initialState: [], onError: null },
   )

--- a/clientV2/src/features/Findings/composables/useFindingReviews.js
+++ b/clientV2/src/features/Findings/composables/useFindingReviews.js
@@ -23,11 +23,11 @@ export function useFindingReviews({ collectionId, selectedFinding, aggregator, l
   })
 
   const { state: reviews, isLoading, error, execute } = useAsyncState(
-    () => fetchFailedReviews(collectionId.value, {
+    ({ signal } = {}) => fetchFailedReviews(collectionId.value, {
       aggregator: aggregator.value,
       aggregatorValue: aggregatorValue.value,
       labelParams: buildLabelFilterParams(labelIds.value),
-    }),
+    }, { signal }),
     { immediate: false, initialState: [], onError: null },
   )
 

--- a/clientV2/src/features/Findings/composables/useFindings.js
+++ b/clientV2/src/features/Findings/composables/useFindings.js
@@ -11,11 +11,11 @@ import { fetchFindings } from '../api/findingsApi.js'
 // row counts honor the orchestrator's label filter.
 export function useFindings({ collectionId, aggregator, benchmarkId, labelIds }) {
   const { state: findings, isLoading, error, execute } = useAsyncState(
-    () => fetchFindings(collectionId.value, {
+    ({ signal } = {}) => fetchFindings(collectionId.value, {
       aggregator: aggregator.value,
       benchmarkId: benchmarkId.value || undefined,
       labelParams: buildLabelFilterParams(labelIds.value),
-    }),
+    }, { signal }),
     { immediate: false, initialState: [], onError: null },
   )
 

--- a/clientV2/src/features/Findings/composables/useFindings.js
+++ b/clientV2/src/features/Findings/composables/useFindings.js
@@ -14,7 +14,7 @@ export function useFindings({ collectionId, aggregator, benchmarkId, labelIds })
     ({ signal } = {}) => fetchFindings(collectionId.value, {
       aggregator: aggregator.value,
       benchmarkId: benchmarkId.value || undefined,
-      labelParams: buildLabelFilterParams(labelIds.value),
+      ...buildLabelFilterParams(labelIds.value),
     }, { signal }),
     { immediate: false, initialState: [], onError: null },
   )

--- a/clientV2/src/features/Findings/tests/Findings.test.js
+++ b/clientV2/src/features/Findings/tests/Findings.test.js
@@ -97,7 +97,6 @@ describe('findings URL state', () => {
     expect(fetchFailedReviews).toHaveBeenCalledWith('17', {
       aggregator: 'groupId',
       aggregatorValue: 'V-219150',
-      labelParams: {},
     }, { signal: expect.any(AbortSignal) })
   })
 
@@ -130,7 +129,6 @@ describe('findings URL state', () => {
     expect(fetchFindings).toHaveBeenCalledWith('17', {
       aggregator: 'cci',
       benchmarkId: undefined,
-      labelParams: {},
     }, { signal: expect.any(AbortSignal) })
   })
 })

--- a/clientV2/src/features/Findings/tests/Findings.test.js
+++ b/clientV2/src/features/Findings/tests/Findings.test.js
@@ -98,7 +98,7 @@ describe('findings URL state', () => {
       aggregator: 'groupId',
       aggregatorValue: 'V-219150',
       labelParams: {},
-    })
+    }, { signal: expect.any(AbortSignal) })
   })
 
   it('restores nothing when ?sel= matches no loaded row', async () => {
@@ -131,6 +131,6 @@ describe('findings URL state', () => {
       aggregator: 'cci',
       benchmarkId: undefined,
       labelParams: {},
-    })
+    }, { signal: expect.any(AbortSignal) })
   })
 })

--- a/clientV2/src/features/Findings/tests/findingsApi.test.js
+++ b/clientV2/src/features/Findings/tests/findingsApi.test.js
@@ -84,7 +84,7 @@ describe('fetchFindings', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('spreads label filter params into the request', () => {
-    fetchFindings('42', { aggregator: 'groupId', labelParams: { labelId: ['l1', 'l2'] } })
+    fetchFindings('42', { aggregator: 'groupId', labelId: ['l1', 'l2'] })
     expect(apiCall).toHaveBeenCalledWith('getFindingsByCollection', {
       collectionId: '42',
       aggregator: 'groupId',
@@ -113,7 +113,7 @@ describe('fetchFailedReviews', () => {
   beforeEach(() => vi.clearAllMocks())
 
   it('spreads label filter params into the request', () => {
-    fetchFailedReviews('42', { aggregator: 'ruleId', aggregatorValue: 'SV-1_rule', labelParams: { labelMatch: 'null' } })
+    fetchFailedReviews('42', { aggregator: 'ruleId', aggregatorValue: 'SV-1_rule', labelMatch: 'null' })
     expect(apiCall).toHaveBeenCalledWith('getReviewsByCollection', {
       collectionId: '42',
       result: 'fail',

--- a/clientV2/src/features/Findings/tests/findingsApi.test.js
+++ b/clientV2/src/features/Findings/tests/findingsApi.test.js
@@ -90,7 +90,13 @@ describe('fetchFindings', () => {
       aggregator: 'groupId',
       projection: ['stigs'],
       labelId: ['l1', 'l2'],
-    })
+    }, undefined, {})
+  })
+
+  it('forwards fetch options (abort signal) to apiCall', () => {
+    const signal = new AbortController().signal
+    fetchFindings('42', { aggregator: 'groupId' }, { signal })
+    expect(apiCall.mock.calls[0][3]).toEqual({ signal })
   })
 
   it('adds no label keys when the filter is empty', () => {
@@ -99,7 +105,7 @@ describe('fetchFindings', () => {
       collectionId: '42',
       aggregator: 'groupId',
       projection: ['stigs'],
-    })
+    }, undefined, {})
   })
 })
 
@@ -114,6 +120,12 @@ describe('fetchFailedReviews', () => {
       projection: ['stigs'],
       ruleId: 'SV-1_rule',
       labelMatch: 'null',
-    })
+    }, undefined, {})
+  })
+
+  it('forwards fetch options (abort signal) to apiCall', () => {
+    const signal = new AbortController().signal
+    fetchFailedReviews('42', { aggregator: 'ruleId', aggregatorValue: 'SV-1_rule' }, { signal })
+    expect(apiCall.mock.calls[0][3]).toEqual({ signal })
   })
 })

--- a/clientV2/src/features/Findings/tests/useCollectionStigSummary.test.js
+++ b/clientV2/src/features/Findings/tests/useCollectionStigSummary.test.js
@@ -1,3 +1,4 @@
+import { flushPromises } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { buildLabelFilterParams } from '../../../shared/lib/labelFilters.js'
@@ -10,8 +11,6 @@ vi.mock('../api/findingsApi.js', () => ({
 
 const { fetchCollectionStigSummary } = await import('../api/findingsApi.js')
 
-const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
-
 function stig(benchmarkId, { high = 0, medium = 0, low = 0 } = {}) {
   return { benchmarkId, title: `${benchmarkId} title`, metrics: { findings: { high, medium, low } } }
 }
@@ -23,7 +22,7 @@ describe('useCollectionStigSummary', () => {
     const labelIds = ['abc-123']
     useCollectionStigSummary({ collectionId: ref('17'), labelIds: ref(labelIds) })
     await flushPromises()
-    expect(fetchCollectionStigSummary).toHaveBeenCalledWith('17', buildLabelFilterParams(labelIds))
+    expect(fetchCollectionStigSummary).toHaveBeenCalledWith('17', buildLabelFilterParams(labelIds), { signal: expect.any(AbortSignal) })
   })
 
   it('filters out STIGs with no open findings', async () => {

--- a/clientV2/src/features/Findings/tests/useFindingReviews.test.js
+++ b/clientV2/src/features/Findings/tests/useFindingReviews.test.js
@@ -39,7 +39,6 @@ describe('useFindingReviews', () => {
     expect(fetchFailedReviews).toHaveBeenCalledWith('17', {
       aggregator: 'groupId',
       aggregatorValue: 'V-219148',
-      labelParams: {},
     }, { signal: expect.any(AbortSignal) })
     expect(reviews.value).toEqual([{ assetId: '1' }])
   })
@@ -53,7 +52,7 @@ describe('useFindingReviews', () => {
     expect(fetchFailedReviews).toHaveBeenLastCalledWith('17', {
       aggregator: 'groupId',
       aggregatorValue: 'V-219148',
-      labelParams: { labelId: ['label-a'] },
+      labelId: ['label-a'],
     }, { signal: expect.any(AbortSignal) })
 
     fetchFailedReviews.mockClear()
@@ -62,7 +61,7 @@ describe('useFindingReviews', () => {
     expect(fetchFailedReviews).toHaveBeenLastCalledWith('17', {
       aggregator: 'groupId',
       aggregatorValue: 'V-219148',
-      labelParams: { labelMatch: 'null' },
+      labelMatch: 'null',
     }, { signal: expect.any(AbortSignal) })
   })
 

--- a/clientV2/src/features/Findings/tests/useFindingReviews.test.js
+++ b/clientV2/src/features/Findings/tests/useFindingReviews.test.js
@@ -1,3 +1,4 @@
+import { flushPromises } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { ref } from 'vue'
 import { useFindingReviews } from '../composables/useFindingReviews.js'
@@ -8,8 +9,6 @@ vi.mock('../api/findingsApi.js', () => ({
 }))
 
 const { fetchFailedReviews } = await import('../api/findingsApi.js')
-
-const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0))
 
 function setup({ collectionId = '17', aggregator = 'groupId', selectedFinding = null, labelIds = [] } = {}) {
   const refs = {
@@ -41,7 +40,7 @@ describe('useFindingReviews', () => {
       aggregator: 'groupId',
       aggregatorValue: 'V-219148',
       labelParams: {},
-    })
+    }, { signal: expect.any(AbortSignal) })
     expect(reviews.value).toEqual([{ assetId: '1' }])
   })
 
@@ -55,7 +54,7 @@ describe('useFindingReviews', () => {
       aggregator: 'groupId',
       aggregatorValue: 'V-219148',
       labelParams: { labelId: ['label-a'] },
-    })
+    }, { signal: expect.any(AbortSignal) })
 
     fetchFailedReviews.mockClear()
     labelIds.value = [null]
@@ -64,7 +63,7 @@ describe('useFindingReviews', () => {
       aggregator: 'groupId',
       aggregatorValue: 'V-219148',
       labelParams: { labelMatch: 'null' },
-    })
+    }, { signal: expect.any(AbortSignal) })
   })
 
   it('clears reviews without fetching when the selection is cleared', async () => {

--- a/clientV2/src/features/Findings/tests/useFindings.test.js
+++ b/clientV2/src/features/Findings/tests/useFindings.test.js
@@ -33,7 +33,6 @@ describe('useFindings', () => {
     expect(fetchFindings).toHaveBeenCalledWith('17', {
       aggregator: 'groupId',
       benchmarkId: undefined,
-      labelParams: {},
     }, SIGNAL)
   })
 
@@ -57,7 +56,6 @@ describe('useFindings', () => {
     expect(fetchFindings).toHaveBeenLastCalledWith('17', {
       aggregator: 'groupId',
       benchmarkId: 'A_STIG',
-      labelParams: {},
     }, SIGNAL)
   })
 
@@ -69,7 +67,7 @@ describe('useFindings', () => {
     expect(fetchFindings).toHaveBeenLastCalledWith('17', {
       aggregator: 'groupId',
       benchmarkId: undefined,
-      labelParams: { labelId: ['label-a'] },
+      labelId: ['label-a'],
     }, SIGNAL)
 
     fetchFindings.mockClear()
@@ -78,7 +76,7 @@ describe('useFindings', () => {
     expect(fetchFindings).toHaveBeenLastCalledWith('17', {
       aggregator: 'groupId',
       benchmarkId: undefined,
-      labelParams: { labelMatch: 'null' },
+      labelMatch: 'null',
     }, SIGNAL)
   })
 

--- a/clientV2/src/features/Findings/tests/useFindings.test.js
+++ b/clientV2/src/features/Findings/tests/useFindings.test.js
@@ -1,0 +1,96 @@
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useFindings } from '../composables/useFindings.js'
+
+vi.mock('../api/findingsApi.js', () => ({
+  fetchFindings: vi.fn(),
+  fetchFailedReviews: vi.fn(),
+  fetchCollectionStigSummary: vi.fn(),
+}))
+
+const { fetchFindings } = await import('../api/findingsApi.js')
+
+const SIGNAL = { signal: expect.any(AbortSignal) }
+
+function setup({ collectionId = '17', aggregator = 'groupId', benchmarkId = null, labelIds = [] } = {}) {
+  const refs = {
+    collectionId: ref(collectionId),
+    aggregator: ref(aggregator),
+    benchmarkId: ref(benchmarkId),
+    labelIds: ref(labelIds),
+  }
+  const composable = useFindings(refs)
+  return { ...refs, ...composable }
+}
+
+describe('useFindings', () => {
+  it('fetches immediately with the collection, aggregator and no benchmarkId in all-STIGs mode', async () => {
+    fetchFindings.mockClear()
+    fetchFindings.mockResolvedValue([])
+    setup()
+    await flushPromises()
+    expect(fetchFindings).toHaveBeenCalledWith('17', {
+      aggregator: 'groupId',
+      benchmarkId: undefined,
+      labelParams: {},
+    }, SIGNAL)
+  })
+
+  it('does not fetch without a collectionId or aggregator', async () => {
+    fetchFindings.mockClear()
+    setup({ collectionId: null })
+    setup({ aggregator: null })
+    await flushPromises()
+    expect(fetchFindings).not.toHaveBeenCalled()
+  })
+
+  it('refetches when the STIG scope changes', async () => {
+    fetchFindings.mockClear()
+    fetchFindings.mockResolvedValue([])
+    const { benchmarkId } = setup()
+    await flushPromises()
+
+    fetchFindings.mockClear()
+    benchmarkId.value = 'A_STIG'
+    await flushPromises()
+    expect(fetchFindings).toHaveBeenLastCalledWith('17', {
+      aggregator: 'groupId',
+      benchmarkId: 'A_STIG',
+      labelParams: {},
+    }, SIGNAL)
+  })
+
+  it('threads the label filter into the request and refetches when it changes', async () => {
+    fetchFindings.mockClear()
+    fetchFindings.mockResolvedValue([])
+    const { labelIds } = setup({ labelIds: ['label-a'] })
+    await flushPromises()
+    expect(fetchFindings).toHaveBeenLastCalledWith('17', {
+      aggregator: 'groupId',
+      benchmarkId: undefined,
+      labelParams: { labelId: ['label-a'] },
+    }, SIGNAL)
+
+    fetchFindings.mockClear()
+    labelIds.value = [null]
+    await flushPromises()
+    expect(fetchFindings).toHaveBeenLastCalledWith('17', {
+      aggregator: 'groupId',
+      benchmarkId: undefined,
+      labelParams: { labelMatch: 'null' },
+    }, SIGNAL)
+  })
+
+  it('sums assetCount across rows into totalOccurrences', async () => {
+    fetchFindings.mockResolvedValue([
+      { groupId: 'V-1', assetCount: 3 },
+      { groupId: 'V-2', assetCount: 1 },
+      { groupId: 'V-3' },
+    ])
+    const { findings, totalOccurrences } = setup()
+    await flushPromises()
+    expect(findings.value).toHaveLength(3)
+    expect(totalOccurrences.value).toBe(4)
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #2161 (label filters on the Findings report). Fixes the stale-filter bug on collection switch, aligns the new fetchers with the rest of the API layer, and adds the missing test coverage.

## Changes

**Bug fix**
- `CollectionView.vue`: reset `selectedLabelIds` in the existing `collectionId` watcher. The ref outlives the `v-if="collection"` remount, so a breadcrumb switch was querying the new collection with the old collection's label UUIDs (empty panes, lingering clear icon in `MetricsFilter`). One reset covers all five consumers.

**API layer**
- `fetchFindings` / `fetchFailedReviews`: replace the nested `labelParams` bag with rest-destructured flat params, matching every other wrapper. Pass-through keys are spread before the fixed keys, so a caller cannot override `result=fail`.
- `fetchFindings`, `fetchFailedReviews`, `fetchCollectionStigSummary`: accept a trailing `opts` argument forwarded to `apiCall`. The three Findings composables now pass the `{ signal }` from `useAsyncState`, so a superseded request is aborted instead of running to completion.

**Tests**
- New `useFindings.test.js` (initial fetch, no-fetch guards, STIG scope refetch, label threading, `totalOccurrences`).
- `findingsApi.test.js`: cover the opts pass-through.
- `useFindingReviews.test.js`, `useCollectionStigSummary.test.js`: import `flushPromises` from `@vue/test-utils` instead of a local copy.

**Docs / comments**
- `useCollectionStigSummary.js`: comment named `getCollectionStigs`; the fetcher calls `getMetricsSummaryByCollectionAggStig`.
- `findings-review.md`: drop the closed "label-filter inconsistency" item.
- `dashboards.md`: fix the cross-reference broken by the renumbering (`#4` → `#2`).
- `pending-api-enhancements.md`: reword the intro (no call-site TODOs remain) and add item 4, label filtering on `getPoamByCollection`, since the POA&M export is still collection-wide while the grid honors the filter.
